### PR TITLE
Fix / Typo in readme

### DIFF
--- a/src/examples/rest/README.md
+++ b/src/examples/rest/README.md
@@ -160,7 +160,7 @@ Then, encode the PEM formatted keys as base64 strings:
 
 ```
 # Output the private key in base64 format
-cat ecsda-private-key.pem | base64
+cat ecdsa-private-key.pem | base64
 # Output the public key in base64 format
 cat ecdsa-public-key.pem | base64
 ```


### PR DESCRIPTION
Currently in the getting started guide there's a really subtle typo which prevents pasting the commands in.