### PR TITLE
Fix / Add Inacessible Directive to Admin UI Metadata Entities + Add directives to custom queries and mutations

### DIFF
--- a/src/examples/federation/src/backend/schema/product-dimension.ts
+++ b/src/examples/federation/src/backend/schema/product-dimension.ts
@@ -19,7 +19,7 @@ class JsonDataProvider extends BaseDataProvider<ProductDimension> {
 @Entity('ProductDimension', {
 	provider: new JsonDataProvider('Product Dimensions'),
 	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { shareable: true },
+	directives: { inaccessible: true },
 })
 export class ProductDimension {
 	id!: string;

--- a/src/examples/federation/src/backend/schema/product-dimension.ts
+++ b/src/examples/federation/src/backend/schema/product-dimension.ts
@@ -19,7 +19,7 @@ class JsonDataProvider extends BaseDataProvider<ProductDimension> {
 @Entity('ProductDimension', {
 	provider: new JsonDataProvider('Product Dimensions'),
 	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { inaccessible: true },
+	directives: { shareable: true },
 })
 export class ProductDimension {
 	id!: string;

--- a/src/packages/core/src/metadata-service/entity-attribute.ts
+++ b/src/packages/core/src/metadata-service/entity-attribute.ts
@@ -1,6 +1,9 @@
 import { Entity, Field } from '../decorators';
 
-@Entity('AdminUiEntityAttributeMetadata', { apiOptions: { excludeFromBuiltInOperations: true } })
+@Entity('AdminUiEntityAttributeMetadata', {
+	apiOptions: { excludeFromBuiltInOperations: true },
+	directives: { shareable: true },
+})
 export class AdminUiEntityAttributeMetadata {
 	@Field(() => Boolean, { nullable: true })
 	isReadOnly?: boolean;

--- a/src/packages/core/src/metadata-service/entity-attribute.ts
+++ b/src/packages/core/src/metadata-service/entity-attribute.ts
@@ -2,7 +2,7 @@ import { Entity, Field } from '../decorators';
 
 @Entity('AdminUiEntityAttributeMetadata', {
 	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { shareable: true },
+	directives: { inaccessible: true },
 })
 export class AdminUiEntityAttributeMetadata {
 	@Field(() => Boolean, { nullable: true })

--- a/src/packages/core/src/metadata-service/entity.ts
+++ b/src/packages/core/src/metadata-service/entity.ts
@@ -11,7 +11,10 @@ graphweaverMetadata.collectEnumInformation({
 	name: 'AggregationType',
 });
 
-@Entity('AdminUiEntityMetadata', { apiOptions: { excludeFromBuiltInOperations: true } })
+@Entity('AdminUiEntityMetadata', {
+	apiOptions: { excludeFromBuiltInOperations: true },
+	directives: { shareable: true },
+})
 export class AdminUiEntityMetadata {
 	@Field(() => String)
 	name!: string;

--- a/src/packages/core/src/metadata-service/entity.ts
+++ b/src/packages/core/src/metadata-service/entity.ts
@@ -13,7 +13,7 @@ graphweaverMetadata.collectEnumInformation({
 
 @Entity('AdminUiEntityMetadata', {
 	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { shareable: true },
+	directives: { inaccessible: true },
 })
 export class AdminUiEntityMetadata {
 	@Field(() => String)

--- a/src/packages/core/src/metadata-service/enum-value.ts
+++ b/src/packages/core/src/metadata-service/enum-value.ts
@@ -1,6 +1,9 @@
 import { Entity, Field } from '../decorators';
 
-@Entity('AdminUiEnumValueMetadata', { apiOptions: { excludeFromBuiltInOperations: true } })
+@Entity('AdminUiEnumValueMetadata', {
+	apiOptions: { excludeFromBuiltInOperations: true },
+	directives: { shareable: true },
+})
 export class AdminUiEnumValueMetadata {
 	@Field(() => String)
 	name!: string;

--- a/src/packages/core/src/metadata-service/enum-value.ts
+++ b/src/packages/core/src/metadata-service/enum-value.ts
@@ -2,7 +2,7 @@ import { Entity, Field } from '../decorators';
 
 @Entity('AdminUiEnumValueMetadata', {
 	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { shareable: true },
+	directives: { inaccessible: true },
 })
 export class AdminUiEnumValueMetadata {
 	@Field(() => String)

--- a/src/packages/core/src/metadata-service/enum.ts
+++ b/src/packages/core/src/metadata-service/enum.ts
@@ -3,7 +3,7 @@ import { AdminUiEnumValueMetadata } from './enum-value';
 
 @Entity('AdminUiEnumMetadata', {
 	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { shareable: true },
+	directives: { inaccessible: true },
 })
 export class AdminUiEnumMetadata {
 	@Field(() => String)

--- a/src/packages/core/src/metadata-service/enum.ts
+++ b/src/packages/core/src/metadata-service/enum.ts
@@ -1,7 +1,10 @@
 import { Entity, Field } from '../decorators';
 import { AdminUiEnumValueMetadata } from './enum-value';
 
-@Entity('AdminUiEnumMetadata', { apiOptions: { excludeFromBuiltInOperations: true } })
+@Entity('AdminUiEnumMetadata', {
+	apiOptions: { excludeFromBuiltInOperations: true },
+	directives: { shareable: true },
+})
 export class AdminUiEnumMetadata {
 	@Field(() => String)
 	name!: string;

--- a/src/packages/core/src/metadata-service/field-attribute.ts
+++ b/src/packages/core/src/metadata-service/field-attribute.ts
@@ -1,6 +1,9 @@
 import { Entity, Field } from '../decorators';
 
-@Entity('AdminUiFieldAttributeMetadata', { apiOptions: { excludeFromBuiltInOperations: true } })
+@Entity('AdminUiFieldAttributeMetadata', {
+	apiOptions: { excludeFromBuiltInOperations: true },
+	directives: { shareable: true },
+})
 export class AdminUiFieldAttributeMetadata {
 	@Field(() => Boolean)
 	isReadOnly!: boolean;

--- a/src/packages/core/src/metadata-service/field-attribute.ts
+++ b/src/packages/core/src/metadata-service/field-attribute.ts
@@ -2,7 +2,7 @@ import { Entity, Field } from '../decorators';
 
 @Entity('AdminUiFieldAttributeMetadata', {
 	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { shareable: true },
+	directives: { inaccessible: true },
 })
 export class AdminUiFieldAttributeMetadata {
 	@Field(() => Boolean)

--- a/src/packages/core/src/metadata-service/field-extensions.ts
+++ b/src/packages/core/src/metadata-service/field-extensions.ts
@@ -2,7 +2,7 @@ import { Entity, Field } from '../decorators';
 
 @Entity('AdminUiFieldExtensionsMetadata', {
 	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { shareable: true },
+	directives: { inaccessible: true },
 })
 export class AdminUiFieldExtensionsMetadata {
 	@Field(() => String, { nullable: true })

--- a/src/packages/core/src/metadata-service/field-extensions.ts
+++ b/src/packages/core/src/metadata-service/field-extensions.ts
@@ -1,6 +1,9 @@
 import { Entity, Field } from '../decorators';
 
-@Entity('AdminUiFieldExtensionsMetadata', { apiOptions: { excludeFromBuiltInOperations: true } })
+@Entity('AdminUiFieldExtensionsMetadata', {
+	apiOptions: { excludeFromBuiltInOperations: true },
+	directives: { shareable: true },
+})
 export class AdminUiFieldExtensionsMetadata {
 	@Field(() => String, { nullable: true })
 	key?: string;

--- a/src/packages/core/src/metadata-service/field.ts
+++ b/src/packages/core/src/metadata-service/field.ts
@@ -5,7 +5,7 @@ import { AdminUiFieldExtensionsMetadata } from './field-extensions';
 
 @Entity('AdminUiFieldMetadata', {
 	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { shareable: true },
+	directives: { inaccessible: true },
 })
 export class AdminUiFieldMetadata {
 	@Field(() => String)

--- a/src/packages/core/src/metadata-service/field.ts
+++ b/src/packages/core/src/metadata-service/field.ts
@@ -3,7 +3,10 @@ import { AdminUiFilterMetadata } from './filter';
 import { AdminUiFieldAttributeMetadata } from './field-attribute';
 import { AdminUiFieldExtensionsMetadata } from './field-extensions';
 
-@Entity('AdminUiFieldMetadata', { apiOptions: { excludeFromBuiltInOperations: true } })
+@Entity('AdminUiFieldMetadata', {
+	apiOptions: { excludeFromBuiltInOperations: true },
+	directives: { shareable: true },
+})
 export class AdminUiFieldMetadata {
 	@Field(() => String)
 	name!: string;

--- a/src/packages/core/src/metadata-service/filter.ts
+++ b/src/packages/core/src/metadata-service/filter.ts
@@ -7,7 +7,10 @@ graphweaverMetadata.collectEnumInformation({
 	target: AdminUIFilterType,
 });
 
-@Entity('AdminUiFilterMetadata', { apiOptions: { excludeFromBuiltInOperations: true } })
+@Entity('AdminUiFilterMetadata', {
+	apiOptions: { excludeFromBuiltInOperations: true },
+	directives: { shareable: true },
+})
 export class AdminUiFilterMetadata {
 	@Field(() => AdminUIFilterType)
 	type!: AdminUIFilterType;

--- a/src/packages/core/src/metadata-service/filter.ts
+++ b/src/packages/core/src/metadata-service/filter.ts
@@ -9,7 +9,7 @@ graphweaverMetadata.collectEnumInformation({
 
 @Entity('AdminUiFilterMetadata', {
 	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { shareable: true },
+	directives: { inaccessible: true },
 })
 export class AdminUiFilterMetadata {
 	@Field(() => AdminUIFilterType)

--- a/src/packages/core/src/metadata-service/metadata.ts
+++ b/src/packages/core/src/metadata-service/metadata.ts
@@ -11,5 +11,5 @@ export class AdminUiMetadata {
 	public entities: AdminUiEntityMetadata[] = [];
 
 	@Field(() => [AdminUiEnumMetadata])
-	public enums: AdminUiEntityMetadata[] = [];
+	public enums: AdminUiEnumMetadata[] = [];
 }

--- a/src/packages/core/src/metadata-service/metadata.ts
+++ b/src/packages/core/src/metadata-service/metadata.ts
@@ -2,7 +2,10 @@ import { Entity, Field } from '../decorators';
 import { AdminUiEntityMetadata } from './entity';
 import { AdminUiEnumMetadata } from './enum';
 
-@Entity('AdminUiMetadata', { apiOptions: { excludeFromBuiltInOperations: true } })
+@Entity('AdminUiMetadata', {
+	apiOptions: { excludeFromBuiltInOperations: true },
+	directives: { shareable: true },
+})
 export class AdminUiMetadata {
 	@Field(() => [AdminUiEntityMetadata])
 	public entities: AdminUiEntityMetadata[] = [];

--- a/src/packages/core/src/metadata-service/metadata.ts
+++ b/src/packages/core/src/metadata-service/metadata.ts
@@ -4,7 +4,7 @@ import { AdminUiEnumMetadata } from './enum';
 
 @Entity('AdminUiMetadata', {
 	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { shareable: true },
+	directives: { inaccessible: true },
 })
 export class AdminUiMetadata {
 	@Field(() => [AdminUiEntityMetadata])

--- a/src/packages/core/src/metadata.ts
+++ b/src/packages/core/src/metadata.ts
@@ -178,6 +178,7 @@ export interface AdditionalOperationInformation {
 	name: string;
 	getType: () => any;
 	resolver: Resolver;
+	directives?: Record<string, unknown>;
 	args?: ArgsMetadata;
 	description?: string;
 }
@@ -543,14 +544,11 @@ class Metadata {
 		return undefined;
 	}
 
-	public addQuery(args: {
-		name: string;
-		getType: GetTypeFunction;
-		resolver: Resolver;
-		args?: ArgsMetadata;
-		description?: string;
-		intentionalOverride?: boolean;
-	}) {
+	public addQuery(
+		args: AdditionalOperationInformation & {
+			intentionalOverride?: boolean;
+		}
+	) {
 		if (this.additionalQueriesLookup.has(args.name) && !args.intentionalOverride) {
 			throw new Error(
 				`Query with name ${args.name} already exists and this is not an intentional override`
@@ -560,14 +558,11 @@ class Metadata {
 		this.additionalQueriesLookup.set(args.name, args);
 	}
 
-	public addMutation(args: {
-		name: string;
-		getType: GetTypeFunction;
-		resolver: Resolver;
-		args?: ArgsMetadata;
-		description?: string;
-		intentionalOverride?: boolean;
-	}) {
+	public addMutation(
+		args: AdditionalOperationInformation & {
+			intentionalOverride?: boolean;
+		}
+	) {
 		if (this.additionalMutationsLookup.has(args.name) && !args.intentionalOverride) {
 			throw new Error(
 				`Mutation with name ${args.name} already exists and this is not an intentional override`

--- a/src/packages/core/src/schema-builder.ts
+++ b/src/packages/core/src/schema-builder.ts
@@ -793,6 +793,9 @@ class SchemaBuilderImplementation {
 							args: customArgs,
 							type: graphQLTypeForEntity(metadata),
 							resolve: trace(resolvers.baseResolver(customQuery.resolver)),
+							extensions: {
+								directives: customQuery.directives ?? {},
+							},
 						};
 					} else {
 						const type: GraphQLOutputType = graphQLTypeForScalarEnumOrUnion(metadata, fieldType);
@@ -802,6 +805,9 @@ class SchemaBuilderImplementation {
 							args: customArgs,
 							type,
 							resolve: trace(resolvers.baseResolver(customQuery.resolver)),
+							extensions: {
+								directives: customQuery.directives ?? {},
+							},
 						};
 					}
 				}
@@ -955,6 +961,9 @@ class SchemaBuilderImplementation {
 							args: customArgs,
 							type: graphQLTypeForEntity(metadata),
 							resolve: trace(resolvers.baseResolver(customMutation.resolver)),
+							extensions: {
+								directives: customMutation.directives ?? {},
+							},
 						};
 					} else {
 						fields[customMutation.name] = {
@@ -962,6 +971,9 @@ class SchemaBuilderImplementation {
 							args: customArgs,
 							type: graphQLScalarForTypeScriptType(type),
 							resolve: trace(resolvers.baseResolver(customMutation.resolver)),
+							extensions: {
+								directives: customMutation.directives ?? {},
+							},
 						};
 					}
 				}

--- a/src/packages/server/src/index.ts
+++ b/src/packages/server/src/index.ts
@@ -112,7 +112,7 @@ export default class Graphweaver<TContext extends BaseContext> {
 				description: 'Query used by the Admin UI to introspect the schema and metadata.',
 				getType: () => AdminUiMetadata,
 				resolver: resolveAdminUiMetadata(this.config.adminMetadata?.hooks),
-				directives: { inacessible: true },
+				directives: { inaccessible: true },
 			});
 		}
 

--- a/src/packages/server/src/index.ts
+++ b/src/packages/server/src/index.ts
@@ -112,6 +112,7 @@ export default class Graphweaver<TContext extends BaseContext> {
 				description: 'Query used by the Admin UI to introspect the schema and metadata.',
 				getType: () => AdminUiMetadata,
 				resolver: resolveAdminUiMetadata(this.config.adminMetadata?.hooks),
+				directives: { inacessible: true },
 			});
 		}
 


### PR DESCRIPTION
These entities are exported from every Graphweaver instance, so we want to enable the scenario where two Graphweaver APIs are part of a federation supergraph. This directive tells the router to ignore these entities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new directives to improve metadata handling, including `inaccessible: true` and `shareable: true`.

- **Improvements**
  - Enhanced security and control over metadata operations by marking certain entity attributes, fields, and filters as inaccessible.
  
- **Updates**
  - Modified directive for the `JsonDataProvider` class in the `ProductDimension` entity from `shareable` to `inaccessible` for better data protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->