### PR TITLE
Chore / Decrease Dependabot Noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: daily
       time: "03:00"
       timezone: Australia/Sydney
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 5
 
   - package-ecosystem: npm
     directory: "/src"
@@ -14,7 +14,7 @@ updates:
       interval: daily
       time: "03:00"
       timezone: Australia/Sydney
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 10
     groups:
       aws-sdk:
         patterns:


### PR DESCRIPTION
Currently Dependabot is giving us a LOT of PRs, which is good, but we genuinely want to be able to see other contributions even when we're not actively merging Dependabot PRs, so this dials it back a bit.