### PR TITLE
GHI222: Scalar Bug

### DIFF
--- a/.github/workflows/scalars-end-to-end-tests.yml
+++ b/.github/workflows/scalars-end-to-end-tests.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  sqlite-end-to-end-tests:
+  scalars-end-to-end-tests:
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/scalars-end-to-end-tests.yml
+++ b/.github/workflows/scalars-end-to-end-tests.yml
@@ -1,0 +1,50 @@
+name: Scalars End to End Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  sqlite-end-to-end-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        env:
+          cache-name: cache-pnpm-modules
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
+
+      - uses: pnpm/action-setup@v2.2.4
+        with:
+          version: 8.6.9
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          cache: "pnpm"
+          cache-dependency-path: src/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm i
+
+      - name: Build CLI tool
+        run: pnpm build
+
+      - name: Test Scalars
+        working-directory: src/packages/end-to-end
+        timeout-minutes: 2
+        run: |
+          pnpm test-scalars
+
+        env:
+          CI: true

--- a/src/packages/auth-ui-components/package.json
+++ b/src/packages/auth-ui-components/package.json
@@ -34,7 +34,7 @@
 	},
 	"peerDependencies": {
 		"@exogee/graphweaver-admin-ui-components": "workspace:*",
-		"graphql": "16.6.0",
+		"graphql": "16.8.1",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
 		"react-router-dom": "6.4.3"

--- a/src/packages/cli/src/init/template.ts
+++ b/src/packages/cli/src/init/template.ts
@@ -29,7 +29,7 @@ export const makePackageJson = (projectName: string, backends: Backend[], versio
 			'reflect-metadata': '0.1.13',
 			'type-graphql': '2.0.0-beta.2',
 			'class-validator': '0.14.0',
-			graphql: '16.6.0',
+			graphql: '16.8.1',
 		},
 		devDependencies: {
 			'@types/node': '20.2.5',

--- a/src/packages/end-to-end/package.json
+++ b/src/packages/end-to-end/package.json
@@ -16,6 +16,7 @@
 		"test-mysql": "export DATEBASE=mysql && jest --runInBand -- api/mysql",
 		"test-postgres": "export DATABASE=postgres && jest --runInBand -- api/postgres",
 		"test-sqlite": "export DATABASE=sqlite && jest --runInBand --forceExit ---- api/sqlite",
+		"test-scalars": "jest --runInBand --forceExit ---- api/scalars",
 		"test-aws-cognito": "jest --runInBand --forceExit ---- api/aws-cognito",
 		"test-ui": "pnpm exec playwright test",
 		"version": "npm version --no-git-tag-version"

--- a/src/packages/end-to-end/src/__tests__/api/scalars/graphql-json.ts
+++ b/src/packages/end-to-end/src/__tests__/api/scalars/graphql-json.ts
@@ -1,0 +1,35 @@
+import 'reflect-metadata';
+import gql from 'graphql-tag';
+import assert from 'assert';
+import Graphweaver from '@exogee/graphweaver-server';
+import { Query, Resolver } from '@exogee/graphweaver';
+
+import { GraphQLJSON } from '@exogee/graphweaver-scalars';
+
+@Resolver()
+class JsonResolver {
+	@Query(() => GraphQLJSON)
+	async testJson(): Promise<{ test: string }> {
+		return {
+			test: 'test',
+		};
+	}
+}
+
+describe('GraphQL JSON Scalar Type', () => {
+	test('should not get error when requesting GraphQL Json scalar types', async () => {
+		const graphweaver = new Graphweaver({
+			resolvers: [JsonResolver],
+		});
+
+		const response = await graphweaver.server.executeOperation({
+			query: gql`
+				query {
+					testJson
+				}
+			`,
+		});
+		assert(response.body.kind === 'single');
+		expect(response.body.singleResult.data?.testJson).toMatchObject({ test: 'test' });
+	});
+});

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -737,7 +737,7 @@ importers:
     dependencies:
       '@apollo/client':
         specifier: 3.7.1
-        version: 3.7.1(graphql@16.6.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 3.7.1(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
       '@simplewebauthn/browser':
         specifier: 8.3.1
         version: 8.3.1
@@ -754,8 +754,8 @@ importers:
         specifier: 2.2.9
         version: 2.2.9(react@18.2.0)
       graphql:
-        specifier: 16.6.0
-        version: 16.6.0
+        specifier: 16.8.1
+        version: 16.8.1
       web3-token:
         specifier: 1.0.6
         version: 1.0.6(react@18.2.0)
@@ -1211,7 +1211,7 @@ importers:
     optionalDependencies:
       '@mikro-orm/knex':
         specifier: 5.7.14
-        version: 5.7.14(@mikro-orm/core@5.7.14)(pg@8.11.1)(sqlite3@5.1.6)
+        version: 5.7.14(@mikro-orm/core@5.7.14)(mysql2@3.5.2)(pg@8.11.1)
       '@mikro-orm/mysql':
         specifier: 5.7.14
         version: 5.7.14(@mikro-orm/core@5.7.14)(pg@8.11.1)
@@ -1484,42 +1484,6 @@ packages:
       graphql: 14.x || 15.x || 16.x
     dependencies:
       graphql: 16.8.1
-    dev: false
-
-  /@apollo/client@3.7.1(graphql@16.6.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-xu5M/l7p9gT9Fx7nF3AQivp0XukjB7TM7tOd5wifIpI8RskYveL4I+rpTijzWrnqCPZabkbzJKH7WEAKdctt9w==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-      graphql-ws: ^5.5.5
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-      subscriptions-transport-ws: ^0.9.0 || ^0.11.0
-    peerDependenciesMeta:
-      graphql-ws:
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-      subscriptions-transport-ws:
-        optional: true
-    dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
-      '@wry/context': 0.7.3
-      '@wry/equality': 0.5.6
-      '@wry/trie': 0.3.2
-      graphql: 16.6.0
-      graphql-tag: 2.12.6(graphql@16.6.0)
-      hoist-non-react-statics: 3.3.2
-      optimism: 0.16.2
-      prop-types: 15.8.1
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      response-iterator: 0.2.6
-      symbol-observable: 4.0.0
-      ts-invariant: 0.10.3
-      tslib: 2.6.0
-      zen-observable-ts: 1.2.5
     dev: false
 
   /@apollo/client@3.7.1(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
@@ -5824,14 +5788,6 @@ packages:
       value-or-promise: 1.0.12
     dev: false
 
-  /@graphql-typed-document-node/core@3.2.0(graphql@16.6.0):
-    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      graphql: 16.6.0
-    dev: false
-
   /@graphql-typed-document-node/core@3.2.0(graphql@16.8.1):
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
@@ -6746,7 +6702,7 @@ packages:
         optional: true
     dependencies:
       '@mikro-orm/core': 5.7.14(@mikro-orm/mysql@5.7.14)(@mikro-orm/postgresql@5.7.14)(@mikro-orm/sqlite@5.7.14)
-      '@mikro-orm/knex': 5.7.14(@mikro-orm/core@5.7.14)(pg@8.11.1)(sqlite3@5.1.6)
+      '@mikro-orm/knex': 5.7.14(@mikro-orm/core@5.7.14)(mysql2@3.5.2)(pg@8.11.1)
       pg: 8.11.1
     transitivePeerDependencies:
       - better-sqlite3
@@ -12833,16 +12789,6 @@ packages:
       graphql: 16.8.1
       iterall: 1.3.0
 
-  /graphql-tag@2.12.6(graphql@16.6.0):
-    resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-    dependencies:
-      graphql: 16.6.0
-      tslib: 2.6.0
-    dev: false
-
   /graphql-tag@2.12.6(graphql@16.8.1):
     resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
     engines: {node: '>=10'}
@@ -12866,11 +12812,6 @@ packages:
       graphql: '>=0.11 <=16'
     dependencies:
       graphql: 16.8.1
-
-  /graphql@16.6.0:
-    resolution: {integrity: sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==}
-    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
-    dev: false
 
   /graphql@16.8.1:
     resolution: {integrity: sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==}


### PR DESCRIPTION
This PR addresses the issue: https://github.com/exogee-technology/graphweaver/issues/222

To resolve we need to make sure that we are using v16.8.1 of GraphQL or higher as version v16.6.0 was causing the scalar types to become unregistered.

This also adds a test for the JSON scalar type to catch this in the future.