### PR TITLE
Chore / Add @typescript-eslint group for dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,6 @@ updates:
       simplewebauthn:
         patterns:
           - "@simplewebauthn*"
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint*"


### PR DESCRIPTION
This stops us from bumping the @typescript-eslint packages separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added configuration for `typescript-eslint` in `dependabot.yml` to ensure dependencies are kept up to date automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->