### PR TITLE
Created a new GitHub action to publish packages to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,9 @@
-name: 🚀 Release package
+name: 🚀 Publish to NPM
 on:
   workflow_dispatch:
     inputs:
       release-type:
         description: "Release type (one of): patch, minor, major"
-        required: true
-      release-tag:
-        description: "Release tag (e.g. v1.0.1 or 0.0.1-beta.1)"
         required: true
 jobs:
   release:
@@ -69,11 +66,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git push origin && git push --tags
-
-      # Update GitHub release with changelog
-      - name: Update GitHub release documentation
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ github.event.inputs.release-tag }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: 🚀 Release package
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: "Release type (one of): patch, minor, major"
+        required: true
+      release-tag:
+        description: "Release tag (e.g. v1.0.1 or 0.0.1-beta.1)"
+        required: true
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    defaults:
+      run:
+        working-directory: src
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        env:
+          cache-name: cache-pnpm-modules
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
+
+      - uses: pnpm/action-setup@v2.2.4
+        with:
+          version: 8.6.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
+          cache-dependency-path: src/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm i
+
+      - name: Check
+        run: pnpm lint
+
+      - name: Build CLI tool 🔧
+        run: pnpm build
+
+      # Bump package version
+      - name: Bump release version
+        run: |
+          pnpm version:bump $RELEASE_TYPE
+        env:
+          RELEASE_TYPE: ${{ github.event.inputs.release-type }}
+
+      # Publish version to public repository
+      - name: Publish package on NPM 📦
+        run: pnpm -r publish --no-git-checks --access=public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Push repository changes
+      - name: Push changes to repository
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push origin && git push --tags
+
+      # Update GitHub release with changelog
+      - name: Update GitHub release documentation
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event.inputs.release-tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://app.clickup.com/t/2704425/ID-4721

<img width="489" alt="Screenshot 2023-08-18 at 10 18 34 am" src="https://github.com/exogee-technology/graphweaver/assets/29393307/612d7bfa-115e-47dc-9498-9dffa53e3993">

This github action does the following:
1. Manually trigger workflow. Require 1 input: Release type: patch, major or minor
2. The workflow is to run `pnpm version:bump` then `pnpm publish`

Prerequisite: Follow these steps to setup the automated npm package releasing:
1. Generate a new npm access token
<img width="764" alt="Screenshot 2023-08-18 at 10 24 12 am" src="https://github.com/exogee-technology/graphweaver/assets/29393307/55c61a7b-9cea-4a0c-b764-c048d6e5f132">

2. Save npm access token as a GitHub secret
In the GitHub repository settings, click on New repository secret and name the secret NPM_TOKEN. Copy the token into it.
<img width="1155" alt="Screenshot 2023-08-18 at 10 23 07 am" src="https://github.com/exogee-technology/graphweaver/assets/29393307/ca874013-2e78-42ce-afab-9e272a1c8add">

<img width="1155" alt="Screenshot 2023-08-18 at 10 23 35 am" src="https://github.com/exogee-technology/graphweaver/assets/29393307/3261dcee-ec07-4ef5-beb9-b839893522e6">
