### PR TITLE
Feature / Added ability for custom fields to show on form.

### DIFF
--- a/src/examples/rest/src/admin-ui/custom-fields/index.ts
+++ b/src/examples/rest/src/admin-ui/custom-fields/index.ts
@@ -8,5 +8,7 @@ customFields.set('Task', [
 		type: 'custom',
 		index: 3,
 		component: Link,
+
+		showOn: { table: true },
 	},
 ]);

--- a/src/examples/rest/src/admin-ui/custom-fields/link.tsx
+++ b/src/examples/rest/src/admin-ui/custom-fields/link.tsx
@@ -1,13 +1,20 @@
 import { MouseEventHandler } from 'react';
 
-import { Task } from '../../types.generated';
 import { ReactComponent as OpenIcon } from '../assets/16-open-external.svg';
+import { CustomFieldArgs } from '@exogee/graphweaver-admin-ui-components';
 
-export const Link = (task: Task) => {
+interface Task {
+	user: {
+		label: string;
+		value: string;
+	};
+}
+
+export const Link = ({ entity }: CustomFieldArgs<Task>) => {
 	const handleClick = (e: MouseEventHandler<HTMLDivElement>) => {
 		e.preventDefault();
 		e.stopPropagation();
-		window.open(`https://google.com/search?q=${task.user.name}`, '_blank', 'noreferrer');
+		window.open(`https://google.com/search?q=${entity.user.label}`, '_blank', 'noreferrer');
 	};
 	return (
 		<div style={{ cursor: 'pointer' }} onClick={handleClick}>

--- a/src/packages/admin-ui-components/src/detail-panel/component.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/component.tsx
@@ -5,12 +5,13 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Modal } from '../modal';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import toast from 'react-hot-toast';
+import { customFields } from 'virtual:graphweaver-user-supplied-custom-fields';
 
 import {
+	CustomField,
 	decodeSearchParams,
 	EntityField,
 	EntityFieldType,
-	Enum,
 	queryForEntity,
 	routeFor,
 	useSchema,
@@ -18,146 +19,26 @@ import {
 } from '../utils';
 import { Button } from '../button';
 import { Spinner } from '../spinner';
-import { Select, SelectMode, SelectOption } from '../multi-select';
-import {
-	generateCreateEntityMutation,
-	generateUpdateEntityMutation,
-	getRelationshipQuery,
-} from './graphql';
+import { generateCreateEntityMutation, generateUpdateEntityMutation } from './graphql';
 
 import styles from './styles.module.css';
+import { BooleanField, EnumField, JSONField, SelectField } from './fields';
 
 interface ResultBaseType {
 	id: string;
 	[x: string]: unknown;
 }
 
-const SelectField = ({ name, entity }: { name: string; entity: EntityField }) => {
-	const [_, meta, helpers] = useField({ name, multiple: false });
-	const { entityByType } = useSchema();
-	const { initialValue } = meta;
-	const relationshipEntityType = entityByType(entity.type);
-
-	useEffect(() => {
-		helpers.setValue(initialValue);
-	}, []);
-
-	const { data } = useQuery<{ result: Record<string, string>[] }>(
-		getRelationshipQuery(entity.type, relationshipEntityType?.summaryField),
-		{
-			variables: {
-				pagination: {
-					orderBy: relationshipEntityType
-						? {
-								[relationshipEntityType.summaryField as string]: 'ASC',
-						  }
-						: { id: 'ASC' },
-				},
-			},
-		}
-	);
-
-	const options = (data?.result ?? []).map<SelectOption>((item): SelectOption => {
-		const label = relationshipEntityType?.summaryField || 'id';
-		return { label: item[label], value: item.id };
-	});
-
-	const handleOnChange = (selected: SelectOption[]) => {
-		helpers.setValue(selected?.[0]);
-	};
-
-	return (
-		<Select
-			options={options}
-			value={initialValue ? [initialValue] : []}
-			onChange={handleOnChange}
-			mode={
-				entity.relationshipType === 'ONE_TO_ONE' || entity.relationshipType === 'MANY_TO_ONE'
-					? SelectMode.SINGLE
-					: SelectMode.MULTI
-			}
-		/>
-	);
-};
-
-const BooleanField = ({ name }: { name: string }) => {
-	const [_, meta, helpers] = useField({ name, multiple: false });
-	const { initialValue } = meta;
-
-	useEffect(() => {
-		helpers.setValue(initialValue);
-	}, []);
-
-	const handleOnChange = (selected: SelectOption[]) => {
-		const value = selected?.[0]?.value;
-		if (value === undefined) {
-			helpers.setValue(undefined);
-		} else {
-			helpers.setValue(value);
-		}
-	};
-
-	return (
-		<Select
-			options={[
-				{ value: true, label: 'true' },
-				{ value: false, label: 'false' },
-			]}
-			value={initialValue === undefined ? [] : [{ value: initialValue, label: `${initialValue}` }]}
-			onChange={handleOnChange}
-			mode={SelectMode.SINGLE}
-		/>
-	);
-};
-
-const EnumField = ({ name, typeEnum }: { name: string; typeEnum: Enum }) => {
-	const [_, meta, helpers] = useField({ name, multiple: false });
-	const { initialValue } = meta;
-
-	useEffect(() => {
-		helpers.setValue(initialValue);
-	}, []);
-
-	const handleOnChange = (selected: SelectOption[]) => {
-		const value = selected?.[0]?.value;
-		if (value === undefined) {
-			helpers.setValue(undefined);
-		} else {
-			helpers.setValue(value);
-		}
-	};
-
-	const enumOptions = Array.from(typeEnum.values).map((v) => ({
-		label: v.name,
-		value: v.value,
-	}));
-
-	return (
-		<Select
-			options={enumOptions}
-			value={initialValue ? [{ value: initialValue, label: `${initialValue}` }] : []}
-			onChange={handleOnChange}
-			mode={SelectMode.SINGLE}
-		/>
-	);
-};
-
-const JSONField = ({ name }: { name: string }) => {
-	const [_, meta] = useField({ name, multiple: false });
-	const { initialValue } = meta;
-	return <code>{JSON.stringify(initialValue, null, 4)}</code>;
-};
-
 const getField = ({ field }: { field: EntityField }) => {
 	if (field.relationshipType) {
 		return <SelectField name={field.name} entity={field} />;
 	}
 
-	if (field.type === EntityFieldType.JSON) {
+	if (field.type === 'JSON') {
 		return <JSONField name={field.name} />;
 	}
 
-	if (field.type === EntityFieldType.BOOLEAN) {
+	if (field.type === 'Boolean') {
 		return <BooleanField name={field.name} />;
 	}
 
@@ -177,6 +58,17 @@ const DetailField = ({ field }: { field: EntityField }) => {
 				{field.name}
 			</label>
 			{getField({ field })}
+		</div>
+	);
+};
+
+const CustomField = ({ field }: { field: CustomField }) => {
+	const { selectedEntity } = useSelectedEntity();
+	if (!selectedEntity) throw new Error('There should always be a selected entity at this point.');
+
+	return (
+		<div className={styles.detailField}>
+			{field.component({ entity: selectedEntity, context: 'detail-form' })}
 		</div>
 	);
 };
@@ -207,7 +99,7 @@ const DetailForm = ({
 	isReadOnly,
 }: {
 	initialValues: Record<string, any>;
-	detailFields: EntityField[];
+	detailFields: (EntityField | CustomField)[];
 	onSubmit: (values: any, actions: FormikHelpers<any>) => void;
 	onCancel: () => void;
 	persistName: string;
@@ -219,7 +111,13 @@ const DetailForm = ({
 				<Form className={styles.detailFormContainer}>
 					<div className={styles.detailFieldList}>
 						{detailFields.map((field) => {
-							return <DetailField key={field.name} field={field} />;
+							if (field.type === 'custom') {
+								const { detailForm: show } = (field as CustomField).showOn ?? { detailForm: true };
+
+								return show ? <CustomField key={field.name} field={field as CustomField} /> : null;
+							} else {
+								return <DetailField key={field.name} field={field} />;
+							}
 						})}
 						<div className={styles.detailButtonContainer}>
 							<Button type="reset" disabled={isSubmitting}>
@@ -273,6 +171,16 @@ export const DetailPanel = () => {
 			(field.relationshipType && field.relationshipType !== 'MANY_TO_MANY') ||
 			(!field.relationshipType && field.name !== 'id' && !field.attributes?.isReadOnly)
 	);
+
+	// Merge any custom fields in at their appropriate indices.
+	// Let's check if there are custom fields to add
+	const customFieldsForEntity = customFields?.get(selectedEntity.name);
+	if (customFieldsForEntity) {
+		// Add the custom fields to the existing fields taking into account any supplied index
+		for (const field of customFieldsForEntity) {
+			formFields.splice(field.index ?? formFields.length, 0, field);
+		}
+	}
 
 	const persistName = `gw-${entity}-${id}`.toLowerCase();
 	const savedSessionState = useMemo((): ResultBaseType | undefined => {

--- a/src/packages/admin-ui-components/src/detail-panel/fields/boolean-field.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/fields/boolean-field.tsx
@@ -1,0 +1,33 @@
+import { useField } from 'formik';
+import { useEffect } from 'react';
+import { SelectOption, Select, SelectMode } from '../../multi-select';
+
+export const BooleanField = ({ name }: { name: string }) => {
+	const [_, meta, helpers] = useField({ name, multiple: false });
+	const { initialValue } = meta;
+
+	useEffect(() => {
+		helpers.setValue(initialValue);
+	}, []);
+
+	const handleOnChange = (selected: SelectOption[]) => {
+		const value = selected?.[0]?.value;
+		if (value === undefined) {
+			helpers.setValue(undefined);
+		} else {
+			helpers.setValue(value);
+		}
+	};
+
+	return (
+		<Select
+			options={[
+				{ value: true, label: 'true' },
+				{ value: false, label: 'false' },
+			]}
+			value={initialValue === undefined ? [] : [{ value: initialValue, label: `${initialValue}` }]}
+			onChange={handleOnChange}
+			mode={SelectMode.SINGLE}
+		/>
+	);
+};

--- a/src/packages/admin-ui-components/src/detail-panel/fields/enum-field.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/fields/enum-field.tsx
@@ -1,0 +1,36 @@
+import { useField } from 'formik';
+import { useEffect } from 'react';
+import { SelectOption, Select, SelectMode } from '../../multi-select';
+import { Enum } from '../../utils';
+
+export const EnumField = ({ name, typeEnum }: { name: string; typeEnum: Enum }) => {
+	const [_, meta, helpers] = useField({ name, multiple: false });
+	const { initialValue } = meta;
+
+	useEffect(() => {
+		helpers.setValue(initialValue);
+	}, []);
+
+	const handleOnChange = (selected: SelectOption[]) => {
+		const value = selected?.[0]?.value;
+		if (value === undefined) {
+			helpers.setValue(undefined);
+		} else {
+			helpers.setValue(value);
+		}
+	};
+
+	const enumOptions = Array.from(typeEnum.values).map((v) => ({
+		label: v.name,
+		value: v.value,
+	}));
+
+	return (
+		<Select
+			options={enumOptions}
+			value={initialValue ? [{ value: initialValue, label: `${initialValue}` }] : []}
+			onChange={handleOnChange}
+			mode={SelectMode.SINGLE}
+		/>
+	);
+};

--- a/src/packages/admin-ui-components/src/detail-panel/fields/index.ts
+++ b/src/packages/admin-ui-components/src/detail-panel/fields/index.ts
@@ -1,0 +1,4 @@
+export * from './boolean-field';
+export * from './enum-field';
+export * from './json-field';
+export * from './select-field';

--- a/src/packages/admin-ui-components/src/detail-panel/fields/json-field.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/fields/json-field.tsx
@@ -1,0 +1,7 @@
+import { useField } from 'formik';
+
+export const JSONField = ({ name }: { name: string }) => {
+	const [_, meta] = useField({ name, multiple: false });
+	const { initialValue } = meta;
+	return <code>{JSON.stringify(initialValue, null, 4)}</code>;
+};

--- a/src/packages/admin-ui-components/src/detail-panel/fields/select-field.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/fields/select-field.tsx
@@ -1,0 +1,54 @@
+import { useQuery } from '@apollo/client';
+import { useField } from 'formik';
+import { useEffect } from 'react';
+import { SelectOption, Select, SelectMode } from '../../multi-select';
+import { EntityField, useSchema } from '../../utils';
+import { getRelationshipQuery } from '../graphql';
+
+export const SelectField = ({ name, entity }: { name: string; entity: EntityField }) => {
+	const [_, meta, helpers] = useField({ name, multiple: false });
+	const { entityByType } = useSchema();
+	const { initialValue } = meta;
+	const relationshipEntityType = entityByType(entity.type);
+
+	useEffect(() => {
+		helpers.setValue(initialValue);
+	}, []);
+
+	const { data } = useQuery<{ result: Record<string, string>[] }>(
+		getRelationshipQuery(entity.type, relationshipEntityType?.summaryField),
+		{
+			variables: {
+				pagination: {
+					orderBy: relationshipEntityType
+						? {
+								[relationshipEntityType.summaryField as string]: 'ASC',
+						  }
+						: { id: 'ASC' },
+				},
+			},
+		}
+	);
+
+	const options = (data?.result ?? []).map<SelectOption>((item): SelectOption => {
+		const label = relationshipEntityType?.summaryField || 'id';
+		return { label: item[label], value: item.id };
+	});
+
+	const handleOnChange = (selected: SelectOption[]) => {
+		helpers.setValue(selected?.[0]);
+	};
+
+	return (
+		<Select
+			options={options}
+			value={initialValue ? [initialValue] : []}
+			onChange={handleOnChange}
+			mode={
+				entity.relationshipType === 'ONE_TO_ONE' || entity.relationshipType === 'MANY_TO_ONE'
+					? SelectMode.SINGLE
+					: SelectMode.MULTI
+			}
+		/>
+	);
+};

--- a/src/packages/admin-ui-components/src/table/component.tsx
+++ b/src/packages/admin-ui-components/src/table/component.tsx
@@ -70,8 +70,23 @@ const columnsForEntity = <T extends TableRowItem>(
 			: undefined,
 	}));
 
-	// Let's check if there are custom fields to add
-	for (const customField of customFields?.get(entity.name) || []) {
+	// Which custom fields do we need to show here?
+	const customFieldsToShow = (customFields?.get(entity.name) || []).filter((customField) => {
+		const { table: show } = customField.showOn ?? { table: true };
+		return show;
+	});
+
+	// Remove any fields that the user intends to replace with a custom field so
+	// their custom field indices are correct regardless of insertion order
+	for (const customField of customFieldsToShow) {
+		const index = entityColumns.findIndex((column) => column.name === customField.name);
+		if (index !== -1) {
+			entityColumns.splice(index, 1);
+		}
+	}
+
+	// Ok, now we can merge our custom fields in
+	for (const customField of customFieldsToShow) {
 		const { table: show } = customField.showOn ?? { table: true };
 		if (show) {
 			entityColumns.splice(customField.index ?? entityColumns.length, 0, {

--- a/src/packages/admin-ui-components/src/utils/use-schema.ts
+++ b/src/packages/admin-ui-components/src/utils/use-schema.ts
@@ -32,13 +32,7 @@ export enum AdminUIFilterType {
 	TEXT = 'TEXT',
 }
 
-export enum EntityFieldType {
-	BOOLEAN = 'Boolean',
-	ID = 'ID!',
-	OPTIONAL_ID = 'ID',
-	JSON = 'JSON',
-	// TODO: This needs to be extended for the other types
-}
+export type EntityFieldType = 'Boolean' | 'custom' | 'ID!' | 'ID' | 'JSON';
 
 export interface EntityField {
 	name: string;
@@ -58,9 +52,23 @@ export interface EntityAttributes {
 	isReadOnly?: boolean;
 }
 
-export interface CustomField extends EntityField {
+export interface CustomFieldArgs<T = unknown> {
+	entity: T;
+	context: 'table' | 'detail-form';
+}
+
+export interface CustomField<T = unknown> extends EntityField {
 	index?: number;
-	component: (entity: unknown) => JSX.Element;
+	type: 'custom';
+
+	component: (args: CustomFieldArgs<T>) => JSX.Element;
+
+	// Defines where the custom field should be shown. If you don't define anything
+	// the default is to show it in both the table and the detail form.
+	showOn?: {
+		table?: boolean;
+		detailForm?: boolean;
+	};
 }
 
 // @todo this needs typing correctly

--- a/src/packages/admin-ui/src/pages/list/component.tsx
+++ b/src/packages/admin-ui/src/pages/list/component.tsx
@@ -3,7 +3,6 @@ import { useQuery } from '@apollo/client';
 import { Outlet, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import {
-	DetailPanel,
 	Table,
 	useSchema,
 	PAGE_SIZE,
@@ -14,7 +13,6 @@ import {
 	TableRowItem,
 	routeFor,
 	RequestRefetchOptions,
-	EntityFieldType,
 	Header,
 } from '@exogee/graphweaver-admin-ui-components';
 import '@exogee/graphweaver-admin-ui-components/lib/index.css';
@@ -108,11 +106,10 @@ export const List = () => {
 		const { fields } = entityByName(entity);
 		for (const key in row) {
 			const field = fields.find((field) => field.name === key);
-			if (field?.type === EntityFieldType.JSON) {
+			if (field?.type === 'JSON') {
 				// We have an array let's stringify it so it can be displayed in the table
 				overrides[key as OverrideKey] = JSON.stringify(row[key as OverrideKey]);
-			}
-			if (field?.type === EntityFieldType.BOOLEAN) {
+			} else if (field?.type === 'Boolean') {
 				overrides[key as OverrideKey] = `${row[key as OverrideKey]}`;
 			}
 		}


### PR DESCRIPTION
We had custom fields already in the table, but not in the detail form.

This PR extends this ability so that custom fields can show in both the table, and the form.

**Breaking Change**: The arguments for custom fields have changed. Instead of just being `entity`, now it's `{ entity, context }` where context tells you the context you're rendering in.

If users specify `showOn` then the field only shows in the places they specify, while if they do not, it shows everywhere.

Users can also override default fields with custom fields by giving them the same name. At that point the custom field wins.

I also refactored the field components into separate files while I was in there, but this was not strictly related to this change.