### PR TITLE
Introspection: Correct Casing for Bidirectional Relationships

### DIFF
--- a/src/packages/mikroorm/src/introspection/generate.ts
+++ b/src/packages/mikroorm/src/introspection/generate.ts
@@ -57,14 +57,14 @@ const generateBidirectionalRelations = (metadata: EntityMetadata[]): void => {
 				if (inverseProp) inverseProp.inversedBy = newProp.name;
 
 				if (prop.reference === ReferenceType.MANY_TO_ONE) {
-					const name = pascalToCamelCaseString(meta.tableName);
+					const name = pascalToCamelCaseString(meta.className);
 					newProp.name = pluralize(name);
 					newProp.reference = ReferenceType.ONE_TO_MANY;
 				} else if (prop.reference === ReferenceType.ONE_TO_ONE && !prop.mappedBy) {
 					newProp.reference = ReferenceType.ONE_TO_ONE;
 					newProp.nullable = true;
 				} else if (prop.reference === ReferenceType.MANY_TO_MANY && !prop.mappedBy) {
-					const name = pascalToCamelCaseString(meta.tableName);
+					const name = pascalToCamelCaseString(meta.className);
 					newProp.name = pluralize(name);
 					newProp.reference = ReferenceType.MANY_TO_MANY;
 				} else {


### PR DESCRIPTION
This PR added GHI 251:

https://github.com/exogee-technology/graphweaver/issues/251

We used `tableName` to name the relationship but this can be in any casing format. Instead, we can use `classname` which is normalised to Pascal casing when the database table is read. From here we can convert to CamelCase.