### PR TITLE
Custom login, async mikroOrmConfig, lambda invoke, bump to 0.1.22

### DIFF
--- a/src/examples/xero/package.json
+++ b/src/examples/xero/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-xero",
-	"version": "0.1.20",
+	"version": "0.2.0",
 	"license": "MIT",
 	"private": true,
 	"description": "Example of using @exogee/graphweaver to connect two Xero instances",

--- a/src/packages/admin-ui-components/@types/custom-pages.d.ts
+++ b/src/packages/admin-ui-components/@types/custom-pages.d.ts
@@ -1,5 +1,6 @@
 declare module 'virtual:graphweaver-user-supplied-custom-pages' {
 	import { RouteObject } from 'react-router-dom';
+	import type { LoginProps } from '@exogee/graphweaver-admin-ui-components';
 
 	export interface NavLinkExport {
 		name: string;
@@ -9,6 +10,7 @@ declare module 'virtual:graphweaver-user-supplied-custom-pages' {
 	export interface CustomPagesExport {
 		routes: () => RouteObject[] | Promise<RouteObject[]>;
 		navLinks: () => NavLinkExport[] | Promise<NavLinkExport[]>;
+		loginProps?: LoginProps;
 	}
 
 	export const customPages: CustomPagesExport;

--- a/src/packages/admin-ui-components/package.json
+++ b/src/packages/admin-ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-admin-ui-components",
-	"version": "0.1.20",
+	"version": "0.1.22",
 	"description": "Components from Graphweaver's admin UI which you can use in your projects as you like",
 	"license": "MIT",
 	"type": "module",

--- a/src/packages/admin-ui-components/src/login/component.tsx
+++ b/src/packages/admin-ui-components/src/login/component.tsx
@@ -1,51 +1,72 @@
 import { Field, Form, Formik, FormikHelpers } from 'formik';
 import { GraphweaverLogo } from '../assets';
 import { Button } from '../button';
-import { Input } from '../input';
 
 import styles from './styles.module.css';
 import { useMutation } from '@apollo/client';
 
 import { LOGIN_MUTATION } from './graphql';
 import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
 
-export const Login = () => {
+interface Form {
+	username: string;
+	password: string;
+}
+
+export interface LoginProps {
+	onLogin?(username: string, password: string): string; // Returns a token to place in Authorization header
+}
+
+export const Login = ({ onLogin }: LoginProps) => {
 	const navigate = useNavigate();
 	const [login] = useMutation<{ login: { authToken: string } }>(LOGIN_MUTATION);
+	const [error, setError] = useState<Error | undefined>();
 
-	const handleOnSubmit = async (values: any, actions: FormikHelpers<any>) => {
-		const res = await login({
-			variables: {
-				username: values.username,
-				password: values.password,
-			},
-		});
+	const handleOnSubmit = async (values: Form, { setSubmitting }: FormikHelpers<Form>) => {
+		let token;
 
-		actions.setSubmitting(false);
+		try {
+			if (onLogin) {
+				token = onLogin(values.username, values.password);
+			} else {
+				const { data } = await login({
+					variables: {
+						username: values.username,
+						password: values.password,
+					},
+				});
 
-		if (res?.data?.login.authToken) {
-			localStorage.setItem('graphweaver-auth', res.data.login.authToken);
-			navigate('/');
+				token = data?.login.authToken;
+				if (!token) throw new Error('Missing token');
+
+				localStorage.setItem('graphweaver-auth', token);
+				navigate('/');
+			}
+		} catch (error) {
+			setError(error instanceof Error ? error : new Error(String(error)));
+		} finally {
+			setSubmitting(false);
 		}
 	};
 
 	return (
-		<Formik initialValues={{ username: '', password: '' }} onSubmit={handleOnSubmit}>
+		<Formik<Form> initialValues={{ username: '', password: '' }} onSubmit={handleOnSubmit}>
 			{({ isSubmitting }) => (
 				<Form className={styles.wrapper}>
 					<GraphweaverLogo width="52" className={styles.logo} />
 					<div className={styles.titleContainer}>Login</div>
 					<Field
-						placeholder={'Username'}
-						id={'username'}
-						name={'username'}
+						placeholder="Username"
+						id="username"
+						name="username"
 						className={styles.textInputField}
 					/>
 					<Field
-						type={'password'}
-						placeholder={'Password'}
-						id={'password'}
-						name={'password'}
+						type="password"
+						placeholder="Password"
+						id="password"
+						name="password"
 						className={styles.textInputField}
 					/>
 					<div className={styles.buttonContainer}>
@@ -53,6 +74,11 @@ export const Login = () => {
 							Login
 						</Button>
 					</div>
+					{!!error && (
+						<div>
+							<b>Error: ${error.message}</b>
+						</div>
+					)}
 				</Form>
 			)}
 		</Formik>

--- a/src/packages/admin-ui-components/src/login/component.tsx
+++ b/src/packages/admin-ui-components/src/login/component.tsx
@@ -15,7 +15,7 @@ interface Form {
 }
 
 export interface LoginProps {
-	onLogin?(username: string, password: string): string; // Returns a token to place in Authorization header
+	onLogin?(username: string, password: string): string | Promise<string>; // Returns a token to place in Authorization header
 }
 
 export const Login = ({ onLogin }: LoginProps) => {
@@ -28,7 +28,7 @@ export const Login = ({ onLogin }: LoginProps) => {
 
 		try {
 			if (onLogin) {
-				token = onLogin(values.username, values.password);
+				token = await onLogin(values.username, values.password);
 			} else {
 				const { data } = await login({
 					variables: {

--- a/src/packages/admin-ui/@types/custom-pages.d.ts
+++ b/src/packages/admin-ui/@types/custom-pages.d.ts
@@ -1,5 +1,6 @@
 declare module 'virtual:graphweaver-user-supplied-custom-pages' {
 	import { RouteObject } from 'react-router-dom';
+	import type { LoginProps } from '@exogee/graphweaver-admin-ui-components';
 
 	export interface NavLinkExport {
 		name: string;
@@ -9,6 +10,7 @@ declare module 'virtual:graphweaver-user-supplied-custom-pages' {
 	export interface CustomPagesExport {
 		routes: () => RouteObject[] | Promise<RouteObject[]>;
 		navLinks: () => NavLinkExport[] | Promise<NavLinkExport[]>;
+		loginProps?: LoginProps;
 	}
 
 	export const customPages: CustomPagesExport;

--- a/src/packages/admin-ui/package.json
+++ b/src/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-admin-ui",
-	"version": "0.1.20",
+	"version": "0.1.22",
 	"type": "module",
 	"main": "dist/main.js",
 	"types": "src/main.tsx",

--- a/src/packages/admin-ui/src/pages/login/component.tsx
+++ b/src/packages/admin-ui/src/pages/login/component.tsx
@@ -1,12 +1,12 @@
-import { Login as LoginForm } from '@exogee/graphweaver-admin-ui-components';
+import { Login as LoginForm, LoginProps } from '@exogee/graphweaver-admin-ui-components';
 
 import styles from './styles.module.css';
 
-export const Login = () => {
+export const Login = (props: LoginProps) => {
 	return (
 		<div className={styles.wrapper}>
 			<div className={styles.container}>
-				<LoginForm />
+				<LoginForm {...props} />
 			</div>
 		</div>
 	);

--- a/src/packages/admin-ui/src/router.tsx
+++ b/src/packages/admin-ui/src/router.tsx
@@ -18,7 +18,7 @@ const defaultRoutes = [
 	},
 	{
 		path: '/login',
-		element: <Login />,
+		element: <Login {...(customPages?.loginProps ?? {})} />,
 	},
 	{
 		path: '/:entity',

--- a/src/packages/apollo/package.json
+++ b/src/packages/apollo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-apollo",
-	"version": "0.1.20",
+	"version": "0.1.22",
 	"description": "Apollo Server support for @exogee/graphweaver",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/auth/package.json
+++ b/src/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-auth",
-	"version": "0.1.20",
+	"version": "0.1.22",
 	"description": "Row-Level Security support for @exogee/graphweaver",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/auth/src/authentication/providers/local/plugin.ts
+++ b/src/packages/auth/src/authentication/providers/local/plugin.ts
@@ -9,9 +9,6 @@ import { ForbiddenError } from 'apollo-server-errors';
 import { AuthProvider } from '../../base-auth-token-provider';
 import { GraphQLError } from 'graphql';
 
-if (!process.env.LOCAL_AUTH_REDIRECT_URI)
-	throw new Error('LOCAL_AUTH_REDIRECT_URI is required in environment');
-
 const redirectUrl = process.env.LOCAL_AUTH_REDIRECT_URI;
 
 const didEncounterForbiddenError = (error: any) => {
@@ -20,78 +17,82 @@ const didEncounterForbiddenError = (error: any) => {
 
 export const localAuthApolloPlugin = (
 	addUserToContext: (userId: string) => Promise<UserProfile>
-): ApolloServerPlugin<AuthorizationContext> => ({
-	async requestDidStart({ request, contextValue }) {
-		logger.trace('LocalAuthApolloPlugin requestDidStart');
-		// We have two use cases this needs to handle:
-		// 1. No auth header, initial request for a guest operation.
-		//    - Some requests are allowed when accessed by a guest defined above.
-		// 2. There is an auth header
-		//    - In this situation we need to verify the token, error if it's not valid and redirect.
-		//
+): ApolloServerPlugin<AuthorizationContext> => {
+	if (!redirectUrl) throw new Error('LOCAL_AUTH_REDIRECT_URI is required in environment');
 
-		// We may need to return a redirect to the client. If so, we'll set this variable.
-		const authHeader = request.http?.headers.get('authorization');
-		// If verification fails then set this flag
-		let tokenVerificationFailed = false;
+	return {
+		async requestDidStart({ request, contextValue }) {
+			logger.trace('LocalAuthApolloPlugin requestDidStart');
+			// We have two use cases this needs to handle:
+			// 1. No auth header, initial request for a guest operation.
+			//    - Some requests are allowed when accessed by a guest defined above.
+			// 2. There is an auth header
+			//    - In this situation we need to verify the token, error if it's not valid and redirect.
+			//
 
-		// Case 1. No auth header, initial request for a guest operation.
-		if (!authHeader) {
-			logger.trace('No Auth header, setting redirect');
+			// We may need to return a redirect to the client. If so, we'll set this variable.
+			const authHeader = request.http?.headers.get('authorization');
+			// If verification fails then set this flag
+			let tokenVerificationFailed = false;
 
-			// We are a guest and have not logged in yet.
-			contextValue.user = new UserProfile({
-				id: undefined,
-				roles: ['GUEST'],
-				provider: AuthProvider.LOCAL,
-			});
-			upsertAuthorizationContext(contextValue);
-		} else {
-			// Case 2. There is an auth header
-			logger.trace('Got a token, checking it is valid.');
+			// Case 1. No auth header, initial request for a guest operation.
+			if (!authHeader) {
+				logger.trace('No Auth header, setting redirect');
 
-			const tokenProvider = new LocalAuthTokenProvider();
-
-			try {
-				const decoded = await tokenProvider.decodeToken(authHeader);
-
-				const userId = typeof decoded === 'object' ? decoded?.id : undefined;
-				const userProfile = await addUserToContext(userId);
-
-				contextValue.token = decoded;
-				contextValue.user = userProfile;
-
+				// We are a guest and have not logged in yet.
+				contextValue.user = new UserProfile({
+					id: undefined,
+					roles: ['GUEST'],
+					provider: AuthProvider.LOCAL,
+				});
 				upsertAuthorizationContext(contextValue);
-			} catch (err: unknown) {
-				logger.trace(`JWT verification failed. ${err}`);
-				tokenVerificationFailed = true;
-			}
-		}
+			} else {
+				// Case 2. There is an auth header
+				logger.trace('Got a token, checking it is valid.');
 
-		return {
-			willSendResponse: async ({ response, contextValue }) => {
-				// Let's check if we are a guest and have received a forbidden error
-				if (
-					contextValue.user?.roles?.includes('GUEST') &&
-					response &&
-					(response.body as any)?.singleResult?.errors
-				) {
-					const didEncounterForbiddenErrors = (response.body as any)?.singleResult?.errors.some(
-						didEncounterForbiddenError
-					);
-					//If we received a forbidden error we need to redirect, set the header to tell the client to do so.
-					if (didEncounterForbiddenErrors) {
-						logger.trace('Forbidden Error Found: setting X-Auth-Redirect header.');
+				const tokenProvider = new LocalAuthTokenProvider();
+
+				try {
+					const decoded = await tokenProvider.decodeToken(authHeader);
+
+					const userId = typeof decoded === 'object' ? decoded?.id : undefined;
+					const userProfile = await addUserToContext(userId);
+
+					contextValue.token = decoded;
+					contextValue.user = userProfile;
+
+					upsertAuthorizationContext(contextValue);
+				} catch (err: unknown) {
+					logger.trace(`JWT verification failed. ${err}`);
+					tokenVerificationFailed = true;
+				}
+			}
+
+			return {
+				willSendResponse: async ({ response, contextValue }) => {
+					// Let's check if we are a guest and have received a forbidden error
+					if (
+						contextValue.user?.roles?.includes('GUEST') &&
+						response &&
+						(response.body as any)?.singleResult?.errors
+					) {
+						const didEncounterForbiddenErrors = (response.body as any)?.singleResult?.errors.some(
+							didEncounterForbiddenError
+						);
+						//If we received a forbidden error we need to redirect, set the header to tell the client to do so.
+						if (didEncounterForbiddenErrors) {
+							logger.trace('Forbidden Error Found: setting X-Auth-Redirect header.');
+							response.http?.headers.set('X-Auth-Redirect', redirectUrl);
+						}
+					}
+
+					// Let's check if verification has failed and redirect to login if it has
+					if (tokenVerificationFailed) {
+						logger.trace('JWT verification failed: setting X-Auth-Redirect header.');
 						response.http?.headers.set('X-Auth-Redirect', redirectUrl);
 					}
-				}
-
-				// Let's check if verification has failed and redirect to login if it has
-				if (tokenVerificationFailed) {
-					logger.trace('JWT verification failed: setting X-Auth-Redirect header.');
-					response.http?.headers.set('X-Auth-Redirect', redirectUrl);
-				}
-			},
-		};
-	},
-});
+				},
+			};
+		},
+	};
+};

--- a/src/packages/auth/src/authentication/providers/local/provider.ts
+++ b/src/packages/auth/src/authentication/providers/local/provider.ts
@@ -4,9 +4,6 @@ import { BaseAuthTokenProvider } from '../../base-auth-token-provider';
 import { AuthToken } from '../../schema/token';
 import { UserProfile } from '../../../user-profile';
 
-if (!process.env.LOCAL_AUTH_JWT_SECRET)
-	throw new Error('LOCAL_AUTH_JWT_SECRET is required in environment');
-
 const secret = process.env.LOCAL_AUTH_JWT_SECRET;
 const expiresIn = process.env.LOCAL_AUTH_JWT_EXPIRES_IN ?? '8h';
 
@@ -25,12 +22,14 @@ const TOKEN_PREFIX = 'Bearer';
 
 export class LocalAuthTokenProvider implements BaseAuthTokenProvider {
 	async generateToken(user: UserProfile) {
+		if (!secret) throw new Error('LOCAL_AUTH_JWT_SECRET is required in environment');
 		// @todo Currently, using HMAC SHA256 look to support RSA SHA256
 		const authToken = jwt.sign({ id: user.id }, secret, { expiresIn });
 		const token = new AuthToken(`${TOKEN_PREFIX} ${authToken}`);
 		return token;
 	}
 	async decodeToken(authToken: string) {
+		if (!secret) throw new Error('LOCAL_AUTH_JWT_SECRET is required in environment');
 		const token = removeAuthPrefixIfPresent(authToken);
 		return jwt.verify(token, secret);
 	}

--- a/src/packages/builder/package.json
+++ b/src/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-builder",
-	"version": "0.1.20",
+	"version": "0.1.22",
 	"description": "A tool for building and running GraphWeaver projects",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/builder/src/start/backend.ts
+++ b/src/packages/builder/src/start/backend.ts
@@ -157,7 +157,7 @@ export const startBackend = async ({ host, port }: BackendStartOptions) => {
 					},
 				},
 				getAllFunctions: () => Object.keys(backendFunctions),
-				getFunction: (key: string) => backendFunctions[key],
+				getFunction: (key: string) => ({ ...backendFunctions[key], name: key }),
 				getAllEventsInFunction: (key: string) => backendFunctions[key].events,
 			},
 		}),

--- a/src/packages/cli/package.json
+++ b/src/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "graphweaver",
-	"version": "0.1.20",
+	"version": "0.1.22",
 	"description": "A tool for managing, running, debugging and building Graphweaver projects",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/config/package.json
+++ b/src/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-config",
-	"version": "0.1.17",
+	"version": "0.1.22",
 	"description": "Retrieve and parse Graphweaver configurations",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver",
-	"version": "0.1.20",
+	"version": "0.1.22",
 	"description": "Graphweaver Core Package",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/logger/package.json
+++ b/src/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/logger",
-	"version": "0.1.20",
+	"version": "0.1.22",
 	"description": "Common logging output for Exogee projects",
 	"license": "MIT",
 	"directories": {

--- a/src/packages/mikroorm/package.json
+++ b/src/packages/mikroorm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-mikroorm",
-	"version": "0.1.20",
+	"version": "0.1.22",
 	"description": "MikroORM backend for @exogee/graphweaver",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/rest/package.json
+++ b/src/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-rest",
-	"version": "0.1.20",
+	"version": "0.1.22",
 	"description": "RESTful backend for @exogee/graphweaver",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/scalars/package.json
+++ b/src/packages/scalars/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-scalars",
-	"version": "0.1.20",
+	"version": "0.1.22",
 	"description": "Common scalar types for use with @exogee/graphweaver",
 	"license": "MIT",
 	"main": "lib/index.js",

--- a/src/packages/vite-plugin-graphweaver/package.json
+++ b/src/packages/vite-plugin-graphweaver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vite-plugin-graphweaver",
-	"version": "0.1.20",
+	"version": "0.1.22",
 	"description": "A vite plugin for use with @exogee/graphweaver's admin UI",
 	"license": "MIT",
 	"main": "lib/index.js",

--- a/src/packages/xero/package.json
+++ b/src/packages/xero/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-xero",
-	"version": "0.1.20",
+	"version": "0.1.22",
 	"description": "Xero backend for @exogee/graphweaver",
 	"license": "MIT",
 	"scripts": {


### PR DESCRIPTION
- Adds a new `loginProps` export to custom-pages which allows to set the props of the Login route-
- Add an `onLogin` prop to the Login route and component, if provided, will not use the built-in mutation, and will instead pass the username and password to the custom function, and use the return string as the token`
- Check JWT_ variables for auth when used instead of at import time
- Add `name` prop to severless lambda function items so that they can be invoked externally
- Allow `mikroOrmConfig` to be a function to allow awaiting a config using AWS Secrets Manager