### PR TITLE
Improve input types on relationship field

### DIFF
--- a/src/packages/core/src/decorators/relationship-field.ts
+++ b/src/packages/core/src/decorators/relationship-field.ts
@@ -1,5 +1,4 @@
 import { getMetadataStorage } from 'type-graphql';
-import { ReturnTypeFunc } from 'type-graphql/dist/decorators/types';
 import { findType } from 'type-graphql/dist/helpers/findType';
 import { ObjectClassMetadata } from 'type-graphql/dist/metadata/definitions/object-class-metdata';
 import { BaseLoaders } from '../base-loader';
@@ -23,6 +22,14 @@ type RelationshipFieldOptions<D> = {
 	id?: (keyof D & string) | ((dataEntity: D) => string | number | undefined);
 	nullable?: boolean;
 };
+
+interface ClassType<T extends GraphQLEntity<BaseDataEntity>> {
+	new (...args: any[]): T;
+}
+interface RecursiveArray<TValue> extends Array<RecursiveArray<TValue> | TValue> {}
+type TypeValue = ClassType<GraphQLEntity<BaseDataEntity>>;
+type ReturnTypeFuncValue = TypeValue | RecursiveArray<TypeValue>;
+type ReturnTypeFunc = () => ReturnTypeFuncValue;
 
 export function RelationshipField<
 	G extends GraphQLEntity<D> = any,


### PR DESCRIPTION
This PR ensures that the Entity passed to the relationship type is of type `GraphQLEntity<T>`

![Screenshot 2023-12-22 at 10 55 33 am](https://github.com/exogee-technology/graphweaver/assets/85143753/9b731651-1fc8-4ced-9d89-e149fe9ba997)

If you pass a data entity by mistake you will receive an error as shown above.