### PR TITLE
Fix / Add @inaccessible to all fields

### DIFF
--- a/src/packages/core/src/metadata-service/entity-attribute.ts
+++ b/src/packages/core/src/metadata-service/entity-attribute.ts
@@ -5,9 +5,9 @@ import { Entity, Field } from '../decorators';
 	directives: { inaccessible: true },
 })
 export class AdminUiEntityAttributeMetadata {
-	@Field(() => Boolean, { nullable: true })
+	@Field(() => Boolean, { nullable: true, directives: { inaccessible: true } })
 	isReadOnly?: boolean;
 
-	@Field(() => Number, { nullable: true })
+	@Field(() => Number, { nullable: true, directives: { inaccessible: true } })
 	exportPageSize?: number;
 }

--- a/src/packages/core/src/metadata-service/entity.ts
+++ b/src/packages/core/src/metadata-service/entity.ts
@@ -16,30 +16,30 @@ graphweaverMetadata.collectEnumInformation({
 	directives: { inaccessible: true },
 })
 export class AdminUiEntityMetadata {
-	@Field(() => String)
+	@Field(() => String, { directives: { inaccessible: true } })
 	name!: string;
 
-	@Field(() => String)
+	@Field(() => String, { directives: { inaccessible: true } })
 	plural!: string;
 
-	@Field(() => String, { nullable: true })
+	@Field(() => String, { nullable: true, directives: { inaccessible: true } })
 	backendId?: string | null;
 
-	@Field(() => String, { nullable: true })
+	@Field(() => String, { nullable: true, directives: { inaccessible: true } })
 	summaryField?: string | null;
 
-	@Field(() => String)
+	@Field(() => String, { directives: { inaccessible: true } })
 	primaryKeyField!: string;
 
-	@Field(() => [AdminUiFieldMetadata])
+	@Field(() => [AdminUiFieldMetadata], { directives: { inaccessible: true } })
 	fields?: AdminUiFieldMetadata[] = [];
 
-	@Field(() => GraphQLJSON, { nullable: true })
+	@Field(() => GraphQLJSON, { nullable: true, directives: { inaccessible: true } })
 	defaultFilter?: Filter<unknown>;
 
-	@Field(() => AdminUiEntityAttributeMetadata)
+	@Field(() => AdminUiEntityAttributeMetadata, { directives: { inaccessible: true } })
 	attributes?: AdminUiEntityAttributeMetadata;
 
-	@Field(() => [AggregationType])
+	@Field(() => [AggregationType], { directives: { inaccessible: true } })
 	supportedAggregationTypes!: AggregationType[];
 }

--- a/src/packages/core/src/metadata-service/enum-value.ts
+++ b/src/packages/core/src/metadata-service/enum-value.ts
@@ -5,9 +5,9 @@ import { Entity, Field } from '../decorators';
 	directives: { inaccessible: true },
 })
 export class AdminUiEnumValueMetadata {
-	@Field(() => String)
+	@Field(() => String, { directives: { inaccessible: true } })
 	name!: string;
 
-	@Field(() => String)
+	@Field(() => String, { directives: { inaccessible: true } })
 	value!: string;
 }

--- a/src/packages/core/src/metadata-service/enum.ts
+++ b/src/packages/core/src/metadata-service/enum.ts
@@ -6,10 +6,10 @@ import { AdminUiEnumValueMetadata } from './enum-value';
 	directives: { inaccessible: true },
 })
 export class AdminUiEnumMetadata {
-	@Field(() => String)
+	@Field(() => String, { directives: { inaccessible: true } })
 	name!: string;
 
-	@Field(() => [AdminUiEnumValueMetadata])
+	@Field(() => [AdminUiEnumValueMetadata], { directives: { inaccessible: true } })
 	values() {
 		return [];
 	}

--- a/src/packages/core/src/metadata-service/field-attribute.ts
+++ b/src/packages/core/src/metadata-service/field-attribute.ts
@@ -5,9 +5,9 @@ import { Entity, Field } from '../decorators';
 	directives: { inaccessible: true },
 })
 export class AdminUiFieldAttributeMetadata {
-	@Field(() => Boolean)
+	@Field(() => Boolean, { directives: { inaccessible: true } })
 	isReadOnly!: boolean;
 
-	@Field(() => Boolean)
+	@Field(() => Boolean, { directives: { inaccessible: true } })
 	isRequired!: boolean;
 }

--- a/src/packages/core/src/metadata-service/field-extensions.ts
+++ b/src/packages/core/src/metadata-service/field-extensions.ts
@@ -5,6 +5,6 @@ import { Entity, Field } from '../decorators';
 	directives: { inaccessible: true },
 })
 export class AdminUiFieldExtensionsMetadata {
-	@Field(() => String, { nullable: true })
+	@Field(() => String, { nullable: true, directives: { inaccessible: true } })
 	key?: string;
 }

--- a/src/packages/core/src/metadata-service/field.ts
+++ b/src/packages/core/src/metadata-service/field.ts
@@ -8,27 +8,33 @@ import { AdminUiFieldExtensionsMetadata } from './field-extensions';
 	directives: { inaccessible: true },
 })
 export class AdminUiFieldMetadata {
-	@Field(() => String)
+	@Field(() => String, { directives: { inaccessible: true } })
 	name!: string;
 
-	@Field(() => String)
+	@Field(() => String, { directives: { inaccessible: true } })
 	type!: string;
 
-	@Field(() => String, { nullable: true })
+	@Field(() => String, { nullable: true, directives: { inaccessible: true } })
 	relationshipType?: string;
 
-	@Field(() => String, { nullable: true })
+	@Field(() => String, { nullable: true, directives: { inaccessible: true } })
 	relatedEntity?: string;
 
-	@Field(() => AdminUiFilterMetadata, { nullable: true })
+	@Field(() => AdminUiFilterMetadata, { nullable: true, directives: { inaccessible: true } })
 	filter?: AdminUiFilterMetadata;
 
-	@Field(() => AdminUiFieldAttributeMetadata, { nullable: true })
+	@Field(() => AdminUiFieldAttributeMetadata, {
+		nullable: true,
+		directives: { inaccessible: true },
+	})
 	attributes?: AdminUiFieldAttributeMetadata;
 
-	@Field(() => AdminUiFieldExtensionsMetadata, { nullable: true })
+	@Field(() => AdminUiFieldExtensionsMetadata, {
+		nullable: true,
+		directives: { inaccessible: true },
+	})
 	extensions?: AdminUiFieldExtensionsMetadata;
 
-	@Field(() => Boolean, { nullable: true })
+	@Field(() => Boolean, { nullable: true, directives: { inaccessible: true } })
 	isArray?: boolean;
 }

--- a/src/packages/core/src/metadata-service/filter.ts
+++ b/src/packages/core/src/metadata-service/filter.ts
@@ -12,6 +12,6 @@ graphweaverMetadata.collectEnumInformation({
 	directives: { inaccessible: true },
 })
 export class AdminUiFilterMetadata {
-	@Field(() => AdminUIFilterType)
+	@Field(() => AdminUIFilterType, { directives: { inaccessible: true } })
 	type!: AdminUIFilterType;
 }

--- a/src/packages/core/src/metadata-service/metadata.ts
+++ b/src/packages/core/src/metadata-service/metadata.ts
@@ -7,9 +7,9 @@ import { AdminUiEnumMetadata } from './enum';
 	directives: { inaccessible: true },
 })
 export class AdminUiMetadata {
-	@Field(() => [AdminUiEntityMetadata])
+	@Field(() => [AdminUiEntityMetadata], { directives: { inaccessible: true } })
 	public entities: AdminUiEntityMetadata[] = [];
 
-	@Field(() => [AdminUiEnumMetadata])
+	@Field(() => [AdminUiEnumMetadata], { directives: { inaccessible: true } })
 	public enums: AdminUiEnumMetadata[] = [];
 }


### PR DESCRIPTION
Cosmo is still complaining about not being `@shareable`. Let's make sure everything is marked as inaccessible for the supergraph.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Added directives to various metadata fields to enhance configuration options and manage field visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->