### PR TITLE
Mikro Decoupling

### DIFF
--- a/.github/workflows/cli-build-and-test.yml
+++ b/.github/workflows/cli-build-and-test.yml
@@ -1,0 +1,48 @@
+name: CLI Build and Test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: pnpm i
+
+      - name: Build CLI tool
+        run: pnpm build
+
+      - name: Change to CLI directory
+        run: cd packages/cli
+
+      - name: Run CLI tests
+        run: pnpm test:create
+
+      - name: Change to GW instance directory
+        run: cd test
+
+      - name: Install GW instance dependencies
+        run: pnpm i
+
+      - name: Change to GW instance directory
+        run: pnpm start &
+
+      - name: Wait for server to start
+        run: npx wait-for http://localhost:9000 -t 30
+
+        env:
+          CI: true

--- a/.github/workflows/cli-build-and-test.yml
+++ b/.github/workflows/cli-build-and-test.yml
@@ -13,12 +13,26 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v2
+      - uses: actions/cache@v3
+        env:
+          cache-name: cache-pnpm-modules
         with:
-          node-version: 16
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
+
+      - uses: pnpm/action-setup@v2.2.4
+        with:
+          version: 7.29.1
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: "pnpm"
+          cache-dependency-path: src/pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm i

--- a/.github/workflows/cli-build-and-test.yml
+++ b/.github/workflows/cli-build-and-test.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  build-and-test:
+  build-and-test-cli:
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/cli-build-and-test.yml
+++ b/.github/workflows/cli-build-and-test.yml
@@ -46,12 +46,20 @@ jobs:
           pwd
           pnpm test:create
 
-      - name: Change to GW instance and start
+      - name: Change to GW instance and install
         working-directory: src/packages/cli/test
         run: |
           pwd
-          pnpm i
-          pnpm start & npx wait-for http://localhost:9001 -t 30
+          npm i
+      
+      - name: Start GW instance
+        working-directory: src/packages/cli/test
+        timeout-minutes: 2
+        run: |
+          npm start &
+          sleep 10 &&
+          curl http://localhost:9000 &&
+          killall node
 
         env:
           CI: true

--- a/.github/workflows/cli-build-and-test.yml
+++ b/.github/workflows/cli-build-and-test.yml
@@ -40,23 +40,18 @@ jobs:
       - name: Build CLI tool
         run: pnpm build
 
-      - name: Change to CLI directory
-        run: cd packages/cli
+      - name: Create GW instance
+        working-directory: src/packages/cli
+        run: |
+          pwd
+          pnpm test:create
 
-      - name: Run CLI tests
-        run: pnpm test:create
-
-      - name: Change to GW instance directory
-        run: cd test
-
-      - name: Install GW instance dependencies
-        run: pnpm i
-
-      - name: Change to GW instance directory
-        run: pnpm start &
-
-      - name: Wait for server to start
-        run: npx wait-for http://localhost:9000 -t 30
+      - name: Change to GW instance and start
+        working-directory: src/packages/cli/test
+        run: |
+          pwd
+          pnpm i
+          pnpm start & npx wait-for http://localhost:9001 -t 30
 
         env:
           CI: true

--- a/src/.eslintignore
+++ b/src/.eslintignore
@@ -6,4 +6,4 @@
 **/.graphweaver/**
 .eslintrc.js
 packages/cli/bin/index.js
-packages/create-graphweaver/bin/index.js
+packages/cli/test-create.js

--- a/src/examples/databases/src/backend/database.ts
+++ b/src/examples/databases/src/backend/database.ts
@@ -1,0 +1,30 @@
+import { MySqlDriver } from '@mikro-orm/mysql';
+import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+
+import { Task, User } from './entities';
+
+export const pgConnection = {
+	connectionManagerId: 'pg',
+	mikroOrmConfig: {
+		entities: [User],
+		driver: PostgreSqlDriver,
+		dbName: 'todo_app',
+		user: 'postgres',
+		password: '',
+		port: 5432,
+	},
+};
+
+export const myConnection = {
+	connectionManagerId: 'my',
+	mikroOrmConfig: {
+		entities: [Task],
+		driver: MySqlDriver,
+		dbName: 'todo_app',
+		user: 'root',
+		password: 'password',
+		port: 3306,
+	},
+};
+
+export const connections = [pgConnection, myConnection];

--- a/src/examples/databases/src/backend/index.ts
+++ b/src/examples/databases/src/backend/index.ts
@@ -1,45 +1,20 @@
 import 'reflect-metadata';
 import Graphweaver from '@exogee/graphweaver-apollo';
 import { handlers, startServerAndCreateLambdaHandler } from '@as-integrations/aws-lambda';
-import { MySqlDriver } from '@mikro-orm/mysql';
-import { PostgreSqlDriver } from '@mikro-orm/postgresql';
-
-import { Task, User } from './entities';
+import { ClearDatabaseContext, connectToDatabase } from '@exogee/graphweaver-mikroorm';
 
 import { UserResolver } from './schema/user';
 import { TaskResolver } from './schema/task';
+
+import { connections } from './database';
 
 const graphweaver = new Graphweaver({
 	resolvers: [TaskResolver, UserResolver],
 	apolloServerOptions: {
 		introspection: process.env.IS_OFFLINE === 'true',
+		plugins: [connectToDatabase(connections), ClearDatabaseContext],
 	},
 	adminMetadata: { enabled: true },
-
-	mikroOrmOptions: [
-		{
-			connectionManagerId: 'pg',
-			mikroOrmConfig: {
-				entities: [User],
-				driver: PostgreSqlDriver,
-				dbName: 'todo_app',
-				user: 'postgres',
-				password: '',
-				port: 5432,
-			},
-		},
-		{
-			connectionManagerId: 'my',
-			mikroOrmConfig: {
-				entities: [Task],
-				driver: MySqlDriver,
-				dbName: 'todo_app',
-				user: 'root',
-				password: 'password',
-				port: 3306,
-			},
-		},
-	],
 });
 
 exports.handler = startServerAndCreateLambdaHandler(

--- a/src/examples/databases/src/backend/schema/task/resolver.ts
+++ b/src/examples/databases/src/backend/schema/task/resolver.ts
@@ -4,9 +4,10 @@ import { Resolver } from 'type-graphql';
 
 import { Task as OrmTask } from '../../entities';
 import { Task } from './entity';
+import { myConnection } from '../../database';
 
 @Resolver((of) => Task)
 export class TaskResolver extends createBaseResolver<Task, OrmTask>(
 	Task,
-	new MikroBackendProvider(OrmTask, 'my')
+	new MikroBackendProvider(OrmTask, myConnection)
 ) {}

--- a/src/examples/databases/src/backend/schema/user/resolver.ts
+++ b/src/examples/databases/src/backend/schema/user/resolver.ts
@@ -4,9 +4,10 @@ import { Resolver } from 'type-graphql';
 
 import { User as OrmUser } from '../../entities';
 import { User } from './entity';
+import { pgConnection } from '../../database';
 
 @Resolver((of) => User)
 export class UserResolver extends createBaseResolver<User, OrmUser>(
 	User,
-	new MikroBackendProvider(OrmUser, 'pg')
+	new MikroBackendProvider(OrmUser, pgConnection)
 ) {}

--- a/src/examples/rest/src/backend/database.ts
+++ b/src/examples/rest/src/backend/database.ts
@@ -1,0 +1,15 @@
+import { MySqlDriver } from '@mikro-orm/mysql';
+import { Task, Tag } from './entities';
+
+// Define the database connection
+export const myConnection = {
+	connectionManagerId: 'my-sql',
+	mikroOrmConfig: {
+		entities: [Task, Tag],
+		driver: MySqlDriver,
+		dbName: 'todo_app',
+		user: 'root',
+		password: 'password',
+		port: 3306,
+	},
+};

--- a/src/examples/rest/src/backend/index.ts
+++ b/src/examples/rest/src/backend/index.ts
@@ -19,9 +19,9 @@ import {
 } from '@exogee/graphweaver-auth';
 import { MySqlDriver } from '@mikro-orm/mysql';
 import { BaseLoaders } from '@exogee/graphweaver';
+import { ClearDatabaseContext, connectToDatabase } from '@exogee/graphweaver-mikroorm';
 
 import { Task, Tag } from './entities';
-
 import { UserResolver, User } from './schema/user';
 import { TaskResolver } from './schema/task';
 import { TagResolver } from './schema/tag';
@@ -37,25 +37,28 @@ export enum Roles {
 
 const resolvers = [TaskResolver, TagResolver, UserResolver];
 
+// Define the database connection
+const mikroOrmOptions = [
+	{
+		connectionManagerId: 'my-sql',
+		mikroOrmConfig: {
+			entities: [Task, Tag],
+			driver: MySqlDriver,
+			dbName: 'todo_app',
+			user: 'root',
+			password: 'password',
+			port: 3306,
+		},
+	},
+];
+
 const graphweaver = new Graphweaver<Context>({
 	resolvers,
 	apolloServerOptions: {
 		introspection: isOffline,
+		plugins: [connectToDatabase(mikroOrmOptions), ClearDatabaseContext],
 	},
 	adminMetadata: { enabled: true },
-	mikroOrmOptions: [
-		{
-			connectionManagerId: 'my-sql',
-			mikroOrmConfig: {
-				entities: [Task, Tag],
-				driver: MySqlDriver,
-				dbName: 'todo_app',
-				user: 'root',
-				password: 'password',
-				port: 3306,
-			},
-		},
-	],
 });
 
 setAdministratorRoleName('ADMINISTRATOR');

--- a/src/examples/rest/src/backend/index.ts
+++ b/src/examples/rest/src/backend/index.ts
@@ -17,14 +17,13 @@ import {
 	setAdministratorRoleName,
 	upsertAuthorizationContext,
 } from '@exogee/graphweaver-auth';
-import { MySqlDriver } from '@mikro-orm/mysql';
 import { BaseLoaders } from '@exogee/graphweaver';
 import { ClearDatabaseContext, connectToDatabase } from '@exogee/graphweaver-mikroorm';
 
-import { Task, Tag } from './entities';
 import { UserResolver, User } from './schema/user';
 import { TaskResolver } from './schema/task';
 import { TagResolver } from './schema/tag';
+import { myConnection } from './database';
 
 export interface Context extends AuthorizationContext {
 	user: User;
@@ -37,26 +36,11 @@ export enum Roles {
 
 const resolvers = [TaskResolver, TagResolver, UserResolver];
 
-// Define the database connection
-const mikroOrmOptions = [
-	{
-		connectionManagerId: 'my-sql',
-		mikroOrmConfig: {
-			entities: [Task, Tag],
-			driver: MySqlDriver,
-			dbName: 'todo_app',
-			user: 'root',
-			password: 'password',
-			port: 3306,
-		},
-	},
-];
-
 const graphweaver = new Graphweaver<Context>({
 	resolvers,
 	apolloServerOptions: {
 		introspection: isOffline,
-		plugins: [connectToDatabase(mikroOrmOptions), ClearDatabaseContext],
+		plugins: [connectToDatabase(myConnection), ClearDatabaseContext],
 	},
 	adminMetadata: { enabled: true },
 });

--- a/src/examples/rest/src/backend/schema/tag/resolver.ts
+++ b/src/examples/rest/src/backend/schema/tag/resolver.ts
@@ -4,9 +4,10 @@ import { Resolver } from 'type-graphql';
 
 import { Tag as OrmTag } from '../../entities';
 import { Tag } from './entity';
+import { myConnection } from '../../database';
 
 @Resolver((of) => Tag)
 export class TagResolver extends createBaseResolver<Tag, OrmTag>(
 	Tag,
-	new MikroBackendProvider(OrmTag, 'my-sql')
+	new MikroBackendProvider(OrmTag, myConnection)
 ) {}

--- a/src/examples/rest/src/backend/schema/task/resolver.ts
+++ b/src/examples/rest/src/backend/schema/task/resolver.ts
@@ -4,10 +4,10 @@ import { Resolver } from 'type-graphql';
 
 import { Task as OrmTask } from '../../entities';
 import { Task } from './entity';
-import { Context } from '../../';
+import { myConnection } from '../../database';
 
 @Resolver((of) => Task)
 export class TaskResolver extends createBaseResolver<Task, OrmTask>(
 	Task,
-	new MikroBackendProvider(OrmTask, 'my-sql')
+	new MikroBackendProvider(OrmTask, myConnection)
 ) {}

--- a/src/examples/xero/package.json
+++ b/src/examples/xero/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-xero",
-	"version": "0.1.16",
+	"version": "0.1.17",
 	"license": "MIT",
 	"private": true,
 	"description": "Example of using @exogee/graphweaver to connect two Xero instances",

--- a/src/packages/admin-ui-components/package.json
+++ b/src/packages/admin-ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-admin-ui-components",
-	"version": "0.1.16",
+	"version": "0.1.17",
 	"description": "Components from Graphweaver's admin UI which you can use in your projects as you like",
 	"license": "MIT",
 	"type": "module",

--- a/src/packages/admin-ui/package.json
+++ b/src/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-admin-ui",
-	"version": "0.1.16",
+	"version": "0.1.17",
 	"type": "module",
 	"main": "dist/main.js",
 	"types": "src/main.tsx",

--- a/src/packages/apollo/package.json
+++ b/src/packages/apollo/package.json
@@ -22,7 +22,6 @@
 	"dependencies": {
 		"@apollo/server": "4.2.2",
 		"@exogee/graphweaver": "workspace:*",
-		"@exogee/graphweaver-mikroorm": "workspace:*",
 		"@exogee/logger": "workspace:*",
 		"@graphql-tools/graphql-file-loader": "7.5.17",
 		"@graphql-tools/load": "7.8.14",

--- a/src/packages/apollo/package.json
+++ b/src/packages/apollo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-apollo",
-	"version": "0.1.16",
+	"version": "0.1.17",
 	"description": "Apollo Server support for @exogee/graphweaver",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/apollo/src/index.ts
+++ b/src/packages/apollo/src/index.ts
@@ -9,9 +9,7 @@ import { logger } from '@exogee/logger';
 import { ApolloServer, BaseContext } from '@apollo/server';
 import { ApolloServerOptionsWithStaticSchema } from '@apollo/server/dist/esm/externalTypes/constructor';
 import {
-	ClearDatabaseContext,
 	ClearDataLoaderCache,
-	connectToDatabase,
 	LogErrors,
 	LogRequests,
 	MutexRequestsInDevelopment,
@@ -68,10 +66,6 @@ export default class Graphweaver<TContext extends BaseContext> {
 			LogErrors,
 			ClearDataLoaderCache,
 			corsPlugin(this.config.corsOptions),
-			// Only load the database plugins if we have a database connected
-			...(this.config.mikroOrmOptions
-				? [connectToDatabase(this.config.mikroOrmOptions), ClearDatabaseContext]
-				: []),
 			...(this.config.apolloServerOptions?.plugins || []),
 		];
 		const resolvers = (this.config.resolvers || []) as any;

--- a/src/packages/apollo/src/index.ts
+++ b/src/packages/apollo/src/index.ts
@@ -16,7 +16,6 @@ import {
 	corsPlugin,
 } from './plugins';
 
-import type { ConnectionOptions } from '@exogee/graphweaver-mikroorm';
 import type { CorsPluginOptions } from './plugins';
 
 export * from '@apollo/server';
@@ -29,7 +28,6 @@ export interface AdminMetadata {
 
 export interface GraphweaverConfig {
 	adminMetadata?: AdminMetadata;
-	mikroOrmOptions?: ConnectionOptions[];
 	resolvers: Array<any>;
 	// We omit schema here because we will build it from your resolvers.
 	apolloServerOptions?: Omit<ApolloServerOptionsWithStaticSchema<any>, 'schema'>;

--- a/src/packages/apollo/src/index.ts
+++ b/src/packages/apollo/src/index.ts
@@ -1,12 +1,12 @@
 import { AdminUiMetadataResolver } from './metadata-service';
 import { AuthChecker, buildSchemaSync } from 'type-graphql';
-import { ConnectionOptions } from '@exogee/graphweaver-mikroorm';
+
 import path from 'path';
 import { loadSchemaSync } from '@graphql-tools/load';
 import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader';
 
 import { logger } from '@exogee/logger';
-import { ApolloServer, BaseContext, ContextFunction } from '@apollo/server';
+import { ApolloServer, BaseContext } from '@apollo/server';
 import { ApolloServerOptionsWithStaticSchema } from '@apollo/server/dist/esm/externalTypes/constructor';
 import {
 	ClearDatabaseContext,
@@ -18,6 +18,7 @@ import {
 	corsPlugin,
 } from './plugins';
 
+import type { ConnectionOptions } from '@exogee/graphweaver-mikroorm';
 import type { CorsPluginOptions } from './plugins';
 
 export * from '@apollo/server';

--- a/src/packages/apollo/src/metadata-service/resolver.ts
+++ b/src/packages/apollo/src/metadata-service/resolver.ts
@@ -3,8 +3,8 @@ import {
 	isSummaryField,
 	AdminUISettingsMap,
 	AdminUIFilterType,
+	RelationshipType,
 } from '@exogee/graphweaver';
-import { ReferenceType } from '@exogee/graphweaver-mikroorm';
 import { getMetadataStorage, Query, Resolver } from 'type-graphql';
 import { ObjectClassMetadata } from 'type-graphql/dist/metadata/definitions/object-class-metdata';
 import { EnumMetadata } from 'type-graphql/dist/metadata/definitions';
@@ -80,12 +80,12 @@ export class AdminUiMetadataResolver {
 						});
 						if (relatedEntity?.typeOptions) {
 							fieldObject.relationshipType = relatedEntity.typeOptions.array
-								? ReferenceType.MANY_TO_MANY
-								: ReferenceType.ONE_TO_MANY;
+								? RelationshipType.MANY_TO_MANY
+								: RelationshipType.ONE_TO_MANY;
 						}
 						fieldObject.relatedEntity = entityName;
 					} else if (relatedObject) {
-						fieldObject.relationshipType = ReferenceType.MANY_TO_ONE;
+						fieldObject.relationshipType = RelationshipType.MANY_TO_ONE;
 					}
 					fieldObject.filter = adminUISettings?.fields?.[field.name]?.filter?.hide
 						? undefined

--- a/src/packages/apollo/src/plugins/index.ts
+++ b/src/packages/apollo/src/plugins/index.ts
@@ -1,6 +1,4 @@
 export { ClearDataLoaderCache } from './clear-data-loader-cache';
-export { ClearDatabaseContext } from './clear-database-context';
-export { connectToDatabase } from './connect-to-database';
 export { LogErrors } from './log-errors';
 export { LogRequests } from './log-requests';
 export { MutexRequestsInDevelopment } from './mutex-requests-in-development';

--- a/src/packages/auth/package.json
+++ b/src/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-auth",
-	"version": "0.1.16",
+	"version": "0.1.17",
 	"description": "Row-Level Security support for @exogee/graphweaver",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/builder/package.json
+++ b/src/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-builder",
-	"version": "0.1.16",
+	"version": "0.1.17",
 	"description": "A tool for building and running GraphWeaver projects",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/cli/package.json
+++ b/src/packages/cli/package.json
@@ -8,6 +8,7 @@
 		"build:js": "node build.js",
 		"prettier": "prettier --write .",
 		"gw": "./bin/gw-bin.js",
+		"test:create": "node test-create.js",
 		"version": "npm version --no-git-tag-version"
 	},
 	"bin": {

--- a/src/packages/cli/package.json
+++ b/src/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-cli",
-	"version": "0.1.16",
+	"version": "0.1.17",
 	"description": "A tool for managing, running, debugging and building Graphweaver projects",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/cli/src/create/index.ts
+++ b/src/packages/cli/src/create/index.ts
@@ -7,6 +7,7 @@ import {
 	makeSchemaIndex,
 	makeTsConfig,
 	makeReadme,
+	makeDatabase,
 } from './template';
 
 import { Backend } from './backend';
@@ -15,6 +16,9 @@ const abort = () => {
 	console.log('Cancelled!');
 	exit(1);
 };
+
+export const needsDatabaseConnection = (backends: Backend[]) =>
+	backends.some((backend) => [Backend.MikroOrmPostgres, Backend.MikroOrmMysql].includes(backend));
 
 export const create = async () => {
 	console.log('GraphWeaver\n');
@@ -62,6 +66,7 @@ export const create = async () => {
 		makePackageJson(projectName, backends);
 		makeTsConfig(projectName);
 		makeIndex(projectName, backends);
+		if (needsDatabaseConnection(backends)) makeDatabase(projectName, backends);
 		makeSchemaIndex(projectName, backends);
 
 		console.log('All Done!\nMake sure you to pnpm install, then pnpm start.');

--- a/src/packages/cli/src/create/index.ts
+++ b/src/packages/cli/src/create/index.ts
@@ -20,6 +20,16 @@ const abort = () => {
 export const needsDatabaseConnection = (backends: Backend[]) =>
 	backends.some((backend) => [Backend.MikroOrmPostgres, Backend.MikroOrmMysql].includes(backend));
 
+export const createGraphWeaver = (projectName: string, backends: Backend[]) => {
+	makeDirectories(projectName);
+	makeReadme(projectName);
+	makePackageJson(projectName, backends);
+	makeTsConfig(projectName);
+	makeIndex(projectName, backends);
+	if (needsDatabaseConnection(backends)) makeDatabase(projectName, backends);
+	makeSchemaIndex(projectName, backends);
+};
+
 export const create = async () => {
 	console.log('GraphWeaver\n');
 
@@ -61,13 +71,7 @@ export const create = async () => {
 
 		if (!createDirectory) abort();
 
-		makeDirectories(projectName);
-		makeReadme(projectName);
-		makePackageJson(projectName, backends);
-		makeTsConfig(projectName);
-		makeIndex(projectName, backends);
-		if (needsDatabaseConnection(backends)) makeDatabase(projectName, backends);
-		makeSchemaIndex(projectName, backends);
+		createGraphWeaver(projectName, backends);
 
 		console.log('All Done!\nMake sure you to pnpm install, then pnpm start.');
 

--- a/src/packages/cli/src/create/template.ts
+++ b/src/packages/cli/src/create/template.ts
@@ -1,6 +1,7 @@
 import { writeFileSync, mkdirSync } from 'fs';
 import { Backend, packagesForBackend } from './backend';
 import { AWS_LAMBDA_VERSION, GRAPHWEAVER_TARGET_VERSION } from './constants';
+import { needsDatabaseConnection } from '.';
 
 export const makePackageJson = (projectName: string, backends: Backend[]) => {
 	const backendPackages = Object.assign(
@@ -44,35 +45,61 @@ export const makeDirectories = (projectName: string) => {
 	mkdirSync(`${projectName}/src/backend/schema/ping`);
 };
 
-export const makeIndex = (projectName: string, backends: Backend[]) => {
+export const makeDatabase = (projectName: string, backends: Backend[]) => {
 	const myDriverImport = `import { MySqlDriver } from '@mikro-orm/mysql';`;
-	const myConfig = `{
-			connectionManagerId: 'my',
-			mikroOrmConfig: {
-				driver: MySqlDriver,
-				entities: [],
-				dbName: '%%REPLACE_WITH_DB_NAME%%',
-				user: '%%REPLACE_WITH_USERNAME%%',
-				password: '%%REPLACE_WITH_PASSWORD%%',
-				port: 3306,
-			},
-		},`;
+	const myConnection = `export const myConnection = {
+	connectionManagerId: 'my',
+	mikroOrmConfig: {
+		driver: MySqlDriver,
+		entities: [],
+		dbName: '%%REPLACE_WITH_DB_NAME%%',
+		user: '%%REPLACE_WITH_USERNAME%%',
+		password: '%%REPLACE_WITH_PASSWORD%%',
+		port: 3306,
+	},
+};`;
 
 	const pgDriverImport = `import { PostgreSqlDriver } from '@mikro-orm/postgresql';`;
-	const pgConfig = `{
-			connectionManagerId: 'pg',
-			mikroOrmConfig: {
-				driver: PostgreSqlDriver,
-				entities: [],
-				dbName: '%%REPLACE_WITH_DB_NAME%%',
-				user: '%%REPLACE_WITH_USERNAME%%',
-				password: '%%REPLACE_WITH_PASSWORD%%',
-				port: 5432,
-			},
-		},`;
+	const pgConnection = `export const pgConnection = {
+	connectionManagerId: 'pg',
+	mikroOrmConfig: {
+		driver: PostgreSqlDriver,
+		entities: [],
+		dbName: '%%REPLACE_WITH_DB_NAME%%',
+		user: '%%REPLACE_WITH_USERNAME%%',
+		password: '%%REPLACE_WITH_PASSWORD%%',
+		port: 5432,
+	},
+};`;
 
 	const hasPostgres = backends.some((backend) => backend === Backend.MikroOrmPostgres);
 	const hasMySql = backends.some((backend) => backend === Backend.MikroOrmMysql);
+
+	// Install the Apollo plugins on the server
+	let plugins = undefined;
+	if (hasPostgres && hasMySql) {
+		plugins = `[connectToDatabase([pgConnection, myConnection]), ClearDatabaseContext]`;
+	} else if (hasPostgres) {
+		plugins = `[connectToDatabase(pgConnection), ClearDatabaseContext]`;
+	} else if (hasMySql) {
+		plugins = `[connectToDatabase(myConnection), ClearDatabaseContext]`;
+	}
+
+	const database = `import { ClearDatabaseContext, connectToDatabase } from '@exogee/graphweaver-mikroorm';
+${hasPostgres ? pgDriverImport : ``}
+${hasMySql ? myDriverImport : ``}
+
+${hasPostgres ? pgConnection : ``}
+${hasMySql ? myConnection : ``}
+
+export const plugins = ${plugins};
+	`;
+
+	writeFileSync(`${projectName}/src/backend/database.ts`, database);
+};
+
+export const makeIndex = (projectName: string, backends: Backend[]) => {
+	const hasDatabaseConnections = needsDatabaseConnection(backends);
 
 	const index = `\
 /* ${projectName} GraphWeaver Project */
@@ -80,8 +107,8 @@ export const makeIndex = (projectName: string, backends: Backend[]) => {
 import 'reflect-metadata';
 import { handlers, startServerAndCreateLambdaHandler } from '@as-integrations/aws-lambda';
 import Graphweaver from '@exogee/graphweaver-apollo';
-${hasPostgres ? pgDriverImport : ``}
-${hasMySql ? myDriverImport : ``}
+${hasDatabaseConnections ? `import { plugins } from './database';` : ''}
+
 import { PingResolver } from './schema/ping';
 
 const isOffline = process.env.IS_OFFLINE === 'true';
@@ -90,16 +117,9 @@ const graphweaver = new Graphweaver({
 	resolvers: [PingResolver],
 	apolloServerOptions: {
 		introspection: isOffline,
+		${hasDatabaseConnections ? `plugins,` : ''}
 	},
 	adminMetadata: { enabled: true },
-	${
-		hasPostgres || hasMySql
-			? `mikroOrmOptions: [
-		${hasPostgres ? pgConfig : ``}
-		${hasMySql ? myConfig : ``}
-	],`
-			: ``
-	}
 });
 
 export const handler = startServerAndCreateLambdaHandler<any>(

--- a/src/packages/cli/src/index.ts
+++ b/src/packages/cli/src/index.ts
@@ -10,6 +10,8 @@ import {
 } from '@exogee/graphweaver-builder';
 import { create } from './create';
 
+export { createGraphWeaver } from './create';
+
 yargs
 	.env('GRAPHWEAVER')
 	.command({

--- a/src/packages/cli/test-create.js
+++ b/src/packages/cli/test-create.js
@@ -1,0 +1,2 @@
+const { createGraphWeaver } = require('./bin');
+createGraphWeaver('test', [0]);

--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver",
-	"version": "0.1.16",
+	"version": "0.1.17",
 	"description": "Graphweaver Core Package",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/core/src/common/types.ts
+++ b/src/packages/core/src/common/types.ts
@@ -141,3 +141,9 @@ export type AdminUISettingsType = {
 		};
 	};
 };
+
+export enum RelationshipType {
+	MANY_TO_ONE = 'MANY_TO_ONE',
+	MANY_TO_MANY = 'MANY_TO_MANY',
+	ONE_TO_MANY = 'ONE_TO_MANY',
+}

--- a/src/packages/logger/package.json
+++ b/src/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/logger",
-	"version": "0.1.16",
+	"version": "0.1.17",
 	"description": "Common logging output for Exogee projects",
 	"license": "MIT",
 	"directories": {

--- a/src/packages/mikroorm/package.json
+++ b/src/packages/mikroorm/package.json
@@ -20,6 +20,7 @@
 		"lib"
 	],
 	"dependencies": {
+		"@apollo/server": "4.2.2",
 		"@exogee/graphweaver": "workspace:*",
 		"@exogee/logger": "workspace:*",
 		"dataloader": "2.2.2",

--- a/src/packages/mikroorm/package.json
+++ b/src/packages/mikroorm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-mikroorm",
-	"version": "0.1.16",
+	"version": "0.1.17",
 	"description": "MikroORM backend for @exogee/graphweaver",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/mikroorm/src/base-resolver/provider.ts
+++ b/src/packages/mikroorm/src/base-resolver/provider.ts
@@ -18,6 +18,7 @@ import {
 	externalIdFieldMap,
 	AnyEntity,
 	IsolationLevel,
+	ConnectionOptions,
 } from '..';
 import { OptimisticLockError } from '../utils/errors';
 import { assign } from './assign';
@@ -127,12 +128,12 @@ export class MikroBackendProvider<D extends BaseDataEntity, G extends GraphQLEnt
 
 	public constructor(
 		mikroType: new () => D,
-		connectionManagerId?: string,
+		connection: ConnectionOptions,
 		transactionIsolationLevel: IsolationLevel = IsolationLevel.REPEATABLE_READ
 	) {
 		this.entityType = mikroType;
-		this.connectionManagerId = connectionManagerId;
-		this._backendId = `mikro-orm-${connectionManagerId || ''}`;
+		this.connectionManagerId = connection.connectionManagerId;
+		this._backendId = `mikro-orm-${connection.connectionManagerId || ''}`;
 		this.transactionIsolationLevel = transactionIsolationLevel;
 	}
 

--- a/src/packages/mikroorm/src/database.ts
+++ b/src/packages/mikroorm/src/database.ts
@@ -255,6 +255,10 @@ class ConnectionsManager {
 		this.connections = new Map<string, DatabaseImplementation>();
 	}
 
+	getConnections() {
+		return Array.from(this.connections.values());
+	}
+
 	get default(): DatabaseImplementation {
 		const [defaultConnection] = [...this.connections];
 		if (!defaultConnection)

--- a/src/packages/mikroorm/src/database.ts
+++ b/src/packages/mikroorm/src/database.ts
@@ -269,7 +269,9 @@ class ConnectionsManager {
 		return databaseConnection;
 	}
 
-	public connect = async (id: string, connectionOptions?: ConnectionOptions) => {
+	public connect = async (id?: string, connectionOptions?: ConnectionOptions) => {
+		if (!id) throw new Error('Error: No id attached to connection.');
+
 		if (this.connections.has(id)) return this.connections.get(id);
 		const database = new DatabaseImplementation();
 		if (connectionOptions) await database.connect(connectionOptions);

--- a/src/packages/mikroorm/src/index.ts
+++ b/src/packages/mikroorm/src/index.ts
@@ -11,6 +11,7 @@ export * from './decorators';
 export * from './database';
 export * from './types';
 export * from './utils/authentication-context';
+export * from './plugins';
 
 // Re-export from Mikro so things that depend on database entities can access helpers such as
 // Reference.isReference().

--- a/src/packages/mikroorm/src/plugins/clear-database-context.ts
+++ b/src/packages/mikroorm/src/plugins/clear-database-context.ts
@@ -1,12 +1,15 @@
 import { ApolloServerPlugin } from '@apollo/server';
-import { ConnectionManager } from '@exogee/graphweaver-mikroorm';
 import { logger } from '@exogee/logger';
+
+import { ConnectionManager } from '../database';
 
 export const ClearDatabaseContext: ApolloServerPlugin = {
 	// We need to ensure the Entity Manager is clear on each request
 	async requestDidStart() {
 		try {
-			ConnectionManager.default.em.clear();
+			for (const connection of ConnectionManager.getConnections()) {
+				connection.em.clear();
+			}
 		} catch (err) {
 			logger.trace('failed to clear default database.');
 		}

--- a/src/packages/mikroorm/src/plugins/connect-to-database.ts
+++ b/src/packages/mikroorm/src/plugins/connect-to-database.ts
@@ -1,12 +1,18 @@
 import { ApolloServerPlugin } from '@apollo/server';
 import { ConnectionManager, ConnectionOptions } from '../database';
 
-export const connectToDatabase = (options: ConnectionOptions[]): ApolloServerPlugin => {
+export const connectToDatabase = (
+	options: ConnectionOptions[] | ConnectionOptions
+): ApolloServerPlugin => {
 	return {
 		serverWillStart: async () => {
-			for (const option of options) {
-				if (option.connectionManagerId)
-					await ConnectionManager.connect(option.connectionManagerId, option);
+			if (Array.isArray(options)) {
+				for (const option of options) {
+					if (option.connectionManagerId)
+						await ConnectionManager.connect(option.connectionManagerId, option);
+				}
+			} else {
+				await ConnectionManager.connect(options.connectionManagerId, options);
 			}
 		},
 	};

--- a/src/packages/mikroorm/src/plugins/connect-to-database.ts
+++ b/src/packages/mikroorm/src/plugins/connect-to-database.ts
@@ -1,5 +1,5 @@
 import { ApolloServerPlugin } from '@apollo/server';
-import { ConnectionManager, ConnectionOptions } from '@exogee/graphweaver-mikroorm';
+import { ConnectionManager, ConnectionOptions } from '../database';
 
 export const connectToDatabase = (options: ConnectionOptions[]): ApolloServerPlugin => {
 	return {

--- a/src/packages/mikroorm/src/plugins/index.ts
+++ b/src/packages/mikroorm/src/plugins/index.ts
@@ -1,0 +1,2 @@
+export { ClearDatabaseContext } from './clear-database-context';
+export { connectToDatabase } from './connect-to-database';

--- a/src/packages/rest/package.json
+++ b/src/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-rest",
-	"version": "0.1.16",
+	"version": "0.1.17",
 	"description": "RESTful backend for @exogee/graphweaver",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/rest/src/base-resolver/loader.ts
+++ b/src/packages/rest/src/base-resolver/loader.ts
@@ -1,4 +1,5 @@
-import { BaseEntity, RelationshipMap, RelationshipType, Relationship } from '../entities';
+import { RelationshipType } from '@exogee/graphweaver';
+import { BaseEntity, Relationship } from '../entities';
 import { logger } from '@exogee/logger';
 import DataLoader from 'dataloader';
 import { EntityConstructor, EntityManager } from '../entity-manager';

--- a/src/packages/rest/src/decorators/many-to-many.ts
+++ b/src/packages/rest/src/decorators/many-to-many.ts
@@ -1,4 +1,6 @@
-import { BaseEntity, RelationshipType } from '../entities/base-entity';
+import { RelationshipType } from '@exogee/graphweaver';
+
+import { BaseEntity } from '../entities/base-entity';
 import { EntityConstructor } from '../entity-manager';
 
 interface FieldOptions {

--- a/src/packages/rest/src/decorators/many-to-one.ts
+++ b/src/packages/rest/src/decorators/many-to-one.ts
@@ -1,4 +1,6 @@
-import { BaseEntity, RelationshipType } from '../entities/base-entity';
+import { RelationshipType } from '@exogee/graphweaver';
+
+import { BaseEntity } from '../entities/base-entity';
 import { EntityConstructor } from '../entity-manager';
 
 interface FieldOptions {

--- a/src/packages/rest/src/decorators/one-to-many.ts
+++ b/src/packages/rest/src/decorators/one-to-many.ts
@@ -1,4 +1,5 @@
-import { BaseEntity, RelationshipType } from '../entities/base-entity';
+import { RelationshipType } from '@exogee/graphweaver';
+import { BaseEntity } from '../entities/base-entity';
 import { EntityConstructor } from '../entity-manager';
 
 interface FieldOptions {

--- a/src/packages/rest/src/entities/base-entity.ts
+++ b/src/packages/rest/src/entities/base-entity.ts
@@ -1,10 +1,4 @@
-import { BaseDataEntity } from '@exogee/graphweaver';
-
-export enum RelationshipType {
-	MANY_TO_ONE = 'MANY_TO_ONE',
-	MANY_TO_MANY = 'MANY_TO_MANY',
-	ONE_TO_MANY = 'ONE_TO_MANY',
-}
+import { BaseDataEntity, RelationshipType } from '@exogee/graphweaver';
 
 export type Relationship<T> = {
 	entity: () => T;

--- a/src/packages/rest/src/entity-manager.ts
+++ b/src/packages/rest/src/entity-manager.ts
@@ -1,4 +1,5 @@
-import { BaseEntity, RelationshipMap, RelationshipType, Relationship } from './entities';
+import { RelationshipType } from '@exogee/graphweaver';
+import { BaseEntity, RelationshipMap, Relationship } from './entities';
 
 export interface EntityConstructor<T extends BaseEntity> {
 	new (_entity: any): T;

--- a/src/packages/scalars/package.json
+++ b/src/packages/scalars/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-scalars",
-	"version": "0.1.16",
+	"version": "0.1.17",
 	"description": "Common scalar types for use with @exogee/graphweaver",
 	"license": "MIT",
 	"main": "lib/index.js",

--- a/src/packages/vite-plugin-graphweaver/package.json
+++ b/src/packages/vite-plugin-graphweaver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vite-plugin-graphweaver",
-	"version": "0.1.16",
+	"version": "0.1.17",
 	"description": "A vite plugin for use with @exogee/graphweaver's admin UI",
 	"license": "MIT",
 	"main": "lib/index.js",

--- a/src/packages/xero/package.json
+++ b/src/packages/xero/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-xero",
-	"version": "0.1.16",
+	"version": "0.1.17",
 	"description": "Xero backend for @exogee/graphweaver",
 	"license": "MIT",
 	"scripts": {

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -414,9 +414,6 @@ importers:
       '@exogee/graphweaver':
         specifier: workspace:*
         version: link:../core
-      '@exogee/graphweaver-mikroorm':
-        specifier: workspace:*
-        version: link:../mikroorm
       '@exogee/logger':
         specifier: workspace:*
         version: link:../logger

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -645,6 +645,9 @@ importers:
 
   packages/mikroorm:
     dependencies:
+      '@apollo/server':
+        specifier: 4.2.2
+        version: 4.2.2(graphql@16.6.0)
       '@exogee/graphweaver':
         specifier: workspace:*
         version: link:../core
@@ -4136,7 +4139,7 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 18.11.11
+      '@types/node': 20.2.3
     dev: false
 
   /@types/bunyan@1.8.6:
@@ -4157,7 +4160,7 @@ packages:
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 18.11.11
+      '@types/node': 20.2.3
     dev: false
 
   /@types/estree@1.0.1:
@@ -4166,7 +4169,7 @@ packages:
   /@types/express-serve-static-core@4.17.35:
     resolution: {integrity: sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==}
     dependencies:
-      '@types/node': 18.11.11
+      '@types/node': 20.2.3
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
@@ -4269,7 +4272,7 @@ packages:
   /@types/node-fetch@2.6.4:
     resolution: {integrity: sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==}
     dependencies:
-      '@types/node': 18.11.11
+      '@types/node': 20.2.3
       form-data: 3.0.1
     dev: false
 
@@ -4285,7 +4288,6 @@ packages:
 
   /@types/node@20.2.3:
     resolution: {integrity: sha512-pg9d0yC4rVNWQzX8U7xb4olIOFuuVL9za3bzMT2pu2SU0SNEi66i2qrvhE2qt0HvkhuCaWJu7pLNOt/Pj8BIrw==}
-    dev: true
 
   /@types/parse-json@4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
@@ -4355,14 +4357,14 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 18.11.11
+      '@types/node': 20.2.3
     dev: false
 
   /@types/serve-static@1.15.1:
     resolution: {integrity: sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==}
     dependencies:
       '@types/mime': 3.0.1
-      '@types/node': 18.11.11
+      '@types/node': 20.2.3
     dev: false
 
   /@types/stack-utils@2.0.1:


### PR DESCRIPTION
Included in this PR:

- Remove `mikroOrmOptions` from GW config
- Remove Mikro dependency from apollo plugins (No longer need to include Mikro-core on non Mikro projects)
- Update CLI Create tool to move the database connections to a `database.ts` file
- Update examples to move the database connections to a `database.ts` file
- Bumped version to `0.1.17`
- Create Github Action to build CLI into a test folder and then make sure that this installs and starts