### PR TITLE
Introspection: Check for unique foreign keys

### DIFF
--- a/src/packages/mikroorm/src/introspection/generate.ts
+++ b/src/packages/mikroorm/src/introspection/generate.ts
@@ -141,9 +141,9 @@ const assertUniqueForeignKeys = (table: DatabaseTable): void => {
 		const { localTableName, referencedTableName, columnNames, referencedColumnNames } = foreignKey;
 		const serializedValue = JSON.stringify({
 			localTableName,
-			columnNames,
+			columnNames: columnNames.sort(),
 			referencedTableName,
-			referencedColumnNames,
+			referencedColumnNames: referencedColumnNames.sort(),
 		});
 
 		if (uniqueForeignKeys.has(serializedValue)) {


### PR DESCRIPTION
Introspection will fail if the database has duplicate foreign keys.

This PR checks for any duplicates and alerts the dev to the table and column where the issue was found:

![Screenshot 2024-03-12 at 2 28 04 pm](https://github.com/exogee-technology/graphweaver/assets/85143753/b4186b84-ddd9-4928-82be-25710e932aff)
