### PR TITLE
Fix / Allow multiple graphweavers simultaneously on different ports.

### DIFF
--- a/src/packages/builder/src/start/backend.ts
+++ b/src/packages/builder/src/start/backend.ts
@@ -166,7 +166,12 @@ export const startBackend = async ({ host, port }: BackendStartOptions) => {
 						noPrependStageInUrl: true,
 						useInProcess: true,
 						...(host ? { host } : {}),
-						...(port ? { httpPort: port + 1 } : {}),
+						...(port
+							? {
+									httpPort: port + 1,
+									lambdaPort: port + 2,
+								}
+							: {}),
 					},
 				},
 				getAllFunctions: () => Object.keys(backendFunctions),


### PR DESCRIPTION
Currently working on federation there's a port clash over 3002 when I try to run two Graphweaver instances on my machine on different ports.

Turns out this is a default of serverless offline, so all we need to do is specify it I believe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved backend startup configuration by automatically setting a `lambdaPort` when a `port` is provided, enhancing server setup flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->