### PR TITLE
Feature / Add Dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: npm
-    directory: "/src"
-    schedule:
-      interval: daily
-      time: "03:00"
-      timezone: Australia/Sydney
-    open-pull-requests-limit: 99
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -14,3 +7,21 @@ updates:
       time: "03:00"
       timezone: Australia/Sydney
     open-pull-requests-limit: 99
+
+  - package-ecosystem: npm
+    directory: "/src"
+    schedule:
+      interval: daily
+      time: "03:00"
+      timezone: Australia/Sydney
+    open-pull-requests-limit: 99
+    groups:
+      graphql-tools:
+        patterns:
+          - "@graphql-tools*"
+      mikro-orm:
+        patterns:
+          - "@mikro-orm*"
+      nivo:
+        patterns:
+          - "@nivo*"


### PR DESCRIPTION
Dependabot supports [grouping](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) of dependencies into a single PR. This should make it so that any updates to `@nivo`, `@mikro-orm` or `@graphql-tools` packages come to us in a single PR that pulls them all together.