### PR TITLE
update UserDog with user field and update dogId

### DIFF
--- a/src/examples/example-complex/src/entities/mikroorm/user-dog.ts
+++ b/src/examples/example-complex/src/entities/mikroorm/user-dog.ts
@@ -8,7 +8,7 @@ export class UserDog extends BaseEntity {
 	id!: string;
 
 	@Property({ type: String })
-	dogId!: string;
+	restDogId!: string;
 
 	@ManyToOne(() => User)
 	user!: User;

--- a/src/examples/example-complex/src/schema/user-dog/entity.ts
+++ b/src/examples/example-complex/src/schema/user-dog/entity.ts
@@ -2,6 +2,7 @@ import { GraphQLEntity, BaseLoaders } from '@exogee/graphweaver';
 import { Field, ID, ObjectType, Root } from 'type-graphql';
 import { UserDog as OrmUserDog } from '../../entities/mikroorm/user-dog';
 import { Dog } from '../dog';
+import { User } from '../user';
 
 @ObjectType('UserDog')
 export class UserDog extends GraphQLEntity<OrmUserDog> {
@@ -12,12 +13,23 @@ export class UserDog extends GraphQLEntity<OrmUserDog> {
 
 	@Field(() => [Dog])
 	async dogs(@Root() userDog: UserDog) {
-		if (!this.dataEntity.dogId) return null;
+		if (!this.dataEntity.restDogId) return null;
 		const dogs = await BaseLoaders.loadByRelatedId({
 			gqlEntityType: Dog,
 			relatedField: 'id',
-			id: userDog.dataEntity.dogId,
+			id: userDog.dataEntity.restDogId,
 		});
 		return dogs.map((dog) => Dog.fromBackendEntity(dog));
+	}
+
+	@Field(() => [User])
+	async users(@Root() userDog: UserDog) {
+		if (!this.dataEntity.user) return null;
+		const users = await BaseLoaders.loadByRelatedId({
+			gqlEntityType: User,
+			relatedField: 'id',
+			id: this.dataEntity.user.id,
+		});
+		return users.map((user) => User.fromBackendEntity(user));
 	}
 }


### PR DESCRIPTION
The field for userDogs on User is returning a relationshipType of null. This PR adds `users` under `userDog` and renames `dogId` to `restDogId`.

```
{
  "name": "userDogs",
  "type": "UserDog",
  "relatedEntity": "UserDog",
  "relationshipType": "m:n"
}
