### PR TITLE
Fixed RelationshipField issue where field name is not same as the entity it is relating to

### DIFF
--- a/src/packages/core/src/decorators/relationship-field.ts
+++ b/src/packages/core/src/decorators/relationship-field.ts
@@ -47,8 +47,9 @@ export function RelationshipField<
 			returnTypeFunc,
 			typeOptions: { nullable },
 		});
-		const typeName = key.charAt(0).toUpperCase() + key.slice(1);
 		const getRelatedType = () => {
+			const relatedEntityType = getType() as GraphQLEntityConstructor<G, D>;
+			const typeName = relatedEntityType.name;
 			return TypeMap[`${pluralize(typeName)}ListFilter`];
 		};
 

--- a/src/packages/end-to-end/package.json
+++ b/src/packages/end-to-end/package.json
@@ -17,6 +17,19 @@
 		"test-mysql": "export DATEBASE=mysql && jest --runInBand -- api/mysql",
 		"version": "npm version --no-git-tag-version"
 	},
+	"dependencies": {
+		"@exogee/graphweaver": "*",
+		"@exogee/graphweaver-scalars": "*",
+		"@exogee/graphweaver-server": "*",
+		"graphweaver": "*",
+		"@exogee/graphweaver-mikroorm": "*",
+		"@mikro-orm/core": "5.4.2",
+		"@mikro-orm/sqlite": "5.4.2",
+		"reflect-metadata": "0.1.13",
+		"type-graphql": "2.0.0-beta.2",
+		"class-validator": "0.14.0",
+		"graphql": "16.6.0"
+	},
 	"devDependencies": {
 		"@types/jest": "26.0.23",
 		"graphql": "16.6.0",

--- a/src/packages/end-to-end/package.json
+++ b/src/packages/end-to-end/package.json
@@ -12,7 +12,7 @@
 		"dev-sqlite": "pnpm import-database-sqlite && pnpm start-server",
 		"dev-postgres": "createdb gw && pnpm seed-postgres && pnpm import-database-postgres  && pnpm start-server",
 		"dev-mysql": "pnpm import-database-mysql && pnpm start-server",
-		"test-sqlite": "export DATABASE=sqlite && jest --runInBand -- api/sqlite",
+		"test-sqlite": "export DATABASE=sqlite && jest --runInBand --forceExit ---- api/sqlite",
 		"test-postgres": "export DATABASE=postgres && jest --runInBand -- api/postgres",
 		"test-mysql": "export DATEBASE=mysql && jest --runInBand -- api/mysql",
 		"version": "npm version --no-git-tag-version"

--- a/src/packages/end-to-end/src/__tests__/api/sqlite/issues/gh146.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/sqlite/issues/gh146.test.ts
@@ -95,14 +95,6 @@ class ArtistResolver extends createBaseResolver<Artist, OrmArtist>(
 describe('RelationshipField', () => {
 	beforeEach(resetDatabase);
 
-	afterAll((done) => {
-		for (const connection of ConnectionManager.getConnections()) {
-			connection.em.clear();
-			connection.close();
-		}
-		done();
-	});
-
 	test('should not get error on buildSchema when relationship field name is not same as entity', async () => {
 		const graphweaver = new Graphweaver({
 			resolvers: [AlbumResolver, ArtistResolver],

--- a/src/packages/end-to-end/src/__tests__/api/sqlite/issues/gh146.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/sqlite/issues/gh146.test.ts
@@ -19,7 +19,7 @@ import {
 	RelationshipField,
 	Resolver,
 } from '@exogee/graphweaver';
-import { BaseEntity, MikroBackendProvider } from '@exogee/graphweaver-mikroorm';
+import { BaseEntity, MikroBackendProvider, ConnectionManager } from '@exogee/graphweaver-mikroorm';
 
 import { resetDatabase } from '../../../../utils';
 

--- a/src/packages/end-to-end/src/__tests__/api/sqlite/issues/gh146.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/sqlite/issues/gh146.test.ts
@@ -95,6 +95,14 @@ class ArtistResolver extends createBaseResolver<Artist, OrmArtist>(
 describe('RelationshipField', () => {
 	beforeEach(resetDatabase);
 
+	afterAll((done) => {
+		for (const connection of ConnectionManager.getConnections()) {
+			connection.em.clear();
+			connection.close();
+		}
+		done();
+	});
+
 	test('should not get error on buildSchema when relationship field name is not same as entity', async () => {
 		const graphweaver = new Graphweaver({
 			resolvers: [AlbumResolver, ArtistResolver],

--- a/src/packages/end-to-end/src/__tests__/api/sqlite/query/relationship-field.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/sqlite/query/relationship-field.test.ts
@@ -1,0 +1,115 @@
+import 'reflect-metadata';
+import gql from 'graphql-tag';
+import assert from 'assert';
+import Graphweaver from '@exogee/graphweaver-server';
+import {
+	Entity,
+	Collection,
+	IdentifiedReference,
+	ManyToOne,
+	OneToMany,
+	PrimaryKey,
+} from '@mikro-orm/core';
+import {
+	createBaseResolver,
+	Field,
+	GraphQLEntity,
+	ID,
+	ObjectType,
+	RelationshipField,
+	Resolver,
+} from '@exogee/graphweaver';
+import { BaseEntity, MikroBackendProvider } from '@exogee/graphweaver-mikroorm';
+
+import { resetDatabase } from '../../../../utils';
+
+import { SqliteDriver } from '@mikro-orm/sqlite';
+
+/** Setup entities and resolvers  */
+@Entity({ tableName: 'Album' })
+class OrmAlbum extends BaseEntity {
+	@PrimaryKey({ fieldName: 'AlbumId', type: 'number' })
+	id!: number;
+
+	@ManyToOne({
+		entity: () => OrmArtist,
+		wrappedReference: true,
+		fieldName: 'ArtistId',
+		index: 'IFK_AlbumArtistId',
+	})
+	artist!: IdentifiedReference<OrmArtist>;
+}
+
+@Entity({ tableName: 'Artist' })
+class OrmArtist extends BaseEntity {
+	@PrimaryKey({ fieldName: 'ArtistId', type: 'number' })
+	id!: number;
+
+	@OneToMany({ entity: () => OrmAlbum, mappedBy: 'artist' })
+	albums = new Collection<OrmAlbum>(this);
+}
+
+@ObjectType('Album')
+export class Album extends GraphQLEntity<OrmAlbum> {
+	public dataEntity!: OrmAlbum;
+
+	@Field(() => ID)
+	id!: number;
+
+	@RelationshipField<Album>(() => Artist, { id: (entity) => entity.artist?.id })
+	renamed_artist!: Artist;
+}
+
+@ObjectType('Artist')
+export class Artist extends GraphQLEntity<OrmArtist> {
+	public dataEntity!: OrmArtist;
+
+	@Field(() => ID)
+	id!: number;
+
+	@RelationshipField<Album>(() => [Album], { relatedField: 'artist' })
+	renamed_albums!: Album[];
+}
+
+const connection = {
+	connectionManagerId: 'sqlite',
+	mikroOrmConfig: {
+		entities: [OrmAlbum, OrmArtist],
+		driver: SqliteDriver,
+		dbName: 'databases/database.sqlite',
+	},
+};
+
+@Resolver((of) => Album)
+class AlbumResolver extends createBaseResolver<Album, OrmAlbum>(
+	Album,
+	new MikroBackendProvider(OrmAlbum, connection)
+) {}
+
+@Resolver((of) => Artist)
+class ArtistResolver extends createBaseResolver<Artist, OrmArtist>(
+	Artist,
+	new MikroBackendProvider(OrmArtist, connection)
+) {}
+
+describe('RelationshipField', () => {
+	beforeEach(resetDatabase);
+
+	test('should not get error on buildSchema when relationship field name is not same as entity', async () => {
+		const graphweaver = new Graphweaver({
+			resolvers: [AlbumResolver, ArtistResolver],
+		});
+
+		const response = await graphweaver.server.executeOperation({
+			query: gql`
+				query {
+					albums {
+						id
+					}
+				}
+			`,
+		});
+		assert(response.body.kind === 'single');
+		expect(response.body.singleResult.data?.albums).toHaveLength(347);
+	});
+});

--- a/src/packages/end-to-end/tsconfig.json
+++ b/src/packages/end-to-end/tsconfig.json
@@ -14,7 +14,7 @@
     "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    "experimentalDecorators": true,                      /* Enable experimental support for legacy experimental decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
     // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
     // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -665,13 +665,44 @@ importers:
         version: 5.0.2
 
   packages/end-to-end:
+    dependencies:
+      '@exogee/graphweaver':
+        specifier: '*'
+        version: link:../core
+      '@exogee/graphweaver-mikroorm':
+        specifier: '*'
+        version: link:../mikroorm
+      '@exogee/graphweaver-scalars':
+        specifier: '*'
+        version: link:../scalars
+      '@exogee/graphweaver-server':
+        specifier: '*'
+        version: link:../server
+      '@mikro-orm/core':
+        specifier: 5.4.2
+        version: 5.4.2(@mikro-orm/sqlite@5.4.2)
+      '@mikro-orm/sqlite':
+        specifier: 5.4.2
+        version: 5.4.2(@mikro-orm/core@5.4.2)(pg@8.11.1)
+      class-validator:
+        specifier: 0.14.0
+        version: 0.14.0
+      graphql:
+        specifier: 16.6.0
+        version: 16.6.0
+      graphweaver:
+        specifier: '*'
+        version: link:../cli
+      reflect-metadata:
+        specifier: 0.1.13
+        version: 0.1.13
+      type-graphql:
+        specifier: 2.0.0-beta.2
+        version: 2.0.0-beta.2(class-validator@0.14.0)(graphql@16.6.0)
     devDependencies:
       '@types/jest':
         specifier: 26.0.23
         version: 26.0.23
-      graphql:
-        specifier: 16.6.0
-        version: 16.6.0
       graphql-tag:
         specifier: 2.12.6
         version: 2.12.6(graphql@16.6.0)
@@ -2627,6 +2658,7 @@ packages:
 
   /@gar/promisify@1.1.3:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
+    requiresBuild: true
     optional: true
 
   /@graphiql/react@0.17.6(@codemirror/language@6.0.0)(@types/react@18.0.25)(graphql@16.6.0)(react-dom@18.2.0)(react-is@17.0.2)(react@18.2.0):
@@ -4156,6 +4188,52 @@ packages:
       mikro-orm: 5.4.2
       reflect-metadata: 0.1.13
 
+  /@mikro-orm/core@5.4.2(@mikro-orm/sqlite@5.4.2):
+    resolution: {integrity: sha512-4JZfkUQNSvLh2RKNPl+2qy3RXmWdWOy8e++Owsb2qzmsL0T6CjIOz2kd+yPqZVvFH+unF5R1eQit/xnP3biM+A==}
+    engines: {node: '>= 14.0.0'}
+    peerDependencies:
+      '@mikro-orm/better-sqlite': ^5.0.0
+      '@mikro-orm/entity-generator': ^5.0.0
+      '@mikro-orm/mariadb': ^5.0.0
+      '@mikro-orm/migrations': ^5.0.0
+      '@mikro-orm/migrations-mongodb': ^5.0.0
+      '@mikro-orm/mongodb': ^5.0.0
+      '@mikro-orm/mysql': ^5.0.0
+      '@mikro-orm/postgresql': ^5.0.0
+      '@mikro-orm/seeder': ^5.0.0
+      '@mikro-orm/sqlite': ^5.0.0
+    peerDependenciesMeta:
+      '@mikro-orm/better-sqlite':
+        optional: true
+      '@mikro-orm/entity-generator':
+        optional: true
+      '@mikro-orm/mariadb':
+        optional: true
+      '@mikro-orm/migrations':
+        optional: true
+      '@mikro-orm/migrations-mongodb':
+        optional: true
+      '@mikro-orm/mongodb':
+        optional: true
+      '@mikro-orm/mysql':
+        optional: true
+      '@mikro-orm/postgresql':
+        optional: true
+      '@mikro-orm/seeder':
+        optional: true
+      '@mikro-orm/sqlite':
+        optional: true
+    dependencies:
+      '@mikro-orm/sqlite': 5.4.2(@mikro-orm/core@5.4.2)(pg@8.11.1)
+      acorn-loose: 8.3.0
+      acorn-walk: 8.2.0
+      dotenv: 16.0.2
+      fs-extra: 10.1.0
+      globby: 11.0.4
+      mikro-orm: 5.4.2
+      reflect-metadata: 0.1.13
+    dev: false
+
   /@mikro-orm/knex@5.4.2(@mikro-orm/core@5.4.2)(mysql2@2.3.3):
     resolution: {integrity: sha512-KOasr9arBAwIyv+MkczA43uS0yu0HoC1axzqwgC1ua+Sw4xMtzospPxeWQyjA2qjqkPnkSST7Wya+CS0NZmc2g==}
     engines: {node: '>= 14.0.0'}
@@ -4239,6 +4317,49 @@ packages:
       - pg-native
       - supports-color
       - tedious
+
+  /@mikro-orm/knex@5.4.2(@mikro-orm/core@5.4.2)(pg@8.11.1)(sqlite3@5.0.11):
+    resolution: {integrity: sha512-KOasr9arBAwIyv+MkczA43uS0yu0HoC1axzqwgC1ua+Sw4xMtzospPxeWQyjA2qjqkPnkSST7Wya+CS0NZmc2g==}
+    engines: {node: '>= 14.0.0'}
+    peerDependencies:
+      '@mikro-orm/core': ^5.0.0
+      '@mikro-orm/entity-generator': ^5.0.0
+      '@mikro-orm/migrations': ^5.0.0
+      better-sqlite3: ^7.0.0
+      mssql: ^7.0.0
+      mysql: ^2.18.1
+      mysql2: ^2.1.0
+      pg: ^8.0.3
+      sqlite3: ^5.0.0
+    peerDependenciesMeta:
+      '@mikro-orm/entity-generator':
+        optional: true
+      '@mikro-orm/migrations':
+        optional: true
+      better-sqlite3:
+        optional: true
+      mssql:
+        optional: true
+      mysql:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      sqlite3:
+        optional: true
+    dependencies:
+      '@mikro-orm/core': 5.4.2(@mikro-orm/sqlite@5.4.2)
+      fs-extra: 10.1.0
+      knex: 2.3.0(pg@8.11.1)(sqlite3@5.0.11)
+      pg: 8.11.1
+      sqlite3: 5.0.11
+      sqlstring: 2.3.3
+    transitivePeerDependencies:
+      - pg-native
+      - supports-color
+      - tedious
+    dev: false
 
   /@mikro-orm/knex@5.4.2(@mikro-orm/core@5.4.2)(pg@8.8.0)(sqlite3@5.0.11):
     resolution: {integrity: sha512-KOasr9arBAwIyv+MkczA43uS0yu0HoC1axzqwgC1ua+Sw4xMtzospPxeWQyjA2qjqkPnkSST7Wya+CS0NZmc2g==}
@@ -4369,6 +4490,40 @@ packages:
       - sqlite3
       - supports-color
       - tedious
+
+  /@mikro-orm/sqlite@5.4.2(@mikro-orm/core@5.4.2)(pg@8.11.1):
+    resolution: {integrity: sha512-fXlYv/XzslTyVpFKryFASfa/ci6848jz56YrADliA9yNFTeYIhj/z5K1+BLRXcqd/Ei4mFFaeloo2U6cGfRMhQ==}
+    engines: {node: '>= 14.0.0'}
+    peerDependencies:
+      '@mikro-orm/core': ^5.0.0
+      '@mikro-orm/entity-generator': ^5.0.0
+      '@mikro-orm/migrations': ^5.0.0
+      '@mikro-orm/seeder': ^5.0.0
+    peerDependenciesMeta:
+      '@mikro-orm/entity-generator':
+        optional: true
+      '@mikro-orm/migrations':
+        optional: true
+      '@mikro-orm/seeder':
+        optional: true
+    dependencies:
+      '@mikro-orm/core': 5.4.2(@mikro-orm/sqlite@5.4.2)
+      '@mikro-orm/knex': 5.4.2(@mikro-orm/core@5.4.2)(pg@8.11.1)(sqlite3@5.0.11)
+      fs-extra: 10.1.0
+      sqlite3: 5.0.11
+      sqlstring-sqlite: 0.1.1
+    transitivePeerDependencies:
+      - better-sqlite3
+      - bluebird
+      - encoding
+      - mssql
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - supports-color
+      - tedious
+    dev: false
 
   /@mikro-orm/sqlite@5.4.2(@mikro-orm/core@5.4.2)(pg@8.8.0):
     resolution: {integrity: sha512-fXlYv/XzslTyVpFKryFASfa/ci6848jz56YrADliA9yNFTeYIhj/z5K1+BLRXcqd/Ei4mFFaeloo2U6cGfRMhQ==}
@@ -4600,6 +4755,7 @@ packages:
 
   /@npmcli/fs@1.1.1:
     resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
+    requiresBuild: true
     dependencies:
       '@gar/promisify': 1.1.3
       semver: 7.5.4
@@ -4609,6 +4765,7 @@ packages:
     resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
     engines: {node: '>=10'}
     deprecated: This functionality has been moved to @npmcli/fs
+    requiresBuild: true
     dependencies:
       mkdirp: 1.0.4
       rimraf: 3.0.2
@@ -5845,6 +6002,7 @@ packages:
   /@tootallnate/once@1.1.2:
     resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
     engines: {node: '>= 6'}
+    requiresBuild: true
     optional: true
 
   /@tsconfig/node10@1.0.9:
@@ -6424,6 +6582,7 @@ packages:
 
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+    requiresBuild: true
 
   /accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -6481,6 +6640,7 @@ packages:
   /agentkeepalive@4.3.0:
     resolution: {integrity: sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==}
     engines: {node: '>= 8.0.0'}
+    requiresBuild: true
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       depd: 2.0.0
@@ -6640,6 +6800,7 @@ packages:
   /are-we-there-yet@3.0.1:
     resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    requiresBuild: true
     dependencies:
       delegates: 1.0.0
       readable-stream: 3.6.2
@@ -7129,6 +7290,7 @@ packages:
   /cacache@15.3.0:
     resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
     engines: {node: '>= 10'}
+    requiresBuild: true
     dependencies:
       '@npmcli/fs': 1.1.1
       '@npmcli/move-file': 1.1.2
@@ -8181,10 +8343,12 @@ packages:
   /env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+    requiresBuild: true
     optional: true
 
   /err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
+    requiresBuild: true
     optional: true
 
   /error-ex@1.3.2:
@@ -9346,6 +9510,7 @@ packages:
   /gauge@4.0.4:
     resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    requiresBuild: true
     dependencies:
       aproba: 2.0.0
       color-support: 1.1.3
@@ -9448,6 +9613,7 @@ packages:
 
   /glob@6.0.4:
     resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
+    requiresBuild: true
     dependencies:
       inflight: 1.0.6
       inherits: 2.0.4
@@ -9776,6 +9942,7 @@ packages:
   /http-proxy-agent@4.0.1:
     resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
     engines: {node: '>= 6'}
+    requiresBuild: true
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2(supports-color@8.1.1)
@@ -9842,6 +10009,7 @@ packages:
 
   /humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+    requiresBuild: true
     dependencies:
       ms: 2.1.3
     optional: true
@@ -9919,6 +10087,7 @@ packages:
 
   /infer-owner@1.0.4:
     resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
+    requiresBuild: true
     optional: true
 
   /inflight@1.0.6:
@@ -9997,6 +10166,7 @@ packages:
 
   /ip@2.0.0:
     resolution: {integrity: sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==}
+    requiresBuild: true
     optional: true
 
   /ipaddr.js@1.9.1:
@@ -10112,6 +10282,7 @@ packages:
 
   /is-lambda@1.0.1:
     resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
+    requiresBuild: true
     optional: true
 
   /is-lower-case@2.0.2:
@@ -11035,6 +11206,54 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /knex@2.3.0(pg@8.11.1)(sqlite3@5.0.11):
+    resolution: {integrity: sha512-WMizPaq9wRMkfnwKXKXgBZeZFOSHGdtoSz5SaLAVNs3WRDfawt9O89T4XyH52PETxjV8/kRk0Yf+8WBEP/zbYw==}
+    engines: {node: '>=12'}
+    hasBin: true
+    peerDependencies:
+      better-sqlite3: '*'
+      mysql: '*'
+      mysql2: '*'
+      pg: '*'
+      pg-native: '*'
+      sqlite3: '*'
+      tedious: '*'
+    peerDependenciesMeta:
+      better-sqlite3:
+        optional: true
+      mysql:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      pg-native:
+        optional: true
+      sqlite3:
+        optional: true
+      tedious:
+        optional: true
+    dependencies:
+      colorette: 2.0.19
+      commander: 9.5.0
+      debug: 4.3.4(supports-color@8.1.1)
+      escalade: 3.1.1
+      esm: 3.2.25
+      get-package-type: 0.1.0
+      getopts: 2.3.0
+      interpret: 2.2.0
+      lodash: 4.17.21
+      pg: 8.11.1
+      pg-connection-string: 2.5.0
+      rechoir: 0.8.0
+      resolve-from: 5.0.0
+      sqlite3: 5.0.11
+      tarn: 3.0.2
+      tildify: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /knex@2.3.0(pg@8.8.0)(sqlite3@5.0.11):
     resolution: {integrity: sha512-WMizPaq9wRMkfnwKXKXgBZeZFOSHGdtoSz5SaLAVNs3WRDfawt9O89T4XyH52PETxjV8/kRk0Yf+8WBEP/zbYw==}
     engines: {node: '>=12'}
@@ -11428,6 +11647,7 @@ packages:
   /make-fetch-happen@9.1.0:
     resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
     engines: {node: '>= 10'}
+    requiresBuild: true
     dependencies:
       agentkeepalive: 4.3.0
       cacache: 15.3.0
@@ -11597,12 +11817,14 @@ packages:
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+    requiresBuild: true
     dev: false
     optional: true
 
   /minipass-collect@1.0.2:
     resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
     engines: {node: '>= 8'}
+    requiresBuild: true
     dependencies:
       minipass: 3.3.6
     optional: true
@@ -11610,6 +11832,7 @@ packages:
   /minipass-fetch@1.4.1:
     resolution: {integrity: sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==}
     engines: {node: '>=8'}
+    requiresBuild: true
     dependencies:
       minipass: 3.3.6
       minipass-sized: 1.0.3
@@ -11621,6 +11844,7 @@ packages:
   /minipass-flush@1.0.5:
     resolution: {integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==}
     engines: {node: '>= 8'}
+    requiresBuild: true
     dependencies:
       minipass: 3.3.6
     optional: true
@@ -11628,6 +11852,7 @@ packages:
   /minipass-pipeline@1.2.4:
     resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
     engines: {node: '>=8'}
+    requiresBuild: true
     dependencies:
       minipass: 3.3.6
     optional: true
@@ -11635,6 +11860,7 @@ packages:
   /minipass-sized@1.0.3:
     resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
     engines: {node: '>=8'}
+    requiresBuild: true
     dependencies:
       minipass: 3.3.6
     optional: true
@@ -11659,6 +11885,7 @@ packages:
   /mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
+    requiresBuild: true
     dependencies:
       minimist: 1.2.8
     dev: false
@@ -11726,6 +11953,7 @@ packages:
 
   /nan@2.17.0:
     resolution: {integrity: sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==}
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -11762,6 +11990,7 @@ packages:
   /ncp@2.0.0:
     resolution: {integrity: sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==}
     hasBin: true
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -11930,6 +12159,7 @@ packages:
   /npmlog@6.0.2:
     resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    requiresBuild: true
     dependencies:
       are-we-there-yet: 3.0.1
       console-control-strings: 1.1.0
@@ -12310,7 +12540,6 @@ packages:
   /pg-cloudflare@1.1.1:
     resolution: {integrity: sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==}
     requiresBuild: true
-    dev: true
     optional: true
 
   /pg-connection-string@2.5.0:
@@ -12329,7 +12558,6 @@ packages:
       pg: '>=8.0'
     dependencies:
       pg: 8.11.1
-    dev: true
 
   /pg-pool@3.6.1(pg@8.8.0):
     resolution: {integrity: sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==}
@@ -12369,7 +12597,6 @@ packages:
       pgpass: 1.0.5
     optionalDependencies:
       pg-cloudflare: 1.1.1
-    dev: true
 
   /pg@8.8.0:
     resolution: {integrity: sha512-UXYN0ziKj+AeNNP7VDMwrehpACThH7LUl/p8TDFpEUuSejCUIwGSfxpHsPvtM6/WXFy6SU4E5RG4IJV/TZAGjw==}
@@ -12580,6 +12807,7 @@ packages:
 
   /promise-inflight@1.0.1:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    requiresBuild: true
     peerDependencies:
       bluebird: '*'
     peerDependenciesMeta:
@@ -12595,6 +12823,7 @@ packages:
   /promise-retry@2.0.1:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
+    requiresBuild: true
     dependencies:
       err-code: 2.0.3
       retry: 0.12.0
@@ -13093,6 +13322,7 @@ packages:
   /retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
+    requiresBuild: true
     optional: true
 
   /retry@0.13.1:
@@ -13111,6 +13341,7 @@ packages:
   /rimraf@2.4.5:
     resolution: {integrity: sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==}
     hasBin: true
+    requiresBuild: true
     dependencies:
       glob: 6.0.4
     dev: false
@@ -13500,6 +13731,7 @@ packages:
   /smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+    requiresBuild: true
     optional: true
 
   /snake-case@3.0.4:
@@ -13512,6 +13744,7 @@ packages:
   /socks-proxy-agent@6.2.1:
     resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
     engines: {node: '>= 10'}
+    requiresBuild: true
     dependencies:
       agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.3.4(supports-color@8.1.1)
@@ -13523,6 +13756,7 @@ packages:
   /socks@2.7.1:
     resolution: {integrity: sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==}
     engines: {node: '>= 10.13.0', npm: '>= 3.0.0'}
+    requiresBuild: true
     dependencies:
       ip: 2.0.0
       smart-buffer: 4.2.0
@@ -13653,6 +13887,7 @@ packages:
   /ssri@8.0.1:
     resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
     engines: {node: '>= 8'}
+    requiresBuild: true
     dependencies:
       minipass: 3.3.6
     optional: true
@@ -14499,12 +14734,14 @@ packages:
 
   /unique-filename@1.1.1:
     resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
+    requiresBuild: true
     dependencies:
       unique-slug: 2.0.2
     optional: true
 
   /unique-slug@2.0.2:
     resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
+    requiresBuild: true
     dependencies:
       imurmurhash: 0.1.4
     optional: true


### PR DESCRIPTION
Steps to reproduce: 
1. Create two entities, 'EntityOne' and 'EntityTwo'
2. Add a RelationshipField to EntityOne with a field name of 'entityTwo'
3. Run `graphweaver start`, will start succesfully
4. Rename the field from 'entityTwo' to anything else, such as 'two', 'entitytwo' or 'somethingElse'
5. Run `graphweaver start`, will fail with error.