### PR TITLE
Chore / Dependabot Group AWS SDK

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
       timezone: Australia/Sydney
     open-pull-requests-limit: 99
     groups:
+      aws-sdk:
+        patterns:
+          - "@aws-sdk*"
       graphql-tools:
         patterns:
           - "@graphql-tools*"


### PR DESCRIPTION
Add AWS SDK to dependabot groups so it gets updated as one atomic PR.