### PR TITLE
Chore / Pluralisation on delete dialog

### DIFF
--- a/src/packages/admin-ui-components/src/selection-bar/component.tsx
+++ b/src/packages/admin-ui-components/src/selection-bar/component.tsx
@@ -32,7 +32,7 @@ export const SelectionBar = ({
 							items={[
 								{
 									id: 'delete-items',
-									name: 'Delete selected rows',
+									name: `Delete selected row${selectedRows.size === 1 ? '' : 's'}`,
 									onClick: handleDelete,
 									className: styles.deleteSelectedRows,
 								},

--- a/src/packages/admin-ui-components/src/table/component.tsx
+++ b/src/packages/admin-ui-components/src/table/component.tsx
@@ -278,7 +278,10 @@ export const Table = <T extends TableRowItem>({
 			.then(() => {
 				toast.success(
 					<div className={styles.successToast}>
-						<div>Success</div> <div className={styles.deletedText}>Rows deleted</div>
+						<div>Success</div>
+						<div className={styles.deletedText}>
+							Row{selectedRows.size === 1 ? '' : 's'} deleted
+						</div>
 					</div>
 				);
 			})

--- a/src/packages/end-to-end/src/__tests__/ui/auth/delete-tag.test.ts
+++ b/src/packages/end-to-end/src/__tests__/ui/auth/delete-tag.test.ts
@@ -22,7 +22,7 @@ test('should allow an admin to delete a tag', async ({ page }) => {
 
 	await page.getByRole('row', { name: tag }).locator('label div').click();
 	await page.getByRole('button', { name: 'Actions' }).click();
-	await page.getByText('Delete selected rows').click();
+	await page.getByText('Delete selected row').click();
 	await page.getByRole('button', { name: 'Delete' }).click();
 	// Wait for the delete to complete
 	const deleteToast = await page.getByText('row deleted');

--- a/src/packages/end-to-end/src/__tests__/ui/auth/delete-tag.test.ts
+++ b/src/packages/end-to-end/src/__tests__/ui/auth/delete-tag.test.ts
@@ -25,7 +25,7 @@ test('should allow an admin to delete a tag', async ({ page }) => {
 	await page.getByText('Delete selected rows').click();
 	await page.getByRole('button', { name: 'Delete' }).click();
 	// Wait for the delete to complete
-	const deleteToast = await page.getByText('rows deleted');
+	const deleteToast = await page.getByText('row deleted');
 	await expect(deleteToast).toHaveCount(1);
 
 	// Check that the item is removed from the table

--- a/src/packages/end-to-end/src/__tests__/ui/auth/delete-tag.test.ts
+++ b/src/packages/end-to-end/src/__tests__/ui/auth/delete-tag.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 import { config } from '../../../config';
 


### PR DESCRIPTION
Now show "Delete selected row" when only one row is selected for deletion instead of always saying "rows".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dynamic text update for deleting rows: "Delete selected row" or "Delete selected rows" based on the number of rows selected.

- **Improvements**
  - Enhanced toast messages to reflect the exact number of rows deleted for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->