### PR TITLE
Fix / Ensure schema data is loaded before rendering the main layout.

### DIFF
--- a/src/packages/admin-ui-components/src/index.ts
+++ b/src/packages/admin-ui-components/src/index.ts
@@ -4,6 +4,7 @@ export * from './button';
 export * from './detail-panel';
 export * from './layouts';
 export * from './loader';
+export * from './require-schema';
 export * from './side-bar';
 export * from './spinner';
 export * from './table';

--- a/src/packages/admin-ui-components/src/layouts/default/component.tsx
+++ b/src/packages/admin-ui-components/src/layouts/default/component.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { SideBar } from '../../side-bar';
 import { Header } from '../../header';
+import { RequireSchema } from '../../require-schema';
 import styles from './styles.module.css';
 
 export const DefaultLayout = ({
@@ -10,14 +11,16 @@ export const DefaultLayout = ({
 	header?: React.ReactNode;
 	children: React.ReactNode;
 }) => (
-	<div className={styles.container}>
-		<header>
-			<Header>{header}</Header>
-		</header>
-		<nav>
-			<SideBar />
-		</nav>
-		<div className={styles.content}>{children}</div>
-		<footer className={styles.footer}>{/* TODO: */ ''}</footer>
-	</div>
+	<RequireSchema>
+		<div className={styles.container}>
+			<header>
+				<Header>{header}</Header>
+			</header>
+			<nav>
+				<SideBar />
+			</nav>
+			<div className={styles.content}>{children}</div>
+			<footer className={styles.footer}>{/* TODO: */ ''}</footer>
+		</div>
+	</RequireSchema>
 );

--- a/src/packages/admin-ui-components/src/require-schema/component.tsx
+++ b/src/packages/admin-ui-components/src/require-schema/component.tsx
@@ -1,0 +1,11 @@
+import { useSchema } from '../utils';
+import { Spinner } from '../spinner';
+
+export const RequireSchema = ({ children }: { children?: React.ReactNode }) => {
+	const { loading, error } = useSchema();
+
+	if (error) return <div>{error.message}</div>;
+
+	// If we're still loading, return the spinner, else, we're ready to go.
+	return loading ? <Spinner /> : <>{children}</>;
+};

--- a/src/packages/admin-ui-components/src/require-schema/index.ts
+++ b/src/packages/admin-ui-components/src/require-schema/index.ts
@@ -1,0 +1,1 @@
+export * from './component';

--- a/src/packages/admin-ui-components/src/utils/use-schema.ts
+++ b/src/packages/admin-ui-components/src/utils/use-schema.ts
@@ -29,7 +29,7 @@ export interface EntityField {
 }
 
 export const useSchema = () => {
-	const { data } = useQuery<{ result: Schema }>(SCHEMA_QUERY);
+	const { data, loading, error } = useQuery<{ result: Schema }>(SCHEMA_QUERY);
 
 	// This is a map of backendId to a list of entities
 	const dataSourceMap = useMemo(() => {
@@ -68,6 +68,8 @@ export const useSchema = () => {
 	}, [data]);
 
 	return {
+		loading,
+		error,
 		entities: Object.keys(entityMap),
 		backends: Object.keys(dataSourceMap),
 		entityByName: (entityName: string) => entityMap[entityName],

--- a/src/packages/admin-ui/src/router.tsx
+++ b/src/packages/admin-ui/src/router.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 
 // This is injected by vite-plugin-graphweaver
 import { dashboards } from 'virtual:graphweaver-user-supplied-dashboards';
-
 import { Loader, DefaultLayout, ToolBar } from '@exogee/graphweaver-admin-ui-components';
+
 import { List, Root } from './pages';
 
 const defaultRoutes = [


### PR DESCRIPTION
This introduces a component which:

- Utilises the `useSchema` hook to check if the schema information is loaded or not.
- If it's not, then it renders the spinner.
- Once it's ready, we get the UI rendering, which can retain all its assertions about needing to have the schema info because now it's definitely loaded.