### PR TITLE
`graphweaver init` UX improvements

### DIFF
--- a/src/packages/cli/package.json
+++ b/src/packages/cli/package.json
@@ -26,14 +26,17 @@
 		"chokidar": "3.5.3",
 		"esbuild": "0.15.5",
 		"inquirer": "9.2.1",
+		"node-semver": "1.0.0",
 		"ora": "5.4.1",
 		"semver": "7.5.4",
+		"validate-npm-package-name": "5.0.0",
 		"yargs": "17.6.2"
 	},
 	"devDependencies": {
 		"@types/inquirer": "9.0.3",
 		"@types/node": "18.11.9",
 		"@types/semver": "7.5.0",
+		"@types/validate-npm-package-name": "4.0.0",
 		"@types/yargs": "17.0.24",
 		"prettier": "2.8.8"
 	}

--- a/src/packages/cli/src/import/index.ts
+++ b/src/packages/cli/src/import/index.ts
@@ -56,7 +56,7 @@ const checkForMissingDependencies = (source: 'mysql' | 'postgresql' | 'sqlite') 
 	if (missingDependencies.length > 0) {
 		console.warn(`\n\nPlease install these missing dependencies and try again:\n`);
 		console.warn(`\t\t pnpm i ${missingDependencies.join(' ')}\n\n`);
-		process.exit();
+		process.exit(1);
 	}
 };
 

--- a/src/packages/cli/src/index.ts
+++ b/src/packages/cli/src/index.ts
@@ -62,7 +62,7 @@ yargs
 				}
 			});
 
-			console.log('Initiasing a new Graphweaver project...');
+			console.log('Initialising a new Graphweaver project...');
 			if (name) console.log(`Project Name: ${name}`);
 			if (backends) console.log(`Backends: ${backends.join(',')}`);
 			if (version) console.log(`Graphweaver Version: ${version}`);

--- a/src/packages/cli/src/index.ts
+++ b/src/packages/cli/src/index.ts
@@ -47,21 +47,20 @@ yargs
 		handler: async (argv) => {
 			const version = argv.version;
 			const name = argv.name;
-			const backends =
-				argv.backend?.flatMap((backend: string) => {
-					switch (backend) {
-						case 'postgres':
-							return Backend.Postgres;
-						case 'mysql':
-							return Backend.Mysql;
-						case 'rest':
-							return Backend.Rest;
-						case 'sqlite':
-							return Backend.Sqlite;
-						default:
-							return [];
-					}
-				}) ?? [];
+			const backends = argv.backend?.flatMap((backend: string) => {
+				switch (backend) {
+					case 'postgres':
+						return Backend.Postgres;
+					case 'mysql':
+						return Backend.Mysql;
+					case 'rest':
+						return Backend.Rest;
+					case 'sqlite':
+						return Backend.Sqlite;
+					default:
+						return [];
+				}
+			});
 
 			console.log('Initiasing a new Graphweaver project...');
 			if (name) console.log(`Project Name: ${name}`);

--- a/src/packages/cli/src/index.ts
+++ b/src/packages/cli/src/index.ts
@@ -36,45 +36,26 @@ yargs
 					describe: 'The name of this project.',
 				})
 				.option('backend', {
-					type: 'string',
-					describe: 'Specify a data source.',
+					type: 'array',
+					describe: 'Specify one or more data sources.',
 					choices: ['postgres', 'mysql', 'rest', 'sqlite'],
 				})
 				.option('version', {
 					type: 'string',
 					describe: 'Specify a version of Graphweaver to use.',
-				})
-				.option('host', {
-					type: 'string',
-					describe: 'Specify the database server hostname.',
-				})
-				.option('port', {
-					type: 'number',
-					describe: 'Specify the database server port.',
-				})
-				.option('password', {
-					type: 'string',
-					describe: 'Specify the database server password.',
-				})
-				.option('user', {
-					type: 'string',
-					describe: 'Specify the database server user.',
 				}),
 		handler: async (argv) => {
 			const version = argv.version;
 			const name = argv.name;
-			const backend = argv.backend;
-			const host = argv.host;
-			const port = argv.port;
-			const password = argv.password;
-			const user = argv.user;
+			const backends = argv.backend;
 
-			console.log(`Initing project ${name}, ${version}, ${backend}, ${host}, ${port}, ${user}...`);
-			if (backend === 'postgres') init({ name, backend: Backend.Postgres, version });
-			if (backend === 'mysql') init({ name, backend: Backend.Mysql, version });
-			if (backend === 'rest') init({ name, backend: Backend.Rest, version });
-			if (backend === 'sqlite') init({ name, backend: Backend.Sqlite, version });
-			init({ name, version });
+			console.log('Initiasing a new Graphweaver project...');
+			if (name) console.log(`Project Name: ${name}`);
+			if (backends) console.log(`Backends: ${backends.join(',')}`);
+			if (version) console.log(`Graphweaver Version: ${version}`);
+			console.log();
+
+			init({ name, version, backends });
 		},
 	})
 	.command({
@@ -110,9 +91,12 @@ yargs
 				}),
 		handler: async ({ source, database, host, port, password, user }) => {
 			console.log('Importing data source...');
-			console.log(
-				`Source: ${source}, Database: ${database}, Host: ${host}, Port: ${port}, User: ${user}`
-			);
+			if (source) console.log(`Source: ${source}`);
+			if (database) console.log(`Database Name: ${database}`);
+			if (host) console.log(`Database Host: ${host}`);
+			if (port) console.log(`Database Port: ${port}`);
+			if (user) console.log(`Database User: ${user}`);
+			console.log();
 
 			await importDataSource(source, database, host, port, password, user);
 		},

--- a/src/packages/cli/src/index.ts
+++ b/src/packages/cli/src/index.ts
@@ -47,20 +47,21 @@ yargs
 		handler: async (argv) => {
 			const version = argv.version;
 			const name = argv.name;
-			const backends = argv.backend.flatMap((backend: string) => {
-				switch (backend) {
-					case 'postgres':
-						return Backend.Postgres;
-					case 'mysql':
-						return Backend.Mysql;
-					case 'rest':
-						return Backend.Rest;
-					case 'sqlite':
-						return Backend.Sqlite;
-					default:
-						return [];
-				}
-			});
+			const backends =
+				argv.backend?.flatMap((backend: string) => {
+					switch (backend) {
+						case 'postgres':
+							return Backend.Postgres;
+						case 'mysql':
+							return Backend.Mysql;
+						case 'rest':
+							return Backend.Rest;
+						case 'sqlite':
+							return Backend.Sqlite;
+						default:
+							return [];
+					}
+				}) ?? [];
 
 			console.log('Initiasing a new Graphweaver project...');
 			if (name) console.log(`Project Name: ${name}`);

--- a/src/packages/cli/src/index.ts
+++ b/src/packages/cli/src/index.ts
@@ -47,7 +47,20 @@ yargs
 		handler: async (argv) => {
 			const version = argv.version;
 			const name = argv.name;
-			const backends = argv.backend;
+			const backends = argv.backend.flatMap((backend: string) => {
+				switch (backend) {
+					case 'postgres':
+						return Backend.Postgres;
+					case 'mysql':
+						return Backend.Mysql;
+					case 'rest':
+						return Backend.Rest;
+					case 'sqlite':
+						return Backend.Sqlite;
+					default:
+						return [];
+				}
+			});
 
 			console.log('Initiasing a new Graphweaver project...');
 			if (name) console.log(`Project Name: ${name}`);

--- a/src/packages/cli/src/init/index.ts
+++ b/src/packages/cli/src/init/index.ts
@@ -48,7 +48,7 @@ export const init = async ({
 	name: initialName,
 	backends: initialBackends,
 }: InitOptions) => {
-	if (version !== undefined && !validSemver(version))
+	if (version !== undefined && !validSemver(version) && version !== 'local')
 		throw new Error(`'${version}' is not a valid semver`);
 
 	if (initialName && Array.isArray(initialBackends) && initialBackends.length > 0) {

--- a/src/packages/cli/src/init/index.ts
+++ b/src/packages/cli/src/init/index.ts
@@ -67,8 +67,9 @@ export const init = async ({
 				message: `What would your like to call your new project?`,
 				default: initialName,
 				validate: (answer) => {
-					const { validForNewPackages, errors } = validate(answer);
-					if (!validForNewPackages) return `Project name is not valid: ${errors?.join(',') ?? ''}`;
+					const { validForNewPackages, warnings, errors } = validate(answer);
+					const messages = [...(errors ?? []), ...(warnings ?? [])];
+					if (!validForNewPackages) return `Project name is not valid: ${messages.join(',')}`;
 					return true;
 				},
 			},

--- a/src/packages/cli/src/init/index.ts
+++ b/src/packages/cli/src/init/index.ts
@@ -118,7 +118,9 @@ export const init = async ({
 		initGraphweaver(name, backends, version);
 	}
 
-	console.log('All Done!\nMake sure you to pnpm install, then pnpm start.');
+	console.log(
+		'All Done!\nMake sure you cd to the new project directory, then run pnpm install and pnpm start.'
+	);
 
 	exit(0);
 };

--- a/src/packages/cli/src/init/index.ts
+++ b/src/packages/cli/src/init/index.ts
@@ -67,9 +67,8 @@ export const init = async ({
 				message: `What would your like to call your new project?`,
 				default: initialName,
 				validate: (answer) => {
-					const { validForNewPackages, warnings } = validate(answer);
-					if (!validForNewPackages)
-						return `Project name is not valid: ${warnings?.join(',') ?? ''}`;
+					const { validForNewPackages, errors } = validate(answer);
+					if (!validForNewPackages) return `Project name is not valid: ${errors?.join(',') ?? ''}`;
 					return true;
 				},
 			},

--- a/src/packages/cli/src/init/index.ts
+++ b/src/packages/cli/src/init/index.ts
@@ -1,6 +1,6 @@
 import { exit, cwd } from 'process';
-import validate from 'validate-npm-package-name';
-import { valid as validSemver } from 'semver';
+import validatePackageName from 'validate-npm-package-name';
+import { valid as validateSemver } from 'semver';
 
 import {
 	makePackageJson,
@@ -48,7 +48,8 @@ export const init = async ({
 	name: initialName,
 	backends: initialBackends,
 }: InitOptions) => {
-	if (version !== undefined && !validSemver(version) && version !== 'local')
+	// version must be a valid semver or the special string 'local' for local development
+	if (version !== undefined && !validateSemver(version) && version !== 'local')
 		throw new Error(`'${version}' is not a valid semver`);
 
 	if (initialName && Array.isArray(initialBackends) && initialBackends.length > 0) {
@@ -67,7 +68,7 @@ export const init = async ({
 				message: `What would your like to call your new project?`,
 				default: initialName,
 				validate: (answer) => {
-					const { validForNewPackages, warnings, errors } = validate(answer);
+					const { validForNewPackages, warnings, errors } = validatePackageName(answer);
 					const messages = [...(errors ?? []), ...(warnings ?? [])];
 					if (!validForNewPackages) return `Project name is not valid: ${messages.join(',')}`;
 					return true;

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -576,12 +576,18 @@ importers:
       inquirer:
         specifier: 9.2.1
         version: 9.2.1
+      node-semver:
+        specifier: 1.0.0
+        version: 1.0.0
       ora:
         specifier: 5.4.1
         version: 5.4.1
       semver:
         specifier: 7.5.4
         version: 7.5.4
+      validate-npm-package-name:
+        specifier: 5.0.0
+        version: 5.0.0
       yargs:
         specifier: 17.6.2
         version: 17.6.2
@@ -595,6 +601,9 @@ importers:
       '@types/semver':
         specifier: 7.5.0
         version: 7.5.0
+      '@types/validate-npm-package-name':
+        specifier: 4.0.0
+        version: 4.0.0
       '@types/yargs':
         specifier: 17.0.24
         version: 17.0.24
@@ -770,7 +779,7 @@ importers:
     optionalDependencies:
       '@mikro-orm/knex':
         specifier: 5.7.14
-        version: 5.7.14(@mikro-orm/core@5.7.14)(mysql2@3.5.2)(pg@8.11.1)
+        version: 5.7.14(@mikro-orm/core@5.7.14)(pg@8.11.1)(sqlite3@5.1.6)
       '@mikro-orm/mysql':
         specifier: 5.7.14
         version: 5.7.14(@mikro-orm/core@5.7.14)(pg@8.11.1)
@@ -4390,7 +4399,7 @@ packages:
         optional: true
     dependencies:
       '@mikro-orm/core': 5.7.14(@mikro-orm/mysql@5.7.14)(@mikro-orm/postgresql@5.7.14)(@mikro-orm/sqlite@5.7.14)
-      '@mikro-orm/knex': 5.7.14(@mikro-orm/core@5.7.14)(mysql2@3.5.2)(pg@8.11.1)
+      '@mikro-orm/knex': 5.7.14(@mikro-orm/core@5.7.14)(pg@8.11.1)(sqlite3@5.1.6)
       pg: 8.11.1
     transitivePeerDependencies:
       - better-sqlite3
@@ -6094,7 +6103,6 @@ packages:
 
   /@types/node@14.14.10:
     resolution: {integrity: sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==}
-    dev: true
 
   /@types/node@18.11.11:
     resolution: {integrity: sha512-KJ021B1nlQUBLopzZmPBVuGU9un7WJd/W4ya7Ih02B4Uwky5Nja0yGYav2EfYIk0RR2Q9oVhf60S2XR1BCWJ2g==}
@@ -6207,6 +6215,10 @@ packages:
     resolution: {integrity: sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==}
     dependencies:
       '@types/node': 20.2.5
+    dev: true
+
+  /@types/validate-npm-package-name@4.0.0:
+    resolution: {integrity: sha512-RpO62vB2lkjEkyLbwTheA2+uwYmtVMWTr/kWRI++UAgVdZqNqdAuIQl/SxBCGeMKfdjWaXPbyhZbiCc4PAj+KA==}
     dev: true
 
   /@types/validator@13.7.17:
@@ -7138,6 +7150,12 @@ packages:
 
   /builtins@1.0.3:
     resolution: {integrity: sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==}
+    dev: false
+
+  /builtins@5.0.1:
+    resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
+    dependencies:
+      semver: 7.5.4
     dev: false
 
   /bunyan@1.8.14:
@@ -11920,6 +11938,11 @@ packages:
       sorted-array-functions: 1.3.0
     dev: false
 
+  /node-semver@1.0.0:
+    resolution: {integrity: sha512-RB7VKO1hfCLiCxzXD2IynGcqFGaxLLbKibDmeZwQnnHX1JYA1PozO125hm+++AWDs03PKa7fV8YkMUtg2rbquw==}
+    deprecated: please use 'semver'
+    dev: false
+
   /nopt@5.0.0:
     resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
     engines: {node: '>=6'}
@@ -14691,6 +14714,13 @@ packages:
       builtins: 1.0.3
     dev: false
 
+  /validate-npm-package-name@5.0.0:
+    resolution: {integrity: sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dependencies:
+      builtins: 5.0.1
+    dev: false
+
   /validator@13.9.0:
     resolution: {integrity: sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==}
     engines: {node: '>= 0.10'}
@@ -14738,7 +14768,7 @@ packages:
       '@rollup/pluginutils': 5.0.2
       '@svgr/core': 7.0.0
       '@svgr/plugin-jsx': 7.0.0
-      vite: 4.3.9(@types/node@20.2.5)
+      vite: 4.3.9(@types/node@14.14.10)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -14774,7 +14804,6 @@ packages:
       rollup: 3.26.3
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /vite@4.3.9(@types/node@18.11.9):
     resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}


### PR DESCRIPTION
https://github.com/exogee-technology/graphweaver/issues/153 

- Update printing of CLI arguments for `init` and `import`
- Remove currently unused `init` arguments
- Default name and backends in the interactive flow if one is provided on CLI
- Allow specifying multiple backends on CLI
- Validate project name
- Update instructions to include to change to the project directory.
- Return error code 1 if there are missing packages on `import`