### PR TITLE
Fix: Add entity null check

### DIFF
--- a/src/packages/core/src/default-from-backend-entity.ts
+++ b/src/packages/core/src/default-from-backend-entity.ts
@@ -47,6 +47,9 @@ export const fromBackendEntity = <G = unknown, D = unknown>(
 		entity = defaultFromBackendEntity<G, D>(entityMetadata, dataEntity) as G;
 	}
 
+	// It is possible that the entity is null returned from target or the defaultFromBackendEntity, so we need to check for that.
+	if (entity === null) return null;
+
 	// Always tag on the original data entity in a hidden way so that we can read it from
 	// resolvers and access it later.
 	(entity as WithDataEntity<D>)[dataEntityPropertyKey] = dataEntity;

--- a/src/packages/core/src/utils/create-or-update-entities.ts
+++ b/src/packages/core/src/utils/create-or-update-entities.ts
@@ -76,7 +76,7 @@ export const createOrUpdateEntities = async <G = unknown, D = unknown>(
 
 	if (Array.isArray(input)) {
 		// If input is an array, loop through the elements
-		const nodes: Partial<G>[] = [];
+		const nodes: Partial<G | null>[] = [];
 		for (const node of input) {
 			const updatedNode = await createOrUpdateEntities(node, meta, info, context);
 			if (Array.isArray(updatedNode)) {
@@ -88,7 +88,7 @@ export const createOrUpdateEntities = async <G = unknown, D = unknown>(
 	} else if (isObject(input)) {
 		// If input is an object, check for nested entities and update/create them
 		let node = { ...input };
-		let parent: G | undefined = undefined;
+		let parent: G | undefined | null = undefined;
 
 		// Loop through the properties and check for nested entities
 		for (const entry of Object.entries(input)) {


### PR DESCRIPTION
It is possible that the data entity is null so we add a check to ensure entity is not null.

If the dataEntity value is null we currently get the error:

`Error! Cannot set properties of null (setting 'Symbol(dataEntity)')`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where the application could crash if a backend entity was `null`. Now, it will safely return `null` in such cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->