### PR TITLE
Fixed issue where ObjectType is different to entity name

### DIFF
--- a/src/packages/core/src/decorators/relationship-field.ts
+++ b/src/packages/core/src/decorators/relationship-field.ts
@@ -1,6 +1,7 @@
 import { getMetadataStorage } from 'type-graphql';
 import { ReturnTypeFunc } from 'type-graphql/dist/decorators/types';
 import { findType } from 'type-graphql/dist/helpers/findType';
+import { ObjectClassMetadata } from 'type-graphql/dist/metadata/definitions/object-class-metdata';
 import { BaseLoaders } from '../base-loader';
 import {
 	BaseContext,
@@ -50,7 +51,10 @@ export function RelationshipField<
 		const getRelatedType = () => {
 			const relatedEntityType = getType() as GraphQLEntityConstructor<G, D>;
 			const typeName = relatedEntityType.name;
-			return TypeMap[`${pluralize(typeName)}ListFilter`];
+			const objectTypeName = (metadata.objectTypes as ObjectClassMetadata[]).find(
+				(objectType: ObjectClassMetadata) => objectType.target?.name === typeName
+			)?.name;
+			return TypeMap[`${pluralize(objectTypeName || typeName)}ListFilter`];
 		};
 
 		// next we need to add the below function as a field resolver

--- a/src/packages/end-to-end/src/__tests__/api/sqlite/issues/gh151.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/sqlite/issues/gh151.test.ts
@@ -1,0 +1,118 @@
+import 'reflect-metadata';
+import gql from 'graphql-tag';
+import assert from 'assert';
+import Graphweaver from '@exogee/graphweaver-server';
+import {
+	Entity,
+	Collection,
+	IdentifiedReference,
+	ManyToOne,
+	OneToMany,
+	PrimaryKey,
+} from '@mikro-orm/core';
+import {
+	createBaseResolver,
+	Field,
+	GraphQLEntity,
+	ID,
+	ObjectType,
+	RelationshipField,
+	Resolver,
+} from '@exogee/graphweaver';
+import { BaseEntity, MikroBackendProvider, ConnectionManager } from '@exogee/graphweaver-mikroorm';
+
+import { resetDatabase } from '../../../../utils';
+
+import { SqliteDriver } from '@mikro-orm/sqlite';
+
+/** Setup entities and resolvers  */
+@Entity({ tableName: 'Album' })
+class OrmAlbum extends BaseEntity {
+	@PrimaryKey({ fieldName: 'AlbumId', type: 'number' })
+	id!: number;
+
+	@ManyToOne({
+		entity: () => OrmArtist,
+		wrappedReference: true,
+		fieldName: 'ArtistId',
+		index: 'IFK_AlbumArtistId',
+	})
+	artist!: IdentifiedReference<OrmArtist>;
+}
+
+@Entity({ tableName: 'Artist' })
+class OrmArtist extends BaseEntity {
+	@PrimaryKey({ fieldName: 'ArtistId', type: 'number' })
+	id!: number;
+
+	@OneToMany({ entity: () => OrmAlbum, mappedBy: 'artist' })
+	albums = new Collection<OrmAlbum>(this);
+}
+
+@ObjectType('TestAlbum')
+export class Album extends GraphQLEntity<OrmAlbum> {
+	public dataEntity!: OrmAlbum;
+
+	@Field(() => ID)
+	id!: number;
+
+	@RelationshipField<Album>(() => Artist, { id: (entity) => entity.artist?.id })
+	renamedArtist!: Artist;
+}
+
+@ObjectType('TestArtist')
+export class Artist extends GraphQLEntity<OrmArtist> {
+	public dataEntity!: OrmArtist;
+
+	@Field(() => ID)
+	id!: number;
+
+	@RelationshipField<Album>(() => [Album], { relatedField: 'artist' })
+	renamedAlbums!: Album[];
+}
+
+const connection = {
+	connectionManagerId: 'sqlite',
+	mikroOrmConfig: {
+		entities: [OrmAlbum, OrmArtist],
+		driver: SqliteDriver,
+		dbName: 'databases/database.sqlite',
+	},
+};
+
+@Resolver((of) => Album)
+class AlbumResolver extends createBaseResolver<Album, OrmAlbum>(
+	Album,
+	new MikroBackendProvider(OrmAlbum, connection)
+) {}
+
+@Resolver((of) => Artist)
+class ArtistResolver extends createBaseResolver<Artist, OrmArtist>(
+	Artist,
+	new MikroBackendProvider(OrmArtist, connection)
+) {}
+
+describe('RelationshipField', () => {
+	beforeEach(resetDatabase);
+
+	test('should not get error on buildSchema when object type name is not same as entity', async () => {
+		const graphweaver = new Graphweaver({
+			resolvers: [AlbumResolver, ArtistResolver],
+		});
+
+		const response = await graphweaver.server.executeOperation({
+			query: gql`
+				query {
+					testAlbums {
+						id
+						renamedArtist {
+							id
+						}
+					}
+				}
+			`,
+		});
+		assert(response.body.kind === 'single');
+		expect(response.body.singleResult.data?.testAlbums).toHaveLength(347);
+	});
+});

--- a/src/packages/server/src/metadata-service/resolver.ts
+++ b/src/packages/server/src/metadata-service/resolver.ts
@@ -50,7 +50,7 @@ export const getAdminUiMetadataResolver = (hooks?: AdminMetadata['hooks']) => {
 			// Build some lookups for more efficient data locating later.
 			const objectTypeData: { [entityName: string]: ObjectClassMetadata } = {};
 			for (const objectType of metadata.objectTypes) {
-				objectTypeData[objectType.name] = objectType;
+				objectTypeData[objectType.target.name] = objectType;
 			}
 
 			const enumMetadata = new Map<object, EnumMetadata>();
@@ -69,23 +69,23 @@ export const getAdminUiMetadataResolver = (hooks?: AdminMetadata['hooks']) => {
 					const fields = objectType.fields?.map((field) => {
 						const typeValue = field.getType() as any;
 						const entityName = typeValue.name ? typeValue.name : enumMetadata.get(typeValue)?.name;
+						const relatedObject = objectTypeData[entityName];
 						const fieldObject: AdminUiFieldMetadata = {
 							name: field.name,
-							type: entityName,
+							type: relatedObject?.name || entityName,
 						};
-						const relatedObject = objectTypeData[entityName];
 						// Check if we have an array of related entities
 						if (field.typeOptions.array && relatedObject) {
 							const relatedEntity = relatedObject.fields?.find((field) => {
 								const fieldType = field.getType() as any;
-								return fieldType.name === name;
+								return fieldType.name === objectType.target.name;
 							});
 							if (relatedEntity?.typeOptions) {
 								fieldObject.relationshipType = relatedEntity.typeOptions.array
 									? RelationshipType.MANY_TO_MANY
 									: RelationshipType.ONE_TO_MANY;
 							}
-							fieldObject.relatedEntity = entityName;
+							fieldObject.relatedEntity = relatedObject.name;
 						} else if (relatedObject) {
 							fieldObject.relationshipType = RelationshipType.MANY_TO_ONE;
 						}


### PR DESCRIPTION
Steps to reproduce: 
1. Create two entities, 'EntityOne' and 'EntityTwo'
2. Add a RelationshipField to EntityOne
3. Run graphweaver start, will start succesfully
4. Rename the ObjectType to `@ObjectType('One')`
5. Run graphweaver start, will fail with error.