### PR TITLE
Fix / Duplicate GitHub Actions Job Name

### DIFF
--- a/.github/workflows/windows-end-to-end-tests.yml
+++ b/.github/workflows/windows-end-to-end-tests.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  sqlite-end-to-end-tests:
+  windows-end-to-end-tests:
     runs-on: windows-latest
     defaults:
       run:


### PR DESCRIPTION
While working on the Jira Issue Linker Bot I noticed there's a duplicate job name in our actions. This PR updates the job name for the Windows end to end tests to reflect what's happening in the actions file.