### PR TITLE
Fix / Single Dashboard with no Profit

### DIFF
--- a/src/packages/admin-ui/src/dashboads/xero/single-company/component.tsx
+++ b/src/packages/admin-ui/src/dashboads/xero/single-company/component.tsx
@@ -41,7 +41,7 @@ export const SingleCompany = () => {
 													currency: 'USD',
 												})
 												.split('.')[0]
-										: '$0.00'}
+										: '$0'}
 								</p>
 								<ResponsiveLine
 									data={chartValues}


### PR DESCRIPTION
When the company has no net profit rows we were throwing an error instead of just showing 0.