### PR TITLE
Added overwrite flag to import command and added confirmation to overwrite existing file

### DIFF
--- a/src/packages/cli/src/import/index.ts
+++ b/src/packages/cli/src/import/index.ts
@@ -66,7 +66,8 @@ export const importDataSource = async (
 	host?: string,
 	port?: number,
 	password?: string,
-	user?: string
+	user?: string,
+	overwriteAllFiles?: boolean
 ) => {
 	const prompts = [];
 
@@ -154,19 +155,19 @@ export const importDataSource = async (
 			createDirectories(path.join('./src/', file.path));
 
 			const fileFullPath = path.join(process.cwd(), './src/', file.path, file.name);
-			let allowOverwrite = true;
-			if (existsSync(fileFullPath)) {
-				const prompt = await inquirer.prompt<{ allowOverwrite: boolean }>([
+			let overwrite = true;
+			if (!overwriteAllFiles && file.needOverwriteWarning && existsSync(fileFullPath)) {
+				const prompt = await inquirer.prompt<{ overwrite: boolean }>([
 					{
 						type: 'confirm',
-						name: 'allowOverwrite',
-						message: `Overwrite this file ${file.name}?`,
+						name: 'overwrite',
+						message: `Overwrite this file ${path.join(file.path, file.name)}?`,
 						default: true,
 					},
 				]);
-				allowOverwrite = prompt.allowOverwrite;
+				overwrite = prompt.overwrite;
 			}
-			if (allowOverwrite) {
+			if (overwrite) {
 				writeFileSync(fileFullPath, file.contents);
 				fileCount += 1;
 			}

--- a/src/packages/cli/src/import/index.ts
+++ b/src/packages/cli/src/import/index.ts
@@ -149,11 +149,29 @@ export const importDataSource = async (
 
 		spinner.stop();
 
+		let fileCount = 0;
 		for (const file of files) {
 			createDirectories(path.join('./src/', file.path));
-			writeFileSync(path.join(process.cwd(), './src/', file.path, file.name), file.contents);
+
+			const fileFullPath = path.join(process.cwd(), './src/', file.path, file.name);
+			let allowOverwrite = true;
+			if (existsSync(fileFullPath)) {
+				const prompt = await inquirer.prompt<{ allowOverwrite: boolean }>([
+					{
+						type: 'confirm',
+						name: 'allowOverwrite',
+						message: `Overwrite this file ${file.name}?`,
+						default: true,
+					},
+				]);
+				allowOverwrite = prompt.allowOverwrite;
+			}
+			if (allowOverwrite) {
+				writeFileSync(fileFullPath, file.contents);
+				fileCount += 1;
+			}
 		}
-		console.log(`${files.length} files have been successfully created in the project.`);
+		console.log(`${fileCount} files have been successfully created in the project.`);
 	} catch (err: unknown) {
 		if (isIntrospectionError(err)) {
 			console.warn(`\n\n${err.title}\n${err.message}\n\n`);

--- a/src/packages/cli/src/index.ts
+++ b/src/packages/cli/src/index.ts
@@ -101,8 +101,13 @@ yargs
 				.option('user', {
 					type: 'string',
 					describe: 'Specify the database server user.',
+				})
+				.option('overwrite', {
+					alias: 'o',
+					type: 'boolean',
+					describe: 'Overwrite all existing files.',
 				}),
-		handler: async ({ source, database, host, port, password, user }) => {
+		handler: async ({ source, database, host, port, password, user, overwrite }) => {
 			console.log('Importing data source...');
 			if (source) console.log(`Source: ${source}`);
 			if (database) console.log(`Database Name: ${database}`);
@@ -111,7 +116,7 @@ yargs
 			if (user) console.log(`Database User: ${user}`);
 			console.log();
 
-			await importDataSource(source, database, host, port, password, user);
+			await importDataSource(source, database, host, port, password, user, overwrite);
 		},
 	})
 	.command({

--- a/src/packages/end-to-end/scripts/import-mysql.sh
+++ b/src/packages/end-to-end/scripts/import-mysql.sh
@@ -7,4 +7,4 @@ cp ../databases/mysql.sql databases/mysql.sql
 mysql -h$DATABASE_HOST -u$DATABASE_USERNAME --password=$DATABASE_PASSWORD -e "DROP DATABASE IF EXISTS Chinook;"
 mysql -h$DATABASE_HOST -u$DATABASE_USERNAME --password=$DATABASE_PASSWORD -e "CREATE DATABASE Chinook;"
 mysql -h$DATABASE_HOST -u$DATABASE_USERNAME --password=$DATABASE_PASSWORD Chinook < databases/mysql.sql
-node ../../cli/bin import mysql --database=Chinook --user=$DATABASE_USERNAME --password=$DATABASE_PASSWORD --host=$DATABASE_HOST --port=3306 
+node ../../cli/bin import mysql --database=Chinook --user=$DATABASE_USERNAME --password=$DATABASE_PASSWORD --host=$DATABASE_HOST --port=3306 --o

--- a/src/packages/end-to-end/scripts/import-postgres.sh
+++ b/src/packages/end-to-end/scripts/import-postgres.sh
@@ -2,4 +2,4 @@ rm -rf ./app
 node ../cli/bin init --name=app --backend=postgres --version=\"local\" 
 cd app 
 pnpm i --ignore-workspace --no-lockfile
-node ../../cli/bin import postgresql --database=gw --user=postgres --password=postgres --host=localhost --port=5432 
+node ../../cli/bin import postgresql --database=gw --user=postgres --password=postgres --host=localhost --port=5432 --o

--- a/src/packages/end-to-end/scripts/import-sqlite.sh
+++ b/src/packages/end-to-end/scripts/import-sqlite.sh
@@ -4,4 +4,4 @@ cd app
 pnpm i --ignore-workspace --no-lockfile
 mkdir databases
 cp ../databases/database.sqlite databases/database.sqlite 
-pnpm run import sqlite --database=databases/database.sqlite
+pnpm run import sqlite --database=databases/database.sqlite --o

--- a/src/packages/mikroorm/src/introspection/generate.ts
+++ b/src/packages/mikroorm/src/introspection/generate.ts
@@ -243,11 +243,14 @@ export const generate = async (databaseType: DatabaseType, options: ConnectionOp
 		// Export the database connection to its own file
 		source.push(new DatabaseFile(databaseType, options));
 
-		const files = source.map((file) => ({
-			path: file.getBasePath(),
-			name: file.getBaseName(),
-			contents: file.generate(),
-		}));
+		const files = source.map((file) => {
+			return {
+				path: file.getBasePath(),
+				name: file.getBaseName(),
+				contents: file.generate(),
+				needOverwriteWarning: !![DatabaseFile, SchemaIndexFile].some((cls) => file instanceof cls),
+			};
+		});
 
 		await closeConnection();
 


### PR DESCRIPTION
Added new flag, --o or --overwrite to import command to skip the overwrite confirmation if the files are already exist.

Example,
run `graphweaver import sqlite --database=databases/database.sqlite --o`

If the overwrite flag is not provided, these two files will be prompted warning confirmation if the files are already exist:
`? Overwrite this file backend/schema/index.ts? Yes`
`? Overwrite this file backend/database.ts? Yes`