### PR TITLE
Fixed start frontend by skipping code generator

### DIFF
--- a/src/packages/builder/src/start/frontend.ts
+++ b/src/packages/builder/src/start/frontend.ts
@@ -11,9 +11,11 @@ export interface StartOptions {
 
 let server: ViteDevServer | undefined = undefined;
 
-export const startFrontend = async ({ host, port }: StartOptions) => {
+export const startFrontend = async ({ host, port }: StartOptions, codeGen = false) => {
 	// We can now generate the front end functions and types
-	await codeGenerator();
+	if (codeGen) {
+		await codeGenerator();
+	}
 
 	// Let's check if we need to start the server
 	if (!server) {

--- a/src/packages/cli/src/index.ts
+++ b/src/packages/cli/src/index.ts
@@ -225,7 +225,7 @@ yargs
 			if (environment === 'frontend' || environment === 'all') {
 				// Logic to start the process
 				console.log('Watch process started...');
-				await startFrontend(args as StartOptions);
+				await startFrontend(args as StartOptions, true);
 
 				// Watch the directory for file changes
 				const watcher = chokidar.watch('./src/**', {
@@ -235,7 +235,7 @@ yargs
 				// Restart the process on file change
 				watcher.on('change', async () => {
 					console.log('File changed. Restarting the process...');
-					await startFrontend(args as StartOptions);
+					await startFrontend(args as StartOptions, true);
 				});
 			}
 		},


### PR DESCRIPTION
Steps to reproduce:
1. Run `graphweaver start frontend` without backend already running
2. Error displayed.

Fixed by executing codeGenerator only when `watch` command. `start` command will ignore the codeGenerator.