### PR TITLE
Fix / Log Queries

### DIFF
--- a/src/packages/server/src/plugins/log-requests.ts
+++ b/src/packages/server/src/plugins/log-requests.ts
@@ -7,9 +7,12 @@ export const LogRequests: ApolloServerPlugin = {
 	async requestDidStart({ request: { variables, query } }) {
 		const variablesCopy = { ...variables };
 
-		logger.info('Query received', {
-			query: query ? stripIgnoredCharacters(query) : query,
-			variables: JSON.stringify(variablesCopy),
-		});
+		logger.info(
+			{
+				query: query ? stripIgnoredCharacters(query) : query,
+				variables: JSON.stringify(variablesCopy),
+			},
+			'Query received'
+		);
 	},
 };


### PR DESCRIPTION
We used to use Bunyan. That logger wanted the context args first. Pino does not check additional parameters as soon as it finds a string. This means we were adding additional info to the logs that wasn't actually getting logged.

**Before this change**

```json
{"level":30,"time":1710230363763,"pid":21573,"hostname":"Kevins-MacBook-Pro-3.local","name":"graphweaver","msg":"Query received"}
```

**After**

```json
{"level":30,"time":1710230651755,"pid":24254,"hostname":"Kevins-MacBook-Pro-3.local","name":"graphweaver","query":"query graphweaver{result:_graphweaver{entities{name plural backendId summaryField defaultFilter fields{name type isArray relationshipType relatedEntity filter{type __typename}attributes{isReadOnly isRequired __typename}extensions{key __typename}__typename}attributes{isReadOnly exportPageSize __typename}__typename}enums{name values{name value __typename}__typename}__typename}}","variables":"{}","msg":"Query received"}
```