### PR TITLE
Chore / Remove UUID

### DIFF
--- a/src/examples/xero/package.json
+++ b/src/examples/xero/package.json
@@ -45,7 +45,6 @@
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
 		"react-router-dom": "6.23.1",
-		"uuid": "9.0.1",
 		"xero-node": "6.0.0"
 	},
 	"devDependencies": {

--- a/src/packages/auth/src/authentication/methods/forgotten-password.ts
+++ b/src/packages/auth/src/authentication/methods/forgotten-password.ts
@@ -1,7 +1,7 @@
 import ms from 'ms';
 import { AuthenticationError } from 'apollo-server-errors';
 import { logger } from '@exogee/logger';
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import { BackendProvider, ResolverOptions, graphweaverMetadata } from '@exogee/graphweaver';
 
 import { AuthorizationContext, AuthenticationType } from '../../types';

--- a/src/packages/auth/src/authentication/methods/magic-link.ts
+++ b/src/packages/auth/src/authentication/methods/magic-link.ts
@@ -1,7 +1,7 @@
 import ms from 'ms';
 import { AuthenticationError } from 'apollo-server-errors';
 import { logger } from '@exogee/logger';
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 import { AuthenticationMethod, AuthorizationContext, JwtPayload } from '../../types';
 import { Token } from '../entities/token';

--- a/src/packages/aws-cognito/package.json
+++ b/src/packages/aws-cognito/package.json
@@ -36,7 +36,6 @@
 		"@aws-sdk/client-cognito-identity-provider": "3.592.0",
 		"@aws-sdk/client-lambda": "3.592.0",
 		"@exogee/graphweaver-rest": "workspace:*",
-		"graphql": "16.8.1",
-		"uuid": "9.0.1"
+		"graphql": "16.8.1"
 	}
 }

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -371,9 +371,6 @@ importers:
       react-router-dom:
         specifier: 6.23.1
         version: 6.23.1(react-dom@18.3.1)(react@18.3.1)
-      uuid:
-        specifier: 9.0.1
-        version: 9.0.1
       xero-node:
         specifier: 6.0.0
         version: 6.0.0
@@ -724,9 +721,6 @@ importers:
       graphql:
         specifier: 16.8.1
         version: 16.8.1
-      uuid:
-        specifier: 9.0.1
-        version: 9.0.1
     devDependencies:
       '@exogee/graphweaver':
         specifier: workspace:*


### PR DESCRIPTION
Remove `uuid` from dependencies now that it's part of `node:crypto` and built in.

Supersedes #730.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the `uuid` dependency (version 9.0.1) from the Xero integration example and AWS Cognito package.
  - Updated import statements for `randomUUID` to use `'node:crypto'` in authentication methods for forgotten password and magic link.
  - Cleaned up `pnpm-lock.yaml` to remove references to the `uuid` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->