### PR TITLE
Refactor / Made API for hiding custom fields more obvious

### DIFF
--- a/src/examples/rest/src/admin-ui/custom-fields/index.ts
+++ b/src/examples/rest/src/admin-ui/custom-fields/index.ts
@@ -9,6 +9,6 @@ customFields.set('Task', [
 		index: 3,
 		component: Link,
 
-		showOn: { table: true },
+		hideOnDetailForm: true,
 	},
 ]);

--- a/src/packages/admin-ui-components/src/detail-panel/component.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/component.tsx
@@ -112,9 +112,9 @@ const DetailForm = ({
 					<div className={styles.detailFieldList}>
 						{detailFields.map((field) => {
 							if (field.type === 'custom') {
-								const { detailForm: show } = (field as CustomField).showOn ?? { detailForm: true };
+								if ((field as CustomField).hideOnDetailForm) return null;
 
-								return show ? <CustomField key={field.name} field={field as CustomField} /> : null;
+								return <CustomField key={field.name} field={field as CustomField} />;
 							} else {
 								return <DetailField key={field.name} field={field} />;
 							}

--- a/src/packages/admin-ui-components/src/table/component.tsx
+++ b/src/packages/admin-ui-components/src/table/component.tsx
@@ -87,8 +87,7 @@ const columnsForEntity = <T extends TableRowItem>(
 
 	// Ok, now we can merge our custom fields in
 	for (const customField of customFieldsToShow) {
-		const { table: show } = customField.showOn ?? { table: true };
-		if (show) {
+		if (!customField.hideOnTable) {
 			entityColumns.splice(customField.index ?? entityColumns.length, 0, {
 				key: customField.name,
 				name: customField.name,

--- a/src/packages/admin-ui-components/src/utils/use-schema.ts
+++ b/src/packages/admin-ui-components/src/utils/use-schema.ts
@@ -63,12 +63,8 @@ export interface CustomField<T = unknown> extends EntityField {
 
 	component: (args: CustomFieldArgs<T>) => JSX.Element;
 
-	// Defines where the custom field should be shown. If you don't define anything
-	// the default is to show it in both the table and the detail form.
-	showOn?: {
-		table?: boolean;
-		detailForm?: boolean;
-	};
+	hideOnTable?: boolean;
+	hideOnDetailForm?: boolean;
 }
 
 // @todo this needs typing correctly


### PR DESCRIPTION
Currently the `showOn` API is a bit surprising. This makes it crystal clear that a custom field is shown by default everywhere, and that it can be hidden by setting hidden to `true` for the context in question.