### PR TITLE
Version 0.2.14

### DIFF
--- a/src/examples/aws-cognito/package.json
+++ b/src/examples/aws-cognito/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-aws-cognito",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"license": "MIT",
 	"description": "Example of connecting to AWS Cognito",
 	"main": "lib/index.js",

--- a/src/examples/databases/package.json
+++ b/src/examples/databases/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-databases",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"license": "MIT",
 	"private": true,
 	"description": "Example of connecting a MySQL and PostgreSQL database together.",

--- a/src/examples/eventbrite/package.json
+++ b/src/examples/eventbrite/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-eventbrite",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"license": "MIT",
 	"private": true,
 	"description": "Example of using @exogee/graphweaver to connect EventBrite.",

--- a/src/examples/mailchimp/package.json
+++ b/src/examples/mailchimp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-mailchimp",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"license": "MIT",
 	"private": true,
 	"description": "Example of connecting Mailchimp.",

--- a/src/examples/rest/package.json
+++ b/src/examples/rest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-rest",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"license": "MIT",
 	"private": true,
 	"description": "Example of connecting a Rest API with a MySQL database.",

--- a/src/examples/xero/package.json
+++ b/src/examples/xero/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-xero",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"license": "MIT",
 	"private": true,
 	"description": "Example of using @exogee/graphweaver to connect two Xero instances",

--- a/src/packages/admin-ui-components/package.json
+++ b/src/packages/admin-ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-admin-ui-components",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "Components from Graphweaver's admin UI which you can use in your projects as you like",
 	"license": "MIT",
 	"type": "module",

--- a/src/packages/admin-ui/package.json
+++ b/src/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-admin-ui",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"type": "module",
 	"main": "dist/main.js",
 	"types": "src/main.tsx",

--- a/src/packages/auth-ui-components/package.json
+++ b/src/packages/auth-ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-auth-ui-components",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "Components from Graphweaver's Auth UI which you can use in your projects as you like",
 	"license": "MIT",
 	"type": "module",

--- a/src/packages/auth/package.json
+++ b/src/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-auth",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "Row-Level Security support for @exogee/graphweaver",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/builder/package.json
+++ b/src/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-builder",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "A tool for building and running Graphweaver projects",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/cli/package.json
+++ b/src/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "graphweaver",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "A tool for managing, running, debugging and building Graphweaver projects",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/config/package.json
+++ b/src/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-config",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "Retrieve and parse Graphweaver configurations",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "Graphweaver Core Package",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/end-to-end/package.json
+++ b/src/packages/end-to-end/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-end-to-end",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "Graphweaver Test Suite",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/graphweaver-aws/package.json
+++ b/src/packages/graphweaver-aws/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-aws",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"main": "lib/index.js",
 	"source": "src/index.ts",
 	"directories": {

--- a/src/packages/logger/package.json
+++ b/src/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/logger",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "Common logging output for Exogee projects",
 	"license": "MIT",
 	"directories": {

--- a/src/packages/mikroorm/package.json
+++ b/src/packages/mikroorm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-mikroorm",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "MikroORM backend for @exogee/graphweaver",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/rest/package.json
+++ b/src/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-rest",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "RESTful backend for @exogee/graphweaver",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/scalars/package.json
+++ b/src/packages/scalars/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-scalars",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "Common scalar types for use with @exogee/graphweaver",
 	"license": "MIT",
 	"main": "lib/index.js",

--- a/src/packages/server/package.json
+++ b/src/packages/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-server",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "Server support for @exogee/graphweaver",
 	"license": "MIT",
 	"scripts": {

--- a/src/packages/vite-plugin-graphweaver/package.json
+++ b/src/packages/vite-plugin-graphweaver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vite-plugin-graphweaver",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "A vite plugin for use with @exogee/graphweaver's admin UI",
 	"license": "MIT",
 	"main": "lib/index.js",

--- a/src/packages/xero/package.json
+++ b/src/packages/xero/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-xero",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "Xero backend for @exogee/graphweaver",
 	"license": "MIT",
 	"scripts": {

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 overrides:
   d3-color: 3.1.0
   '@babel/traverse': 7.23.2
@@ -80,10 +76,10 @@ importers:
         version: link:../../packages/server
       '@mikro-orm/core':
         specifier: 5.7.14
-        version: 5.7.14(@mikro-orm/mysql@5.7.14)
+        version: 5.7.14(@mikro-orm/mysql@5.7.14)(@mikro-orm/postgresql@5.7.14)(@mikro-orm/sqlite@5.7.14)
       '@mikro-orm/mysql':
         specifier: 5.7.14
-        version: 5.7.14(@mikro-orm/core@5.7.14)
+        version: 5.7.14(@mikro-orm/core@5.7.14)(pg@8.11.1)
       class-validator:
         specifier: 0.14.0
         version: 0.14.0
@@ -360,10 +356,10 @@ importers:
         version: link:../../packages/server
       '@mikro-orm/core':
         specifier: 5.7.14
-        version: 5.7.14(@mikro-orm/mysql@5.7.14)
+        version: 5.7.14(@mikro-orm/mysql@5.7.14)(@mikro-orm/postgresql@5.7.14)(@mikro-orm/sqlite@5.7.14)
       '@mikro-orm/mysql':
         specifier: 5.7.14
-        version: 5.7.14(@mikro-orm/core@5.7.14)
+        version: 5.7.14(@mikro-orm/core@5.7.14)(pg@8.11.1)
       class-validator:
         specifier: 0.14.0
         version: 0.14.0
@@ -5463,52 +5459,6 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: false
 
-  /@mikro-orm/core@5.7.14(@mikro-orm/mysql@5.7.14):
-    resolution: {integrity: sha512-og2TJ4mRdGKF8ok/xSdGNbznm+WFF6VJosJnneulmY4VirRNfDfp7uNPBOinewigS4Q8Ntdirmponx4KrOoMBg==}
-    engines: {node: '>= 14.0.0'}
-    peerDependencies:
-      '@mikro-orm/better-sqlite': ^5.0.0
-      '@mikro-orm/entity-generator': ^5.0.0
-      '@mikro-orm/mariadb': ^5.0.0
-      '@mikro-orm/migrations': ^5.0.0
-      '@mikro-orm/migrations-mongodb': ^5.0.0
-      '@mikro-orm/mongodb': ^5.0.0
-      '@mikro-orm/mysql': ^5.0.0
-      '@mikro-orm/postgresql': ^5.0.0
-      '@mikro-orm/seeder': ^5.0.0
-      '@mikro-orm/sqlite': ^5.0.0
-    peerDependenciesMeta:
-      '@mikro-orm/better-sqlite':
-        optional: true
-      '@mikro-orm/entity-generator':
-        optional: true
-      '@mikro-orm/mariadb':
-        optional: true
-      '@mikro-orm/migrations':
-        optional: true
-      '@mikro-orm/migrations-mongodb':
-        optional: true
-      '@mikro-orm/mongodb':
-        optional: true
-      '@mikro-orm/mysql':
-        optional: true
-      '@mikro-orm/postgresql':
-        optional: true
-      '@mikro-orm/seeder':
-        optional: true
-      '@mikro-orm/sqlite':
-        optional: true
-    dependencies:
-      '@mikro-orm/mysql': 5.7.14(@mikro-orm/core@5.7.14)
-      acorn-loose: 8.3.0
-      acorn-walk: 8.2.0
-      dotenv: 16.3.1
-      fs-extra: 11.1.1
-      globby: 11.1.0
-      mikro-orm: 5.7.14
-      reflect-metadata: 0.1.13
-    dev: false
-
   /@mikro-orm/core@5.7.14(@mikro-orm/mysql@5.7.14)(@mikro-orm/postgresql@5.7.14)(@mikro-orm/sqlite@5.7.14):
     resolution: {integrity: sha512-og2TJ4mRdGKF8ok/xSdGNbznm+WFF6VJosJnneulmY4VirRNfDfp7uNPBOinewigS4Q8Ntdirmponx4KrOoMBg==}
     engines: {node: '>= 14.0.0'}
@@ -5555,48 +5505,6 @@ packages:
       globby: 11.1.0
       mikro-orm: 5.7.14
       reflect-metadata: 0.1.13
-
-  /@mikro-orm/knex@5.7.14(@mikro-orm/core@5.7.14)(mysql2@3.5.2):
-    resolution: {integrity: sha512-dLw80JiOfQ6YBtKXI3j0C31lYfbWlytZUpXFM4tEKlMbAMmSbPqDgZpiF3luxBKTg3JpsnGSK0urBOxL1c/m+g==}
-    engines: {node: '>= 14.0.0'}
-    peerDependencies:
-      '@mikro-orm/core': ^5.0.0
-      '@mikro-orm/entity-generator': ^5.0.0
-      '@mikro-orm/migrations': ^5.0.0
-      better-sqlite3: '*'
-      mssql: '*'
-      mysql: '*'
-      mysql2: '*'
-      pg: '*'
-      sqlite3: '*'
-    peerDependenciesMeta:
-      '@mikro-orm/entity-generator':
-        optional: true
-      '@mikro-orm/migrations':
-        optional: true
-      better-sqlite3:
-        optional: true
-      mssql:
-        optional: true
-      mysql:
-        optional: true
-      mysql2:
-        optional: true
-      pg:
-        optional: true
-      sqlite3:
-        optional: true
-    dependencies:
-      '@mikro-orm/core': 5.7.14(@mikro-orm/mysql@5.7.14)
-      fs-extra: 11.1.1
-      knex: 2.5.1(mysql2@3.5.2)(pg@8.11.1)
-      mysql2: 3.5.2
-      sqlstring: 2.3.3
-    transitivePeerDependencies:
-      - pg-native
-      - supports-color
-      - tedious
-    dev: false
 
   /@mikro-orm/knex@5.7.14(@mikro-orm/core@5.7.14)(mysql2@3.5.2)(pg@8.11.1):
     resolution: {integrity: sha512-dLw80JiOfQ6YBtKXI3j0C31lYfbWlytZUpXFM4tEKlMbAMmSbPqDgZpiF3luxBKTg3JpsnGSK0urBOxL1c/m+g==}
@@ -5681,36 +5589,6 @@ packages:
       - pg-native
       - supports-color
       - tedious
-
-  /@mikro-orm/mysql@5.7.14(@mikro-orm/core@5.7.14):
-    resolution: {integrity: sha512-6VfVOMhKcqM72p197G9n+3suWx7fuaoKD4Fcl3rjILkiSS8uFNutgCoRdrjg/2TMEZSgywkZdorwVfPyH+1kbw==}
-    engines: {node: '>= 14.0.0'}
-    peerDependencies:
-      '@mikro-orm/core': ^5.0.0
-      '@mikro-orm/entity-generator': ^5.0.0
-      '@mikro-orm/migrations': ^5.0.0
-      '@mikro-orm/seeder': ^5.0.0
-    peerDependenciesMeta:
-      '@mikro-orm/entity-generator':
-        optional: true
-      '@mikro-orm/migrations':
-        optional: true
-      '@mikro-orm/seeder':
-        optional: true
-    dependencies:
-      '@mikro-orm/core': 5.7.14(@mikro-orm/mysql@5.7.14)
-      '@mikro-orm/knex': 5.7.14(@mikro-orm/core@5.7.14)(mysql2@3.5.2)
-      mysql2: 3.5.2
-    transitivePeerDependencies:
-      - better-sqlite3
-      - mssql
-      - mysql
-      - pg
-      - pg-native
-      - sqlite3
-      - supports-color
-      - tedious
-    dev: false
 
   /@mikro-orm/mysql@5.7.14(@mikro-orm/core@5.7.14)(pg@8.11.1):
     resolution: {integrity: sha512-6VfVOMhKcqM72p197G9n+3suWx7fuaoKD4Fcl3rjILkiSS8uFNutgCoRdrjg/2TMEZSgywkZdorwVfPyH+1kbw==}
@@ -18329,3 +18207,7 @@ packages:
       compress-commons: 4.1.1
       readable-stream: 3.6.2
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
New in this version:
- Disable readonly fields and ID fields from editing
- Default user name for the database import wizard
- The types output location is now done via config passed to Graphweaver and not as a cli flag
- The default location for outputting the types file is ./src/frontend/types.ts