### PR TITLE
Fix / Mikro version mismatch

### DIFF
--- a/src/packages/cli/build.js
+++ b/src/packages/cli/build.js
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { exec: nodeExec } = require('child_process');
+const path = require('node:path');
+const fs = require('node:fs/promises');
 const { promisify } = require('util');
 
 const { build } = require('esbuild');
@@ -7,7 +9,43 @@ const { dependencies, devDependencies } = require('./package.json');
 
 const exec = promisify(nodeExec);
 
+const validateMikroOrmExpectedVersion = async () => {
+	// The CLI has the introspection operation. We need to make sure our target
+	// MikroORM version matches with the version specified in the mikro-orm adapter
+	// package.json file or the build should fail.
+	const {
+		devDependencies: mikroDevDependencies,
+		peerDependencies: mikroPeerDependencies,
+	} = require(path.resolve('..', 'mikroorm', 'package.json'));
+
+	// Let's make sure first that the version in dev and peer match.
+	const devVersion = mikroDevDependencies['@mikro-orm/core'];
+	const peerVersion = mikroPeerDependencies['@mikro-orm/core'];
+	if (devVersion !== peerVersion) {
+		throw new Error(
+			`The version of @mikro-orm/core in the mikroorm package's devDependencies (${devVersion}) and peerDependencies (${peerVersion}) do not match.`
+		);
+	}
+
+	// Ok, what's ours?
+	const searchPattern = /export const MIKRO_ORM_TARGET_VERSION = '(.+)';/;
+	const constantsContents = await fs.readFile(path.resolve('src', 'init', 'constants.ts'), 'utf-8');
+	const match = searchPattern.exec(constantsContents);
+	if (!match) {
+		throw new Error(`Could not find MIKRO_ORM_TARGET_VERSION in src/init/constants.ts.`);
+	}
+	const MIKRO_ORM_TARGET_VERSION = match[1];
+
+	if (peerVersion !== MIKRO_ORM_TARGET_VERSION) {
+		throw new Error(
+			`The version of @mikro-orm/core in the mikroorm package's peerDependencies (${peerVersion}) does not match the target version in the CLI (${MIKRO_ORM_TARGET_VERSION}). Update the CLI package's src/init/constants.ts file to match the target version.`
+		);
+	}
+};
+
 (async () => {
+	await validateMikroOrmExpectedVersion();
+
 	// Build the CLI
 	await build({
 		entryPoints: ['./src/index.ts'],

--- a/src/packages/cli/src/init/constants.ts
+++ b/src/packages/cli/src/init/constants.ts
@@ -1,7 +1,7 @@
 import { version } from '../../package.json';
 
 export const GRAPHWEAVER_TARGET_VERSION = version;
-export const MIKRO_ORM_TARGET_VERSION = '6.2.8';
+export const MIKRO_ORM_TARGET_VERSION = '6.2.9';
 export const AWS_LAMBDA_VERSION = '2.0.1';
 
 export const graphweaverVersion = (versionOverride?: string, packageName?: string) => {


### PR DESCRIPTION
We used Dependabot to update MikroORM without realising we hadn't updated the start template.

This PR:
- Updates the target version of MikroORM to fix the issue reported in #775
- Adds a build step to ensure they don't ever get out of sync again.