### PR TITLE
Support Validation Rules

### DIFF
--- a/src/packages/server/src/index.ts
+++ b/src/packages/server/src/index.ts
@@ -49,7 +49,7 @@ export interface GraphweaverConfig {
 	graphqlDeduplicator?: {
 		enabled: boolean;
 	};
-	enableValidationRules: boolean;
+	enableValidationRules?: boolean;
 }
 
 export default class Graphweaver<TContext extends BaseContext> {

--- a/src/packages/server/src/index.ts
+++ b/src/packages/server/src/index.ts
@@ -49,6 +49,7 @@ export interface GraphweaverConfig {
 	graphqlDeduplicator?: {
 		enabled: boolean;
 	};
+	enableValidationRules: boolean;
 }
 
 export default class Graphweaver<TContext extends BaseContext> {
@@ -62,6 +63,7 @@ export default class Graphweaver<TContext extends BaseContext> {
 		graphqlDeduplicator: {
 			enabled: true,
 		},
+		enableValidationRules: false,
 	};
 
 	constructor(config: GraphweaverConfig) {
@@ -119,6 +121,7 @@ export default class Graphweaver<TContext extends BaseContext> {
 		const schema = buildSchemaSync({
 			resolvers,
 			authChecker: config.authChecker ?? (() => true),
+			validate: this.config.enableValidationRules,
 		});
 
 		logger.trace(`Graphweaver starting ApolloServer`);


### PR DESCRIPTION
To use the [class validator](https://www.npmjs.com/package/class-validator) rules within Graphweaver we need to be able to configure the validation on TypeGraphQL.

This PR adds a new config param to enable validation.

