### PR TITLE
Fixed error where id cannot be null

### DIFF
--- a/src/packages/graphweaver-aws/src/cognito/resolver.ts
+++ b/src/packages/graphweaver-aws/src/cognito/resolver.ts
@@ -41,7 +41,8 @@ export const createAwsCognitoUserResolver = ({
 			return (await getManyUsers(client, UserPoolId, filter)).map(mapId);
 		},
 		create: async ({ client, UserPoolId }, entity) => {
-			return mapId(await createUser(client, UserPoolId, entity));
+			const result = await createUser(client, UserPoolId, entity);
+			return mapId(result.User);
 		},
 		update: async ({ client, UserPoolId }, entityId: string, entityWithChanges) => {
 			const existingUser = await getOneUser(client, UserPoolId, entityId);


### PR DESCRIPTION
Steps to reproduce:
1. Create a new cognito user
2. Error shown with message 'Cannot return null for non-nullable field CognitoUser.id'