### PR TITLE
Fix/missing deps

### DIFF
--- a/src/packages/cli/src/import/index.ts
+++ b/src/packages/cli/src/import/index.ts
@@ -2,6 +2,7 @@ import { introspection } from '@exogee/graphweaver-mikroorm';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import ora from 'ora';
 import path from 'path';
+import { GRAPHWEAVER_TARGET_VERSION, MIKRO_ORM_TARGET_VERSION } from '../init/constants';
 
 const createDirectories = (dirPath: string) => {
 	const directories = dirPath.split(path.sep);
@@ -26,10 +27,44 @@ export const isIntrospectionError = (
 	);
 };
 
+const checkForMissingDependencies = async (source: 'mysql' | 'postgresql' | 'sqlite') => {
+	// We want to read the package.json of gw app so we can ignore this error
+	// eslint-disable-next-line @typescript-eslint/no-var-requires
+	const packageJson = require(path.join(process.cwd(), 'package.json'));
+	const dependencies = Object.keys(packageJson.dependencies ?? {});
+
+	// These dependencies are required to run the
+	const requiredDependencies = [
+		'@exogee/graphweaver-mikroorm',
+		'@mikro-orm/core',
+		`@mikro-orm/${source}`,
+	];
+
+	const missingDependencies: string[] = [];
+
+	requiredDependencies.forEach((dependency) => {
+		if (!dependencies.includes(dependency)) {
+			missingDependencies.push(
+				`${dependency}@${
+					dependency.includes('@mikro-orm/') ? MIKRO_ORM_TARGET_VERSION : GRAPHWEAVER_TARGET_VERSION
+				}`
+			);
+		}
+	});
+
+	if (missingDependencies.length > 0) {
+		console.warn(`\n\nPlease install these missing dependencies and try again:\n`);
+		console.warn(`\t\t pnpm i ${missingDependencies.join(' ')}\n\n`);
+		process.exit();
+	}
+};
+
 export const importDataSource = async (
 	source: 'mysql' | 'postgresql' | 'sqlite',
 	database?: string
 ) => {
+	await checkForMissingDependencies(source);
+
 	const { default: inquirer } = await import('inquirer');
 	const { host, dbName, user, password, port } =
 		source === 'sqlite'

--- a/src/packages/cli/src/init/index.ts
+++ b/src/packages/cli/src/init/index.ts
@@ -83,6 +83,13 @@ export const init = async ({ version, name, backend }: InitOptions) => {
 						name: 'REST Backend',
 					},
 				],
+				validate(answer) {
+					if (answer.length < 1) {
+						return 'You must select at least one backend (Press <space> to select).';
+					}
+
+					return true;
+				},
 			},
 			{
 				type: 'confirm',


### PR DESCRIPTION
This PR does two things to ensure that the dependencies are added.

1. The first is that we check that at least one data source is selected when running `graphweaver init`
2. The second is that we check the dependencies are installed before running `graphweaver import`