### PR TITLE
Feature / Detail Field Labels as Component

### DIFF
--- a/src/packages/admin-ui-components/src/detail-panel-field-label/component.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel-field-label/component.tsx
@@ -1,0 +1,7 @@
+import styles from './styles.module.css';
+
+export const DetailPanelFieldLabel = ({ fieldName }: { fieldName: string }) => (
+	<label htmlFor={fieldName} className={styles.detailPanelFieldLabel}>
+		{fieldName}
+	</label>
+);

--- a/src/packages/admin-ui-components/src/detail-panel-field-label/index.ts
+++ b/src/packages/admin-ui-components/src/detail-panel-field-label/index.ts
@@ -1,0 +1,1 @@
+export * from './component';

--- a/src/packages/admin-ui-components/src/detail-panel-field-label/styles.module.css
+++ b/src/packages/admin-ui-components/src/detail-panel-field-label/styles.module.css
@@ -1,0 +1,12 @@
+.detailPanelFieldLabel {
+	flex: none;
+
+	font-family: 'Inter';
+	font-style: normal;
+	font-size: 14px;
+	line-height: 150%;
+	/* identical to box height, or 21px */
+
+	color: rgba(237, 232, 242, 0.6);
+	font-weight: 600;
+}

--- a/src/packages/admin-ui-components/src/detail-panel/component.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/component.tsx
@@ -23,6 +23,7 @@ import { generateCreateEntityMutation, generateUpdateEntityMutation } from './gr
 
 import styles from './styles.module.css';
 import { BooleanField, EnumField, JSONField, SelectField } from './fields';
+import { DetailPanelFieldLabel } from '../detail-panel-field-label';
 
 interface ResultBaseType {
 	id: string;
@@ -54,9 +55,8 @@ const getField = ({ field }: { field: EntityField }) => {
 const DetailField = ({ field }: { field: EntityField }) => {
 	return (
 		<div className={styles.detailField}>
-			<label htmlFor={field.name} className={styles.fieldLabel}>
-				{field.name}
-			</label>
+			<DetailPanelFieldLabel fieldName={field.name} />
+
 			{getField({ field })}
 		</div>
 	);

--- a/src/packages/admin-ui-components/src/detail-panel/styles.module.css
+++ b/src/packages/admin-ui-components/src/detail-panel/styles.module.css
@@ -45,19 +45,6 @@
 	gap: 10px;
 }
 
-.fieldLabel {
-	flex: none;
-
-	font-family: 'Inter';
-	font-style: normal;
-	font-size: 14px;
-	line-height: 150%;
-	/* identical to box height, or 21px */
-
-	color: rgba(237, 232, 242, 0.6);
-	font-weight: 600;
-}
-
 .textInputField,
 .selectField {
 	box-sizing: border-box;
@@ -106,9 +93,9 @@
 }
 
 .link {
-	background: none!important;
+	background: none !important;
 	border: none;
-	padding: 0!important;
+	padding: 0 !important;
 	font-family: 'Inter';
 	font-style: normal;
 	color: white;

--- a/src/packages/admin-ui-components/src/index.ts
+++ b/src/packages/admin-ui-components/src/index.ts
@@ -3,6 +3,7 @@ export * from './apollo';
 export * from './assets';
 export * from './button';
 export * from './detail-panel';
+export * from './detail-panel-field-label';
 export * from './header';
 export * from './layouts';
 export * from './loader';


### PR DESCRIPTION
Moved Detail Field Label into its own component so people building custom fields for the detail panel can easily include labels that match our styling.

Also ran Prettier on the existing styles.module.css file for the DetailPanel component.