### PR TITLE
Add JIRA Linker bot

### DIFF
--- a/.github/workflows/jira-linker-and-linter-bot.yml
+++ b/.github/workflows/jira-linker-and-linter-bot.yml
@@ -9,7 +9,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           jira-token: ${{ secrets.JIRA_TOKEN }}
-          jira-user: kevin.brown
+          jira-user: ${{ secrets.JIRA_USER }}
           jira-base-url: https://exogee.atlassian.net
           skip-branches: "^(production|master|main|staging|development)$"
           skip-comments: true

--- a/.github/workflows/jira-linker-and-linter-bot.yml
+++ b/.github/workflows/jira-linker-and-linter-bot.yml
@@ -1,0 +1,14 @@
+name: action-jira-linker-and-linter
+on: [pull_request]
+
+jobs:
+  action-jira-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: btwrk/action-jira-linter@v1.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          jira-token: ${{ secrets.JIRA_TOKEN }}
+          jira-base-url: https://exogee.atlassian.net
+          skip-branches: "^(production|master|main|staging|development)$"
+          skip-comments: true

--- a/.github/workflows/jira-linker-and-linter-bot.yml
+++ b/.github/workflows/jira-linker-and-linter-bot.yml
@@ -9,6 +9,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           jira-token: ${{ secrets.JIRA_TOKEN }}
+          jira-user: kevin.brown
           jira-base-url: https://exogee.atlassian.net
           skip-branches: "^(production|master|main|staging|development)$"
           skip-comments: true

--- a/.github/workflows/jira-linker.yml
+++ b/.github/workflows/jira-linker.yml
@@ -5,9 +5,13 @@ jobs:
   action-jira-linker:
     runs-on: ubuntu-latest
     steps:
-      - uses: exogee-technology/action-jira-linker@v1.0.0
+      - uses: exogee-technology/action-jira-linker@v1.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           jira-token: ${{ secrets.JIRA_TOKEN }}
           jira-user: ${{ secrets.JIRA_USER }}
           jira-base-url: https://exogee.atlassian.net
+          comment-header: |
+            If you work at Exogee, you can find more information about this pull request in JIRA.
+
+            ---

--- a/.github/workflows/jira-linker.yml
+++ b/.github/workflows/jira-linker.yml
@@ -5,7 +5,7 @@ jobs:
   action-jira-linker:
     runs-on: ubuntu-latest
     steps:
-      - uses: exogee-technology/action-jira-linker@0.0.1
+      - uses: exogee-technology/action-jira-linker@1.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           jira-token: ${{ secrets.JIRA_TOKEN }}

--- a/.github/workflows/jira-linker.yml
+++ b/.github/workflows/jira-linker.yml
@@ -5,7 +5,7 @@ jobs:
   action-jira-linker:
     runs-on: ubuntu-latest
     steps:
-      - uses: exogee-technology/action-jira-linker@1.0.0
+      - uses: exogee-technology/action-jira-linker@v1.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           jira-token: ${{ secrets.JIRA_TOKEN }}

--- a/.github/workflows/jira-linker.yml
+++ b/.github/workflows/jira-linker.yml
@@ -5,7 +5,7 @@ jobs:
   action-jira-linker:
     runs-on: ubuntu-latest
     steps:
-      - uses: exogee-technology/action-jira-linker
+      - uses: exogee-technology/action-jira-linker@0.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           jira-token: ${{ secrets.JIRA_TOKEN }}

--- a/.github/workflows/jira-linker.yml
+++ b/.github/workflows/jira-linker.yml
@@ -1,15 +1,13 @@
-name: action-jira-linker-and-linter
+name: action-jira-linker
 on: [pull_request]
 
 jobs:
-  action-jira-linter:
+  action-jira-linker:
     runs-on: ubuntu-latest
     steps:
-      - uses: btwrk/action-jira-linter@v1.0.1
+      - uses: exogee-technology/action-jira-linker
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           jira-token: ${{ secrets.JIRA_TOKEN }}
           jira-user: ${{ secrets.JIRA_USER }}
           jira-base-url: https://exogee.atlassian.net
-          skip-branches: "^(production|master|main|staging|development)$"
-          skip-comments: true


### PR DESCRIPTION
It'd be great to have a link back to the Jira issue for any PR that specifies an issue key. I found a bot that supposedly does this, so let's test it out.