### PR TITLE
Run `onResolve` hook in builder/build when building backend/index

### DIFF
--- a/src/packages/builder/src/build/backend.ts
+++ b/src/packages/builder/src/build/backend.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { build, buildSync } from 'esbuild';
+import { build } from 'esbuild';
 import rimrafCallback from 'rimraf';
 import { promisify } from 'util';
 import { AdditionalFunctionOptions, config } from '@exogee/graphweaver-config';
@@ -23,16 +23,20 @@ export const buildBackend = async (_: BackendBuildOptions) => {
 	// Clear the folder
 	await rimraf(path.join('.graphweaver', 'backend'));
 
+	const { onResolveEsbuildConfiguration } = config().build;
+
 	// Put the index.js file in there.
-	await build({
-		...baseEsbuildConfig,
+	await build(
+		onResolveEsbuildConfiguration({
+			...baseEsbuildConfig,
 
-		// Anything in node_modules should be marked as external for running.
-		plugins: [makeAllPackagesExternalPlugin(), CssModulesPlugin()],
+			// Anything in node_modules should be marked as external for running.
+			plugins: [makeAllPackagesExternalPlugin(), CssModulesPlugin()],
 
-		entryPoints: ['./src/backend/index.ts'],
-		outfile: '.graphweaver/backend/index.js',
-	});
+			entryPoints: ['./src/backend/index.ts'],
+			outfile: '.graphweaver/backend/index.js',
+		})
+	);
 
 	// Are there any custom additional functions we need to build?
 	// If so, merge them in.
@@ -46,7 +50,6 @@ export const buildBackend = async (_: BackendBuildOptions) => {
 	];
 
 	const { additionalFunctions } = config().backend;
-	const { onResolveEsbuildConfiguration } = config().build;
 	functions.push(...additionalFunctions);
 
 	for (const backendFunction of functions) {
@@ -74,45 +77,6 @@ export const buildBackend = async (_: BackendBuildOptions) => {
 
 	console.log();
 	console.log('Finished!');
-
-	// Note, this will leave the ESBuild service process around:
-	// https://github.com/evanw/esbuild/issues/985
-	// console.log('Handles: ', (process as any)._getActiveHandles());
-	//
-	// We'll kill it with a process.exit(0) out in the main file when we know we're done.
-};
-
-export const buildBackendSync = (_: BackendBuildOptions) => {
-	// Clear the folder
-	rimrafCallback.sync(path.join('.graphweaver', 'backend'));
-
-	// Are there any custom additional functions we need to build?
-	// If so, merge them in.
-	// eslint-disable-next-line @typescript-eslint/no-var-requires
-	const { backend } = require(path.join(process.cwd(), 'graphweaver-config'));
-
-	const functions: AdditionalFunctionOptions[] = [
-		{
-			handlerPath: './src/backend/index',
-		},
-		...backend.additionalFunctions,
-	];
-
-	if (Array.isArray(backend.additionalFunctions)) {
-		for (const backendFunction of functions) {
-			// TODO: Better validation
-			if (backendFunction.handlerPath) {
-				buildSync({
-					...baseEsbuildConfig,
-
-					plugins: [makeOptionalMikroOrmPackagesExternalPlugin()],
-
-					entryPoints: [inputPathFor(backendFunction.handlerPath)],
-					outfile: `${buildOutputPathFor(backendFunction.handlerPath)}.js`,
-				});
-			}
-		}
-	}
 
 	// Note, this will leave the ESBuild service process around:
 	// https://github.com/evanw/esbuild/issues/985


### PR DESCRIPTION
- Make sure that the onResolveEsbuildConfiguration runs on the index at build time
- Remove the sync version of build as it looks like orphaned code