### PR TITLE
Fix / JIRA Linker Fail

### DIFF
--- a/.github/workflows/jira-linker.yml
+++ b/.github/workflows/jira-linker.yml
@@ -6,6 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: exogee-technology/action-jira-linker@v1.1.1
+        # We don't want to try to link JIRA issues if we're running from an external collaborator / dependabot / etc as
+        # none of these secrets will be available to us and it'll just error.
+        if: github.secret_source == 'Actions'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           jira-token: ${{ secrets.JIRA_TOKEN }}

--- a/.github/workflows/jira-linker.yml
+++ b/.github/workflows/jira-linker.yml
@@ -5,7 +5,7 @@ jobs:
   action-jira-linker:
     runs-on: ubuntu-latest
     steps:
-      - uses: exogee-technology/action-jira-linker@v1.1.1
+      - uses: exogee-technology/action-jira-linker@v1.1.3
         # We don't want to try to link JIRA issues if we're running from an external collaborator / dependabot / etc as
         # none of these secrets will be available to us and it'll just error.
         if: github.secret_source == 'Actions'


### PR DESCRIPTION
Only run the jira linker if we're running in the context where we'll have our JIRA credentials anyway.