### PR TITLE
Fix React Hook order-related frontend crash

### DIFF
--- a/src/packages/admin-ui-components/src/table/component.tsx
+++ b/src/packages/admin-ui-components/src/table/component.tsx
@@ -21,6 +21,10 @@ import { ApolloError } from '@apollo/client';
 
 import { customFields } from 'virtual:graphweaver-user-supplied-custom-fields';
 
+// Without stopping propagation on our links, the grid will be notified about the click,
+// which is not what we want. We want to navigate and not let the grid handle it
+const gobbleEvent = (e: MouseEvent<HTMLAnchorElement>) => e.stopPropagation();
+
 const columnsForEntity = <T extends TableRowItem>(
 	entity: Entity,
 	entityByType: (type: string) => Entity
@@ -36,9 +40,6 @@ const columnsForEntity = <T extends TableRowItem>(
 		// We only need a formatter for relationships.
 		formatter: field.relationshipType
 			? ({ row }: FormatterProps<T, unknown>) => {
-					// Without stopping propagation on our links, the grid will be notified about the click,
-					// which is not what we want. We want to navigate and not let the grid handle it
-					const gobbleEvent = (e: MouseEvent<HTMLAnchorElement>) => e.stopPropagation();
 
 					const value = row[field.name as keyof typeof row];
 					const relatedEntity = entityByType(field.type);

--- a/src/packages/admin-ui-components/src/table/component.tsx
+++ b/src/packages/admin-ui-components/src/table/component.tsx
@@ -38,10 +38,8 @@ const columnsForEntity = <T extends TableRowItem>(
 			? ({ row }: FormatterProps<T, unknown>) => {
 					// Without stopping propagation on our links, the grid will be notified about the click,
 					// which is not what we want. We want to navigate and not let the grid handle it
-					const gobbleEvent = useCallback(
-						(e: MouseEvent<HTMLAnchorElement>) => e.stopPropagation(),
-						[]
-					);
+					const gobbleEvent = (e: MouseEvent<HTMLAnchorElement>) => e.stopPropagation();
+
 					const value = row[field.name as keyof typeof row];
 					const relatedEntity = entityByType(field.type);
 

--- a/src/packages/admin-ui-components/src/table/component.tsx
+++ b/src/packages/admin-ui-components/src/table/component.tsx
@@ -40,7 +40,6 @@ const columnsForEntity = <T extends TableRowItem>(
 		// We only need a formatter for relationships.
 		formatter: field.relationshipType
 			? ({ row }: FormatterProps<T, unknown>) => {
-
 					const value = row[field.name as keyof typeof row];
 					const relatedEntity = entityByType(field.type);
 


### PR DESCRIPTION
This PR refactors out the use of a React hook in logic that is conditionally run. Under some specific circumstances (for example the recreation steps outlined in https://github.com/exogee-technology/graphweaver/issues/248) this can cause the UI to crash with a React hook order-related error.