### PR TITLE
Fix / Allow Formik Hooks in Custom Fields

### DIFF
--- a/src/packages/admin-ui-components/build.js
+++ b/src/packages/admin-ui-components/build.js
@@ -21,6 +21,7 @@ const flagIncludes = (flagName) => !!flags.find((flag) => flag === `--${flagName
 			// And these can't because they're peer dependencies, and we need to use
 			// the version supplied by the ultimate consumer of the library.
 			'graphql',
+			'formik',
 			'react',
 			'react-dom',
 			'react-router',

--- a/src/packages/admin-ui-components/package.json
+++ b/src/packages/admin-ui-components/package.json
@@ -37,6 +37,7 @@
 		"react-hot-toast": "2.4.1"
 	},
 	"peerDependencies": {
+		"formik": "2.2.9",
 		"graphql": "16.8.1",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",

--- a/src/packages/admin-ui/package.json
+++ b/src/packages/admin-ui/package.json
@@ -22,6 +22,7 @@
 		"@apollo/client": "3.7.1",
 		"@exogee/graphweaver-admin-ui-components": "workspace:*",
 		"classnames": "2.3.2",
+		"formik": "2.2.9",
 		"graphql": "16.8.1",
 		"pluralize": "8.0.0",
 		"prop-types": "15.8.1",

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -367,9 +367,6 @@ importers:
       dotenv:
         specifier: 16.0.0
         version: 16.0.0
-      formik:
-        specifier: 2.2.9
-        version: 2.2.9(react@18.2.0)
       got:
         specifier: 11.8.5
         version: 11.8.5

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -367,6 +367,9 @@ importers:
       dotenv:
         specifier: 16.0.0
         version: 16.0.0
+      formik:
+        specifier: 2.2.9
+        version: 2.2.9(react@18.2.0)
       got:
         specifier: 11.8.5
         version: 11.8.5
@@ -510,6 +513,9 @@ importers:
       classnames:
         specifier: 2.3.2
         version: 2.3.2
+      formik:
+        specifier: 2.2.9
+        version: 2.2.9(react@18.2.0)
       graphql:
         specifier: 16.8.1
         version: 16.8.1


### PR DESCRIPTION
This PR:

- Moves Formik to an external peer dependency of admin-ui-components.
- It also adds it to package.json for `admin-ui` so that it's there for Vite to find as code in `admin-ui-components` uses it.
- This dedupes the dependency so that the react context is shared between all the components correctly.
- Code in custom fields that wants to `useFormikContext` on the detail form now gets values in the return.