### PR TITLE
Fix / Array Relationships Default to One to Many

### DIFF
--- a/src/packages/server/src/metadata-service/resolver.ts
+++ b/src/packages/server/src/metadata-service/resolver.ts
@@ -109,18 +109,22 @@ export const getAdminUiMetadataResolver = (hooks?: AdminMetadata['hooks']) => {
 								isRequired,
 							},
 						};
+
 						// Check if we have an array of related entities
 						if (field.typeOptions.array && relatedObject) {
-							const relatedEntity = relatedObject.fields.find((field) => {
-								const fieldType = field.getType() as any;
+							// Ok, it's a relationship to another object type that is an array, e.g. "to many".
+							// We'll default to one to many, then if we can find a field on the other side that points
+							// back to us and it's also an array, then it's a many to many.
+							fieldObject.relatedEntity = relatedObject.name;
+							fieldObject.relationshipType = RelationshipType.ONE_TO_MANY;
+
+							const relatedEntityField = relatedObject.fields.find((field) => {
+								const fieldType = field.getType() as { name?: string };
 								return fieldType.name === entity.target.name;
 							});
-							if (relatedEntity?.typeOptions) {
-								fieldObject.relationshipType = relatedEntity.typeOptions.array
-									? RelationshipType.MANY_TO_MANY
-									: RelationshipType.ONE_TO_MANY;
+							if (relatedEntityField?.typeOptions.array) {
+								fieldObject.relationshipType = RelationshipType.MANY_TO_MANY;
 							}
-							fieldObject.relatedEntity = relatedObject.name;
 						} else if (relatedObject) {
 							fieldObject.relationshipType = RelationshipType.MANY_TO_ONE;
 						}


### PR DESCRIPTION
Previously we had a default relationship type of one to many. This used to mean if you did the following (pseudocode):

```
entity Author {
  books: [Book!]
}

entity Book {
  name: String!
}
```
Then you'd get a one to many on the Author side, and no relationship on the other side. Because we're now testing for a back-reference property on the Book side and aren't finding it, we don't mark it as a relationship at all. This means the admin area issues a query similar to this to load Authors:

```graphql
query AdminUIListPage {
  result: authors {
    id
    books
    __typename
  }
}
```
Which then errors with:
```
Field "books" of type "Author" must have a selection of subfields.
```

This change will mean the admin area assumes a one directional relationship to another entity that is an array is a one to many, which I think is the best compromise here. It may be worth allowing users to override this inference with explicit configuration in the future if this does not prove flexible enough.