### PR TITLE
Bump versions for npm and fix types version issue in admin-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,37 @@
 # GraphWeaver
 
+## Getting Started with GraphWeaver
+
+You can create a new project with the __GraphWeaver CLI__, by running `npm init @exogee/graphweaver`.
+
+The prompts will ask you which backends to install, and create a scaffold project with schema folders ready to create a schema.
+
+```
+❯ npm init @exogee/graphweaver
+GraphWeaver
+
+? What would your like to call your new project? 
+test-project
+
+? Which GraphWeaver backends will you need? 
+MikroORM - PostgreSQL Backend
+REST Backend
+
+? OK, we're ready- I'm going to create a new app in /Users/helloworld/project- is that OK? 
+Yes
+
+All Done!
+
+Make sure you npm install / yarn install / pnpm install, then run the start script to get started
+❯ 
+```
+
 ## Examples
 
 ### examples/example-basic - `@exogee/graphweaver-example-basic`
 Stripped down example of using GraphWeaver with the MikroORM adapter.
 
-```shell
+```
 # Install dependencies
 pnpm install
 
@@ -22,7 +48,7 @@ cd src/apps/example-basic && pnpm start
 ### examples/example-complex - `@exogee/graphweaver-example-complex`
 A more complex example of using GraphWeaver with multiple adapters and relationships in serverless.
 
-```shell
+```
 # Install dependencies
 pnpm install
 
@@ -42,7 +68,7 @@ cd src/apps/example-complex && pnpm migrate && pnpm build && pnpm start
 ### packages/core - `@exogee/graphweaver`
 GraphWeaver core package, includes `createBaseResolver` method that creates a resolver in combination with one of the backend packages:
 
-```ts
+```typescript
 @Resolver(() => UserGQLEntity)
 export class UserGQLResolver extends createBaseResolver(
 	UserGQLEntity,

--- a/src/apps/example-basic/package.json
+++ b/src/apps/example-basic/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-basic-app",
-	"version": "0.1.0-alpha.1",
+	"version": "0.1.0-alpha.5",
 	"license": "MIT",
 	"private": true,
 	"description": "Build and launch the GraphWeaver example app",

--- a/src/apps/example-complex/package.json
+++ b/src/apps/example-complex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-complex-app",
-	"version": "0.1.0-alpha.0",
+	"version": "0.1.0-alpha.5",
 	"license": "MIT",
 	"private": true,
 	"description": "App to build and launch the graphweaver example app",
@@ -20,7 +20,7 @@
 	},
 	"dependencies": {
 		"@aws-sdk/signature-v4-crt": "3.54.1",
-		"@exogee/graphweaver-example-complex": "workspace:0.1.0-alpha.0",
+		"@exogee/graphweaver-example-complex": "workspace:0.1.0-alpha.5",
 		"dotenv": "10.0.0",
 		"esbuild": "0.15.5"
 	}

--- a/src/apps/graphweaver/package.json
+++ b/src/apps/graphweaver/package.json
@@ -1,12 +1,12 @@
 {
 	"name": "@exogee/graphweaver-app",
-	"version": "0.1.0-alpha.0",
+	"version": "0.1.0-alpha.5",
 	"license": "MIT",
 	"private": true,
 	"description": "App to build, package and distribute the full graphweaver app",
 	"scripts": {
 		"build": "concurrently \"pnpm build:types\" \"pnpm build:js\"",
-		"build:types": "pnpm -r build:types --filter \"!@exogee/graphweaver-example-*\"",
+		"build:types": "pnpm -r build:types --filter \"!@exogee/graphweaver-example-*\" --filter \"!@exogee/graphweaver-ui\"",
 		"build:js": "node transpile.js",
 		"build:legacy": "pnpm -r build:legacy"
 	},

--- a/src/examples/example-basic/package.json
+++ b/src/examples/example-basic/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-basic",
-	"version": "0.1.0-alpha.1",
+	"version": "0.1.0-alpha.5",
 	"license": "MIT",
 	"description": "An example project for @exogee/graphweaver",
 	"bin": "bin/index.js",
@@ -16,9 +16,9 @@
 		"test:prettier": "prettier --check ."
 	},
 	"dependencies": {
-		"@exogee/graphweaver-apollo": "workspace:0.1.0-alpha.1",
-		"@exogee/graphweaver": "workspace:0.1.0-alpha.0",
-		"@exogee/graphweaver-mikroorm": "workspace:0.1.0-alpha.1",
+		"@exogee/graphweaver-apollo": "workspace:0.1.0-alpha.5",
+		"@exogee/graphweaver": "workspace:0.1.0-alpha.5",
+		"@exogee/graphweaver-mikroorm": "workspace:0.1.0-alpha.5",
 		"@mikro-orm/core": "5.4.2",
 		"@mikro-orm/postgresql": "5.4.2",
 		"apollo-server": "3.11.1",

--- a/src/examples/example-complex-migrations/package.json
+++ b/src/examples/example-complex-migrations/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-complex-migrations",
-	"version": "0.1.0-alpha.0",
+	"version": "0.1.0-alpha.5",
 	"license": "MIT",
 	"private": true,
 	"description": "Database migrations for example-complex",
@@ -18,7 +18,7 @@
 		"test": "jest"
 	},
 	"dependencies": {
-		"@exogee/graphweaver-mikroorm": "0.1.0-alpha.1",
+		"@exogee/graphweaver-mikroorm": "0.1.0-alpha.5",
 		"@exogee/logger": "0.1.0",
 		"aws-sdk": "2.1069.0",
 		"color-convert": "2.0.1",

--- a/src/examples/example-complex/package.json
+++ b/src/examples/example-complex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-complex",
-	"version": "0.1.0-alpha.0",
+	"version": "0.1.0-alpha.5",
 	"license": "MIT",
 	"private": true,
 	"description": "Complex example of using @exogee/graphweaver",
@@ -18,12 +18,12 @@
 		"lib"
 	],
 	"dependencies": {
-		"@exogee/graphweaver-scalars": "workspace:0.1.0-alpha.1",
-		"@exogee/graphweaver": "workspace:0.1.0-alpha.0",
-		"@exogee/graphweaver-apollo": "workspace:0.1.0-alpha.1",
-		"@exogee/graphweaver-mikroorm": "workspace:0.1.0-alpha.1",
-		"@exogee/graphweaver-rest": "workspace:0.1.0-alpha.0",
-		"@exogee/graphweaver-rls": "workspace:0.1.0-alpha.1",
+		"@exogee/graphweaver-scalars": "workspace:0.1.0-alpha.5",
+		"@exogee/graphweaver": "workspace:0.1.0-alpha.5",
+		"@exogee/graphweaver-apollo": "workspace:0.1.0-alpha.5",
+		"@exogee/graphweaver-mikroorm": "workspace:0.1.0-alpha.5",
+		"@exogee/graphweaver-rest": "workspace:0.1.0-alpha.5",
+		"@exogee/graphweaver-rls": "workspace:0.1.0-alpha.5",
 		"@exogee/logger": "workspace:0.1.0",
 		"@mikro-orm/core": "5.4.2",
 		"apollo-server-core": "3.10.3",

--- a/src/packages/admin-ui/package.json
+++ b/src/packages/admin-ui/package.json
@@ -15,7 +15,7 @@
 		"vite-plugin-svgr": "2.2.2"
 	},
 	"devDependencies": {
-		"@types/react": "18.0.24",
+		"@types/react": "18.0.25",
 		"@types/react-dom": "18.0.8",
 		"@vitejs/plugin-react": "2.2.0",
 		"typescript": "4.6.4",

--- a/src/packages/apollo/package.json
+++ b/src/packages/apollo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-apollo",
-	"version": "0.1.0-alpha.1",
+	"version": "0.1.0-alpha.5",
 	"description": "Apollo Server support for @exogee/graphweaver",
 	"license": "MIT",
 	"scripts": {
@@ -17,8 +17,8 @@
 		"lib"
 	],
 	"dependencies": {
-		"@exogee/graphweaver": "workspace:0.1.0-alpha.0",
-		"@exogee/graphweaver-mikroorm": "workspace:0.1.0-alpha.1",
+		"@exogee/graphweaver": "workspace:0.1.0-alpha.5",
+		"@exogee/graphweaver-mikroorm": "workspace:0.1.0-alpha.5",
 		"@exogee/logger": "workspace:0.1.0",
 		"async-mutex": "0.3.2",
 		"apollo-server-core": "3.10.3",

--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver",
-	"version": "0.1.0-alpha.0",
+	"version": "0.1.0-alpha.5",
 	"description": "Graphweaver Core Package",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/create-graphweaver/package.json
+++ b/src/packages/create-graphweaver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exogee/create-graphweaver",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "Create a new GraphWeaver project interactively",
   "license": "MIT",
   "scripts": {

--- a/src/packages/create-graphweaver/src/backend.ts
+++ b/src/packages/create-graphweaver/src/backend.ts
@@ -1,10 +1,4 @@
-import {
-	GRAPHWEAVER_CORE_TARGET_VERSION,
-	GRAPHWEAVER_APOLLO_TARGET_VERSION,
-	GRAPHWEAVER_REST_TARGET_VERSION,
-	GRAPHWEAVER_MIKROORM_TARGET_VERSION,
-	MIKRO_ORM_TARGET_VERSION,
-} from './constants';
+import { GRAPHWEAVER_TARGET_VERSION, MIKRO_ORM_TARGET_VERSION } from './constants';
 
 export enum Backend {
 	MikroORMPostgres,
@@ -15,15 +9,15 @@ export const packagesForBackend = (backend: Backend): Record<string, string> => 
 	switch (backend) {
 		case Backend.MikroORMPostgres:
 			return {
-				'@exogee/graphweaver-mikroorm': GRAPHWEAVER_MIKROORM_TARGET_VERSION,
-				'@exogee/graphweaver-apollo': GRAPHWEAVER_APOLLO_TARGET_VERSION,
+				'@exogee/graphweaver-mikroorm': GRAPHWEAVER_TARGET_VERSION,
+				'@exogee/graphweaver-apollo': GRAPHWEAVER_TARGET_VERSION,
 				'@mikro-orm/core': MIKRO_ORM_TARGET_VERSION,
 				'@mikro-orm/postgresql': MIKRO_ORM_TARGET_VERSION,
 			};
 
 		case Backend.REST:
 			return {
-				'@exogee/graphweaver-rest': GRAPHWEAVER_REST_TARGET_VERSION,
+				'@exogee/graphweaver-rest': GRAPHWEAVER_TARGET_VERSION,
 			};
 	}
 };

--- a/src/packages/create-graphweaver/src/constants.ts
+++ b/src/packages/create-graphweaver/src/constants.ts
@@ -1,5 +1,2 @@
-export const GRAPHWEAVER_CORE_TARGET_VERSION = '0.1.0-alpha.0';
-export const GRAPHWEAVER_REST_TARGET_VERSION = '0.1.0-alpha.0';
-export const GRAPHWEAVER_MIKROORM_TARGET_VERSION = '0.1.0-alpha.1';
-export const GRAPHWEAVER_APOLLO_TARGET_VERSION = '0.1.0-alpha.1';
+export const GRAPHWEAVER_TARGET_VERSION = '0.1.0-alpha.5';
 export const MIKRO_ORM_TARGET_VERSION = '5.4.2';

--- a/src/packages/create-graphweaver/src/index.ts
+++ b/src/packages/create-graphweaver/src/index.ts
@@ -8,6 +8,7 @@ import {
 	makeIndex,
 	makeSchemaIndex,
 	makeTsConfig,
+	makeReadme,
 } from './template';
 
 import { Backend } from './backend';
@@ -53,6 +54,7 @@ const abort = () => {
 	if (!createDirectory) abort();
 
 	makeDirectories();
+	makeReadme(projectName);
 	makePackageJson(projectName, backends);
 	makeTsConfig();
 	makeIndex(projectName, backends);

--- a/src/packages/create-graphweaver/src/template.ts
+++ b/src/packages/create-graphweaver/src/template.ts
@@ -1,6 +1,6 @@
 import { writeFileSync, mkdirSync } from 'fs';
 import { Backend, packagesForBackend } from './backend';
-import { GRAPHWEAVER_CORE_TARGET_VERSION } from './constants';
+import { GRAPHWEAVER_TARGET_VERSION } from './constants';
 
 export const makePackageJson = (projectName: string, backends: Backend[]) => {
 	const backendPackages = Object.assign(
@@ -16,7 +16,7 @@ export const makePackageJson = (projectName: string, backends: Backend[]) => {
 			start: 'ts-node src/index.ts',
 		},
 		dependencies: {
-			'@exogee/graphweaver': GRAPHWEAVER_CORE_TARGET_VERSION,
+			'@exogee/graphweaver': GRAPHWEAVER_TARGET_VERSION,
 			...backendPackages,
 			'apollo-server': '3.11.1',
 			'apollo-server-core': '3.10.3',

--- a/src/packages/mikroorm/package.json
+++ b/src/packages/mikroorm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-mikroorm",
-	"version": "0.1.0-alpha.1",
+	"version": "0.1.0-alpha.5",
 	"description": "MikroORM backend for @exogee/graphweaver",
 	"license": "MIT",
 	"scripts": {
@@ -19,7 +19,7 @@
 		"lib"
 	],
 	"dependencies": {
-		"@exogee/graphweaver": "workspace:0.1.0-alpha.0",
+		"@exogee/graphweaver": "workspace:0.1.0-alpha.5",
 		"apollo-server-core": "3.10.3",
 		"@exogee/logger": "workspace:0.1.0",
 		"dataloader": "2.0.0",

--- a/src/packages/rest/package.json
+++ b/src/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-rest",
-	"version": "0.1.0-alpha.0",
+	"version": "0.1.0-alpha.5",
 	"description": "RESTful backend for @exogee/graphweaver",
 	"license": "MIT",
 	"scripts": {
@@ -19,9 +19,9 @@
 		"lib"
 	],
 	"dependencies": {
-		"@exogee/graphweaver": "workspace:0.1.0-alpha.0",
+		"@exogee/graphweaver": "workspace:0.1.0-alpha.5",
 		"@exogee/logger": "workspace:0.1.0",
-		"apollo-datasource": "^3.3.2",
+		"apollo-datasource": "3.3.2",
 		"apollo-datasource-rest": "3.7.0",
 		"apollo-server-errors": "3.3.1",
 		"dataloader": "2.1.0",

--- a/src/packages/rls/package.json
+++ b/src/packages/rls/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-rls",
-	"version": "0.1.0-alpha.1",
+	"version": "0.1.0-alpha.5",
 	"description": "Row-Level Security support for @exogee/graphweaver",
 	"license": "MIT",
 	"scripts": {
@@ -19,8 +19,8 @@
 		"lib"
 	],
 	"dependencies": {
-		"@exogee/graphweaver": "workspace:0.1.0-alpha.0",
-		"@exogee/graphweaver-mikroorm": "workspace:0.1.0-alpha.1",
+		"@exogee/graphweaver": "workspace:0.1.0-alpha.5",
+		"@exogee/graphweaver-mikroorm": "workspace:0.1.0-alpha.5",
 		"@exogee/logger": "workspace:0.1.0",
 		"apollo-server-errors": "3.3.1",
 		"dotenv": "10.0.0",

--- a/src/packages/scalars/package.json
+++ b/src/packages/scalars/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-scalars",
-	"version": "0.1.0-alpha.1",
+	"version": "0.1.0-alpha.5",
 	"description": "Common scalar types for use with @exogee/graphweaver",
 	"license": "MIT",
 	"main": "lib/index.js",
@@ -17,7 +17,7 @@
 		"test:watch": "jest --passWithNoTests --watch"
 	},
 	"dependencies": {
-		"@exogee/graphweaver-mikroorm": "workspace:0.1.0-alpha.1"
+		"@exogee/graphweaver-mikroorm": "workspace:0.1.0-alpha.5"
 	},
 	"devDependencies": {
 		"@types/jest": "26.0.23",

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
   apps/example-complex:
     specifiers:
       '@aws-sdk/signature-v4-crt': 3.54.1
-      '@exogee/graphweaver-example-complex': workspace:0.1.0-alpha.0
+      '@exogee/graphweaver-example-complex': workspace:0.1.0-alpha.5
       concurrently: 7.0.0
       dotenv: 10.0.0
       esbuild: 0.15.5
@@ -79,9 +79,9 @@ importers:
 
   examples/example-basic:
     specifiers:
-      '@exogee/graphweaver': workspace:0.1.0-alpha.0
-      '@exogee/graphweaver-apollo': workspace:0.1.0-alpha.1
-      '@exogee/graphweaver-mikroorm': workspace:0.1.0-alpha.1
+      '@exogee/graphweaver': workspace:0.1.0-alpha.5
+      '@exogee/graphweaver-apollo': workspace:0.1.0-alpha.5
+      '@exogee/graphweaver-mikroorm': workspace:0.1.0-alpha.5
       '@mikro-orm/core': 5.4.2
       '@mikro-orm/postgresql': 5.4.2
       '@types/node': 14.14.10
@@ -114,12 +114,12 @@ importers:
 
   examples/example-complex:
     specifiers:
-      '@exogee/graphweaver': workspace:0.1.0-alpha.0
-      '@exogee/graphweaver-apollo': workspace:0.1.0-alpha.1
-      '@exogee/graphweaver-mikroorm': workspace:0.1.0-alpha.1
-      '@exogee/graphweaver-rest': workspace:0.1.0-alpha.0
-      '@exogee/graphweaver-rls': workspace:0.1.0-alpha.1
-      '@exogee/graphweaver-scalars': workspace:0.1.0-alpha.1
+      '@exogee/graphweaver': workspace:0.1.0-alpha.5
+      '@exogee/graphweaver-apollo': workspace:0.1.0-alpha.5
+      '@exogee/graphweaver-mikroorm': workspace:0.1.0-alpha.5
+      '@exogee/graphweaver-rest': workspace:0.1.0-alpha.5
+      '@exogee/graphweaver-rls': workspace:0.1.0-alpha.5
+      '@exogee/graphweaver-scalars': workspace:0.1.0-alpha.5
       '@exogee/logger': workspace:0.1.0
       '@graphql-codegen/cli': 1.19.4
       '@graphql-codegen/typescript': 1.19.0
@@ -233,7 +233,7 @@ importers:
 
   examples/example-complex-migrations:
     specifiers:
-      '@exogee/graphweaver-mikroorm': 0.1.0-alpha.1
+      '@exogee/graphweaver-mikroorm': 0.1.0-alpha.5
       '@exogee/logger': 0.1.0
       '@mikro-orm/core': 5.4.2
       '@mikro-orm/entity-generator': 5.4.2
@@ -272,7 +272,7 @@ importers:
 
   packages/admin-ui:
     specifiers:
-      '@types/react': 18.0.24
+      '@types/react': 18.0.25
       '@types/react-dom': 18.0.8
       '@vitejs/plugin-react': 2.2.0
       react: 18.2.0
@@ -285,7 +285,7 @@ importers:
       react-dom: 18.2.0_react@18.2.0
       vite-plugin-svgr: 2.2.2_vite@3.2.3
     devDependencies:
-      '@types/react': 18.0.24
+      '@types/react': 18.0.25
       '@types/react-dom': 18.0.8
       '@vitejs/plugin-react': 2.2.0_vite@3.2.3
       typescript: 4.6.4
@@ -293,8 +293,8 @@ importers:
 
   packages/apollo:
     specifiers:
-      '@exogee/graphweaver': workspace:0.1.0-alpha.0
-      '@exogee/graphweaver-mikroorm': workspace:0.1.0-alpha.1
+      '@exogee/graphweaver': workspace:0.1.0-alpha.5
+      '@exogee/graphweaver-mikroorm': workspace:0.1.0-alpha.5
       '@exogee/logger': workspace:0.1.0
       apollo-server-core: 3.10.3
       async-mutex: 0.3.2
@@ -370,7 +370,7 @@ importers:
 
   packages/mikroorm:
     specifiers:
-      '@exogee/graphweaver': workspace:0.1.0-alpha.0
+      '@exogee/graphweaver': workspace:0.1.0-alpha.5
       '@exogee/logger': workspace:0.1.0
       '@mikro-orm/core': 5.4.2
       '@mikro-orm/postgresql': 5.4.2
@@ -397,10 +397,10 @@ importers:
 
   packages/rest:
     specifiers:
-      '@exogee/graphweaver': workspace:0.1.0-alpha.0
+      '@exogee/graphweaver': workspace:0.1.0-alpha.5
       '@exogee/logger': workspace:0.1.0
       '@types/node': 14.14.10
-      apollo-datasource: ^3.3.2
+      apollo-datasource: 3.3.2
       apollo-datasource-rest: 3.7.0
       apollo-server-errors: 3.3.1
       dataloader: 2.1.0
@@ -436,8 +436,8 @@ importers:
 
   packages/rls:
     specifiers:
-      '@exogee/graphweaver': workspace:0.1.0-alpha.0
-      '@exogee/graphweaver-mikroorm': workspace:0.1.0-alpha.1
+      '@exogee/graphweaver': workspace:0.1.0-alpha.5
+      '@exogee/graphweaver-mikroorm': workspace:0.1.0-alpha.5
       '@exogee/logger': workspace:0.1.0
       '@types/node': 14.14.10
       apollo-server-errors: 3.3.1
@@ -467,7 +467,7 @@ importers:
 
   packages/scalars:
     specifiers:
-      '@exogee/graphweaver-mikroorm': workspace:0.1.0-alpha.1
+      '@exogee/graphweaver-mikroorm': workspace:0.1.0-alpha.5
       '@types/jest': 26.0.23
       decimal.js: 10.3.1
       graphql: 15.8.0
@@ -1717,6 +1717,7 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-loong64/0.15.14:
@@ -1725,6 +1726,7 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-loong64/0.15.5:
@@ -1811,7 +1813,6 @@ packages:
       - typescript
       - utf-8-validate
       - zen-observable
-      - zenObservable
     dev: true
 
   /@graphql-codegen/core/1.17.9_graphql@15.8.0:
@@ -3692,10 +3693,8 @@ packages:
       zen-observable:
         optional: true
     dependencies:
-      any-observable: 0.3.0_rxjs@6.6.7
+      any-observable: 0.3.0
       rxjs: 6.6.7
-    transitivePeerDependencies:
-      - zenObservable
     dev: true
 
   /@serverless/dashboard-plugin/6.2.2_supports-color@8.1.1:
@@ -4364,14 +4363,6 @@ packages:
       '@types/react': 18.0.25
     dev: true
 
-  /@types/react/18.0.24:
-    resolution: {integrity: sha512-wRJWT6ouziGUy+9uX0aW4YOJxAY0bG6/AOk5AW5QSvZqI7dk6VBIbXvcVgIw/W5Jrl24f77df98GEKTJGOLx7Q==}
-    dependencies:
-      '@types/prop-types': 15.7.5
-      '@types/scheduler': 0.16.2
-      csstype: 3.1.1
-    dev: true
-
   /@types/react/18.0.25:
     resolution: {integrity: sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==}
     dependencies:
@@ -4978,19 +4969,9 @@ packages:
     resolution: {integrity: sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A==}
     dev: false
 
-  /any-observable/0.3.0_rxjs@6.6.7:
+  /any-observable/0.3.0:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
-    peerDependencies:
-      rxjs: '*'
-      zenObservable: '*'
-    peerDependenciesMeta:
-      rxjs:
-        optional: true
-      zenObservable:
-        optional: true
-    dependencies:
-      rxjs: 6.6.7
     dev: true
 
   /anymatch/2.0.0:
@@ -4998,8 +4979,6 @@ packages:
     dependencies:
       micromatch: 3.1.10
       normalize-path: 2.1.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /anymatch/3.1.2:
@@ -5052,6 +5031,7 @@ packages:
   /apollo-datasource/3.3.2:
     resolution: {integrity: sha512-L5TiS8E2Hn/Yz7SSnWIVbZw0ZfEIXZCa5VUiVxD9P53JvSrf4aStvsFDlGWPvpIdCR+aly2CfoB79B9/JjKFqg==}
     engines: {node: '>=12.0'}
+    deprecated: The `apollo-datasource` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
     dependencies:
       '@apollo/utils.keyvaluecache': 1.0.1
       apollo-server-env: 4.2.1
@@ -5306,7 +5286,6 @@ packages:
       parseurl: 1.3.3
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: false
 
   /apollo-server-lambda/3.10.0_graphql@15.8.0:
@@ -5323,7 +5302,6 @@ packages:
       graphql: 15.8.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: false
 
   /apollo-server-plugin-base/0.14.0_graphql@15.8.0:
@@ -5430,7 +5408,6 @@ packages:
       graphql: 15.8.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: false
 
   /apollo-tracing/0.16.0_graphql@15.8.0:
@@ -6003,8 +5980,6 @@ packages:
       raw-body: 2.5.1
       type-is: 1.6.18
       unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /boxen/5.1.2:
@@ -6047,8 +6022,6 @@ packages:
       snapdragon-node: 2.1.1
       split-string: 3.1.0
       to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /braces/3.0.2:
@@ -6988,35 +6961,13 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.0.0
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.1.3
-    dev: true
-
-  /debug/3.2.7_supports-color@5.5.0:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.3
-      supports-color: 5.5.0
     dev: true
 
   /debug/4.3.4:
@@ -7572,6 +7523,7 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-android-64/0.15.5:
@@ -7588,6 +7540,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-android-arm64/0.15.5:
@@ -7619,6 +7572,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-darwin-64/0.15.5:
@@ -7635,6 +7589,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-darwin-arm64/0.15.5:
@@ -7651,6 +7606,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-freebsd-64/0.15.5:
@@ -7667,6 +7623,7 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-freebsd-arm64/0.15.5:
@@ -7683,6 +7640,7 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-32/0.15.5:
@@ -7699,6 +7657,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-64/0.15.5:
@@ -7715,6 +7674,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-arm/0.15.5:
@@ -7731,6 +7691,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-arm64/0.15.5:
@@ -7747,6 +7708,7 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-mips64le/0.15.5:
@@ -7763,6 +7725,7 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-ppc64le/0.15.5:
@@ -7779,6 +7742,7 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-riscv64/0.15.5:
@@ -7795,6 +7759,7 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-s390x/0.15.5:
@@ -7811,6 +7776,7 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-netbsd-64/0.15.5:
@@ -7827,6 +7793,7 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-openbsd-64/0.15.5:
@@ -7852,6 +7819,7 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-sunos-64/0.15.5:
@@ -7868,6 +7836,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-32/0.15.5:
@@ -7884,6 +7853,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-64/0.15.5:
@@ -7900,6 +7870,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-arm64/0.15.5:
@@ -7938,6 +7909,7 @@ packages:
       esbuild-windows-32: 0.15.14
       esbuild-windows-64: 0.15.14
       esbuild-windows-arm64: 0.15.14
+    dev: true
 
   /esbuild/0.15.5:
     resolution: {integrity: sha512-VSf6S1QVqvxfIsSKb3UKr3VhUCis7wgDbtF4Vd9z84UJr05/Sp2fRKmzC+CSPG/dNAPPJZ0BTBLTT1Fhd6N9Gg==}
@@ -8300,8 +8272,6 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /expect/26.6.2:
@@ -8361,8 +8331,6 @@ packages:
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /ext-list/2.2.2:
@@ -8425,8 +8393,6 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /extract-files/9.0.0:
@@ -8624,8 +8590,6 @@ packages:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /find-requires/1.0.0:
@@ -8831,6 +8795,7 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /fstream/1.0.12:
@@ -10640,8 +10605,6 @@ packages:
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /jest-haste-map/27.5.1:
@@ -10902,8 +10865,6 @@ packages:
       '@jest/types': 26.6.2
       jest-regex-util: 26.0.0
       jest-snapshot: 26.6.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /jest-resolve-dependencies/27.5.1:
@@ -11261,8 +11222,6 @@ packages:
       natural-compare: 1.4.0
       pretty-format: 26.6.2
       semver: 7.3.8
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /jest-snapshot/27.5.1:
@@ -11988,7 +11947,6 @@ packages:
       rxjs: 6.6.7
     transitivePeerDependencies:
       - zen-observable
-      - zenObservable
     dev: true
 
   /loader-runner/4.3.0:
@@ -12333,8 +12291,6 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /micromatch/4.0.5:
@@ -12551,6 +12507,7 @@ packages:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+    dev: true
 
   /nanomatch/1.2.13:
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
@@ -12567,8 +12524,6 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /native-promise-only/0.8.1:
@@ -12688,7 +12643,7 @@ packages:
     requiresBuild: true
     dependencies:
       chokidar: 3.5.3
-      debug: 3.2.7_supports-color@5.5.0
+      debug: 3.2.7
       ignore-by-default: 1.0.1
       minimatch: 3.1.2
       pstree.remy: 1.1.8
@@ -13410,8 +13365,6 @@ packages:
       async: 2.6.4
       debug: 3.2.7
       mkdirp: 0.5.6
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /posix-character-classes/0.1.1:
@@ -13504,6 +13457,7 @@ packages:
       nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: true
 
   /postgres-array/1.0.3:
     resolution: {integrity: sha512-5wClXrAP0+78mcsNX3/ithQ5exKvCyK5lr5NEEEeGwwM6NJdQgzIJBVxLvRW+huFpX92F2QnZ5CcokH0VhK2qQ==}
@@ -14132,6 +14086,7 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /rsvp/4.8.5:
     resolution: {integrity: sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==}
@@ -14209,8 +14164,6 @@ packages:
       micromatch: 3.1.10
       minimist: 1.2.7
       walker: 1.0.8
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /sax/1.2.1:
@@ -14295,8 +14248,6 @@ packages:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /sentence-case/3.0.4:
@@ -14321,8 +14272,6 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.18.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /serverless-http/2.6.0:
@@ -14684,8 +14633,6 @@ packages:
       source-map: 0.5.7
       source-map-resolve: 0.5.3
       use: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /sort-keys-length/1.0.1:
@@ -14709,6 +14656,7 @@ packages:
   /source-map-js/1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /source-map-resolve/0.5.3:
     resolution: {integrity: sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==}
@@ -16279,6 +16227,7 @@ packages:
       rollup: 2.79.1
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /w3c-hr-time/1.0.2:
     resolution: {integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==}

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,5 @@
 {
 	"compilerOptions": {
-		/* Basic Options */
 		"target": "es2019",
 		"module": "commonjs",
 		"lib": ["ES6", "ES2019"],
@@ -11,16 +10,13 @@
 		"composite": true,
 		"isolatedModules": true,
 
-		/* Strict Type-Checking Options */
 		"strict": true,
 		"noImplicitAny": true,
 		"strictNullChecks": true,
 		"noImplicitThis": true,
 
-		/* Additional Checks */
 		"noUnusedLocals": false,
 
-		/* Module Resolution Options */
 		"moduleResolution": "node",
 		"baseUrl": ".",
 		"paths": {
@@ -30,11 +26,9 @@
 		"allowSyntheticDefaultImports": true,
 		"esModuleInterop": true,
 
-		/* Experimental Options */
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true,
 
-		/* Advanced Options */
 		"skipLibCheck": true,
 		"forceConsistentCasingInFileNames": true
 	},


### PR DESCRIPTION
- Bump to 0.1.0-alpha.5
- Add initial "Getting Started" to README
- `admin-ui` had incompatible types packages, so bumped the react types version to match react-dom