### PR TITLE
Fix / Minimal Optimise Deps Config for Vite

### DIFF
--- a/src/packages/builder/package.json
+++ b/src/packages/builder/package.json
@@ -38,7 +38,6 @@
 		"serverless-dotenv-plugin": "6.0.0",
 		"serverless-offline": "13.6.0",
 		"vite": "5.3.2",
-		"vite-plugin-commonjs": "0.10.1",
 		"vite-plugin-graphweaver": "workspace:*"
 	},
 	"devDependencies": {

--- a/src/packages/builder/package.json
+++ b/src/packages/builder/package.json
@@ -38,11 +38,11 @@
 		"serverless-dotenv-plugin": "6.0.0",
 		"serverless-offline": "13.6.0",
 		"vite": "5.3.2",
+		"vite-plugin-commonjs": "0.10.1",
 		"vite-plugin-graphweaver": "workspace:*"
 	},
 	"devDependencies": {
 		"@types/node": "20.14.9",
-		"@types/rimraf": "4.0.5",
 		"prettier": "3.3.2",
 		"typescript": "5.5.2"
 	},

--- a/src/packages/builder/src/vite-config.ts
+++ b/src/packages/builder/src/vite-config.ts
@@ -18,43 +18,29 @@ export const viteConfig = ({
 	rootDirectory,
 	backendUrl,
 	base = '/',
-}: ViteConfigOptions): InlineConfig => {
-	// This is a fix to the issue where the bundled components are not being optimized for esm.
-	// Issue: https://github.com/exogee-technology/graphweaver/issues/290
-	const optimizeDeps = [
-		...Object.keys(
-			requireSilent('@exogee/graphweaver-admin-ui-components/package.json').dependencies
-		),
-		...Object.keys(
-			requireSilent('@exogee/graphweaver-auth-ui-components/package.json').dependencies
-		),
-		...Object.keys(requireSilent('@exogee/graphweaver-admin-ui/package.json').dependencies),
-	];
-
-	return {
-		configFile: false,
-		root: rootDirectory,
-		base,
-		define: {
-			...(backendUrl ? { 'import.meta.env.VITE_GRAPHWEAVER_API_URL': `'${backendUrl}'` } : {}),
-			'import.meta.env.VITE_ADMIN_UI_BASE': `'${base.replace(/\/$/, '')}'`,
-		},
-		build: {
-			outDir: path.resolve(process.cwd(), '.graphweaver', 'admin-ui'),
-		},
-		server: {
-			...(host ? { host } : {}),
-			...(port ? { port } : {}),
-		},
-		optimizeDeps: {
-			include: ['react-dom/client', ...optimizeDeps],
-			exclude: [
-				// This can't be bundled because it's virtual and supplied by
-				// our vite plugin directly.
-				'virtual:graphweaver-user-supplied-custom-pages',
-				'virtual:graphweaver-user-supplied-custom-fields',
-			],
-		},
-		plugins: [react(), graphweaver()],
-	};
-};
+}: ViteConfigOptions): InlineConfig => ({
+	configFile: false,
+	root: rootDirectory,
+	base,
+	define: {
+		...(backendUrl ? { 'import.meta.env.VITE_GRAPHWEAVER_API_URL': `'${backendUrl}'` } : {}),
+		'import.meta.env.VITE_ADMIN_UI_BASE': `'${base.replace(/\/$/, '')}'`,
+	},
+	build: {
+		outDir: path.resolve(process.cwd(), '.graphweaver', 'admin-ui'),
+	},
+	server: {
+		...(host ? { host } : {}),
+		...(port ? { port } : {}),
+	},
+	optimizeDeps: {
+		include: ['react-dom/client'],
+		exclude: [
+			// This can't be bundled because it's virtual and supplied by
+			// our vite plugin directly.
+			'virtual:graphweaver-user-supplied-custom-pages',
+			'virtual:graphweaver-user-supplied-custom-fields',
+		],
+	},
+	plugins: [react(), graphweaver()],
+});

--- a/src/packages/builder/src/vite-config.ts
+++ b/src/packages/builder/src/vite-config.ts
@@ -34,20 +34,27 @@ export const viteConfig = ({
 	},
 	optimizeDeps: {
 		include: [
-			'react-dom',
-			'react-dom/client',
+			// These are deps where if we don't pre-build them things stop working even though they're ESM.
+			// Not sure why, but they need to be here.
+			'formik',
+			'graphql',
 
 			// These are CJS dependencies that need to get translated to ESM before Vite will be happy with them.
 			// We used to pull all of our dependencies in automatically from package.json and force this, but
-			// optimizing deps also means they're not normal source files, so we want this to be a minimal list.
+			// optimizing deps also means they're not normal source files, so we want this to be a minimal list
+			// that decreases over time.
 			'copy-to-clipboard',
 			'graphql-deduplicator',
 			'hoist-non-react-statics',
 			'nullthrows',
 			'papaparse',
 			'prop-types',
+			'react-dom',
+			'react-dom/client',
 			'react-fast-compare',
 			'react-is',
+			'react-router-dom',
+			'react',
 			'rehackt',
 			'set-value',
 		],

--- a/src/packages/builder/src/vite-config.ts
+++ b/src/packages/builder/src/vite-config.ts
@@ -2,7 +2,6 @@ import react from '@vitejs/plugin-react';
 import graphweaver from 'vite-plugin-graphweaver';
 import { InlineConfig } from 'vite';
 import path from 'path';
-import { requireSilent } from './util';
 
 export interface ViteConfigOptions {
 	rootDirectory: string;

--- a/src/packages/builder/src/vite-config.ts
+++ b/src/packages/builder/src/vite-config.ts
@@ -1,4 +1,5 @@
 import react from '@vitejs/plugin-react';
+import commonjs from 'vite-plugin-commonjs';
 import graphweaver from 'vite-plugin-graphweaver';
 import { InlineConfig } from 'vite';
 import path from 'path';
@@ -41,5 +42,5 @@ export const viteConfig = ({
 			'virtual:graphweaver-user-supplied-custom-fields',
 		],
 	},
-	plugins: [react(), graphweaver()],
+	plugins: [commonjs(), react(), graphweaver()],
 });

--- a/src/packages/builder/src/vite-config.ts
+++ b/src/packages/builder/src/vite-config.ts
@@ -1,5 +1,4 @@
 import react from '@vitejs/plugin-react';
-import commonjs from 'vite-plugin-commonjs';
 import graphweaver from 'vite-plugin-graphweaver';
 import { InlineConfig } from 'vite';
 import path from 'path';
@@ -34,7 +33,24 @@ export const viteConfig = ({
 		...(port ? { port } : {}),
 	},
 	optimizeDeps: {
-		include: ['react-dom/client'],
+		include: [
+			'react-dom',
+			'react-dom/client',
+
+			// These are CJS dependencies that need to get translated to ESM before Vite will be happy with them.
+			// We used to pull all of our dependencies in automatically from package.json and force this, but
+			// optimizing deps also means they're not normal source files, so we want this to be a minimal list.
+			'copy-to-clipboard',
+			'graphql-deduplicator',
+			'hoist-non-react-statics',
+			'nullthrows',
+			'papaparse',
+			'prop-types',
+			'react-fast-compare',
+			'react-is',
+			'rehackt',
+			'set-value',
+		],
 		exclude: [
 			// This can't be bundled because it's virtual and supplied by
 			// our vite plugin directly.
@@ -42,5 +58,5 @@ export const viteConfig = ({
 			'virtual:graphweaver-user-supplied-custom-fields',
 		],
 	},
-	plugins: [commonjs(), react(), graphweaver()],
+	plugins: [react(), graphweaver()],
 });

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -288,7 +288,7 @@ importers:
         version: 6.2.9
       '@mikro-orm/postgresql':
         specifier: 6.2.9
-        version: 6.2.9(@mikro-orm/core@6.2.9)
+        version: 6.2.9(@mikro-orm/core@6.2.9)(mysql2@3.10.1)
       graphql:
         specifier: 16.9.0
         version: 16.9.0
@@ -340,10 +340,10 @@ importers:
         version: 6.2.9
       '@mikro-orm/knex':
         specifier: 6.2.9
-        version: 6.2.9(@mikro-orm/core@6.2.9)(pg@8.11.5)(sqlite3@5.1.7)
+        version: 6.2.9(@mikro-orm/core@6.2.9)(mysql2@3.10.1)(pg@8.11.5)
       '@mikro-orm/sqlite':
         specifier: 6.2.9
-        version: 6.2.9(@mikro-orm/core@6.2.9)(pg@8.11.5)
+        version: 6.2.9(@mikro-orm/core@6.2.9)(pg@8.12.0)
       graphql:
         specifier: 16.9.0
         version: 16.9.0
@@ -870,6 +870,9 @@ importers:
       vite:
         specifier: 5.3.2
         version: 5.3.2(@types/node@20.14.9)
+      vite-plugin-commonjs:
+        specifier: 0.10.1
+        version: 0.10.1
       vite-plugin-graphweaver:
         specifier: workspace:*
         version: link:../vite-plugin-graphweaver
@@ -877,9 +880,6 @@ importers:
       '@types/node':
         specifier: 20.14.9
         version: 20.14.9
-      '@types/rimraf':
-        specifier: 4.0.5
-        version: 4.0.5
       prettier:
         specifier: 3.3.2
         version: 3.3.2
@@ -1053,7 +1053,7 @@ importers:
         version: 6.2.9
       '@mikro-orm/postgresql':
         specifier: 6.2.9
-        version: 6.2.9(@mikro-orm/core@6.2.9)
+        version: 6.2.9(@mikro-orm/core@6.2.9)(mysql2@3.10.1)
       '@mikro-orm/sqlite':
         specifier: 6.2.9
         version: 6.2.9(@mikro-orm/core@6.2.9)(pg@8.12.0)
@@ -1142,10 +1142,10 @@ importers:
     dependencies:
       '@mikro-orm/knex':
         specifier: 6.2.9
-        version: 6.2.9(@mikro-orm/core@6.2.9)(pg@8.11.5)(sqlite3@5.1.7)
+        version: 6.2.9(@mikro-orm/core@6.2.9)(mysql2@3.10.1)(pg@8.11.5)
       '@mikro-orm/sqlite':
         specifier: 6.2.9
-        version: 6.2.9(@mikro-orm/core@6.2.9)(pg@8.11.5)
+        version: 6.2.9(@mikro-orm/core@6.2.9)(pg@8.12.0)
       node-sqlite3-wasm:
         specifier: 0.8.16
         version: 0.8.16
@@ -1195,13 +1195,13 @@ importers:
     optionalDependencies:
       '@mikro-orm/knex':
         specifier: 6.2.9
-        version: 6.2.9(@mikro-orm/core@6.2.9)(pg@8.11.5)(sqlite3@5.1.7)
+        version: 6.2.9(@mikro-orm/core@6.2.9)(mysql2@3.10.1)(pg@8.11.5)
       '@mikro-orm/mysql':
         specifier: 6.2.9
         version: 6.2.9(@mikro-orm/core@6.2.9)(pg@8.11.5)
       '@mikro-orm/postgresql':
         specifier: 6.2.9
-        version: 6.2.9(@mikro-orm/core@6.2.9)
+        version: 6.2.9(@mikro-orm/core@6.2.9)(mysql2@3.10.1)
       '@mikro-orm/sqlite':
         specifier: 6.2.9
         version: 6.2.9(@mikro-orm/core@6.2.9)(pg@8.11.5)
@@ -5525,6 +5525,7 @@ packages:
       - supports-color
       - tedious
     dev: false
+    optional: true
 
   /@mikro-orm/knex@6.2.9(@mikro-orm/core@6.2.9)(pg@8.12.0)(sqlite3@5.1.7):
     resolution: {integrity: sha512-eSHPiS5em+RGv/jx5lP7a1xDVVlnrG+l90/7N7WAgTGcPOzyILVw9EJOZl2KR8dh8EfPI6Wm35Lo4qkO2LoDUg==}
@@ -5599,30 +5600,6 @@ packages:
       - tedious
     dev: false
 
-  /@mikro-orm/postgresql@6.2.9(@mikro-orm/core@6.2.9):
-    resolution: {integrity: sha512-CRW5QPvsQhlhRZbx9SsgLrdC7LxCSbz+Pm5rAA8S1SAZG8qJ1WxMovHF61PFZj/7rydnb9fSh4nVwfutOyYwWg==}
-    engines: {node: '>= 18.12.0'}
-    peerDependencies:
-      '@mikro-orm/core': ^6.0.0
-    dependencies:
-      '@mikro-orm/core': 6.2.9
-      '@mikro-orm/knex': 6.2.9(@mikro-orm/core@6.2.9)(pg@8.11.5)(sqlite3@5.1.7)
-      pg: 8.11.5
-      postgres-array: 3.0.2
-      postgres-date: 2.1.0
-      postgres-interval: 4.0.2
-    transitivePeerDependencies:
-      - better-sqlite3
-      - libsql
-      - mariadb
-      - mysql
-      - mysql2
-      - pg-native
-      - sqlite3
-      - supports-color
-      - tedious
-    dev: false
-
   /@mikro-orm/postgresql@6.2.9(@mikro-orm/core@6.2.9)(mysql2@3.10.1):
     resolution: {integrity: sha512-CRW5QPvsQhlhRZbx9SsgLrdC7LxCSbz+Pm5rAA8S1SAZG8qJ1WxMovHF61PFZj/7rydnb9fSh4nVwfutOyYwWg==}
     engines: {node: '>= 18.12.0'}
@@ -5670,6 +5647,7 @@ packages:
       - supports-color
       - tedious
     dev: false
+    optional: true
 
   /@mikro-orm/sqlite@6.2.9(@mikro-orm/core@6.2.9)(pg@8.12.0):
     resolution: {integrity: sha512-+ZdlKEtE8HmqbZWSm44MaZwfeS1AlrhMJrZfRr5tQfvdKi5VuRQ+I87Uxo03Ni5r0JXV1wEfFyWovK5c6h1iCQ==}
@@ -8124,13 +8102,6 @@ packages:
       '@types/node': 20.14.9
     dev: false
 
-  /@types/rimraf@4.0.5:
-    resolution: {integrity: sha512-DTCZoIQotB2SUJnYgrEx43cQIUYOlNZz0AZPbKU4PSLYTUdML5Gox0++z4F9kQocxStrCmRNhi4x5x/UlwtKUA==}
-    deprecated: This is a stub types definition. rimraf provides its own type definitions, so you do not need this installed.
-    dependencies:
-      rimraf: 5.0.7
-    dev: true
-
   /@types/secp256k1@4.0.6:
     resolution: {integrity: sha512-hHxJU6PAEUn0TP4S/ZOzuTUvJWuZ6eIKeNKb5RBpODvSl6hp1Wrw4s7ATY50rklRCScUDpHzVA/DQdSjJ3UoYQ==}
     dependencies:
@@ -10430,6 +10401,10 @@ packages:
   /es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  /es-module-lexer@1.5.4:
+    resolution: {integrity: sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==}
+    dev: false
 
   /es5-ext@0.10.64:
     resolution: {integrity: sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==}
@@ -13204,6 +13179,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+    optional: true
 
   /knex@3.1.0(pg@8.12.0)(sqlite3@5.1.7):
     resolution: {integrity: sha512-GLoII6hR0c4ti243gMs5/1Rb3B+AjwMOfjYm97pu0FOQa7JH56hgBxYf5WK2525ceSbBY1cjeZ9yk99GPMB6Kw==}
@@ -13646,7 +13622,6 @@ packages:
     resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
 
   /make-dir@1.3.0:
     resolution: {integrity: sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==}
@@ -15518,6 +15493,7 @@ packages:
     hasBin: true
     dependencies:
       glob: 10.4.2
+    dev: false
 
   /ripemd160@2.0.2:
     resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
@@ -16982,6 +16958,24 @@ packages:
       - supports-color
       - terser
     dev: true
+
+  /vite-plugin-commonjs@0.10.1:
+    resolution: {integrity: sha512-taP8R9kYGlCW5OzkVR0UIWRCnG6rSxeWWuA7tnU5b9t5MniibOnDY219NhisTeDhJAeGT8cEnrhVWZ9A5yD+vg==}
+    dependencies:
+      acorn: 8.12.0
+      fast-glob: 3.3.2
+      magic-string: 0.30.10
+      vite-plugin-dynamic-import: 1.5.0
+    dev: false
+
+  /vite-plugin-dynamic-import@1.5.0:
+    resolution: {integrity: sha512-Qp85c+AVJmLa8MLni74U4BDiWpUeFNx7NJqbGZyR2XJOU7mgW0cb7nwlAMucFyM4arEd92Nfxp4j44xPi6Fu7g==}
+    dependencies:
+      acorn: 8.12.0
+      es-module-lexer: 1.5.4
+      fast-glob: 3.3.2
+      magic-string: 0.30.10
+    dev: false
 
   /vite-plugin-svgr@4.2.0(typescript@5.5.2)(vite@5.3.2):
     resolution: {integrity: sha512-SC7+FfVtNQk7So0XMjrrtLAbEC8qjFPifyD7+fs/E6aaNdVde6umlVVh0QuwDLdOMu7vp5RiGFsB70nj5yo0XA==}

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -870,9 +870,6 @@ importers:
       vite:
         specifier: 5.3.2
         version: 5.3.2(@types/node@20.14.9)
-      vite-plugin-commonjs:
-        specifier: 0.10.1
-        version: 0.10.1
       vite-plugin-graphweaver:
         specifier: workspace:*
         version: link:../vite-plugin-graphweaver
@@ -10402,10 +10399,6 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  /es-module-lexer@1.5.4:
-    resolution: {integrity: sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==}
-    dev: false
-
   /es5-ext@0.10.64:
     resolution: {integrity: sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==}
     engines: {node: '>=0.10'}
@@ -13622,6 +13615,7 @@ packages:
     resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
 
   /make-dir@1.3.0:
     resolution: {integrity: sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==}
@@ -16958,24 +16952,6 @@ packages:
       - supports-color
       - terser
     dev: true
-
-  /vite-plugin-commonjs@0.10.1:
-    resolution: {integrity: sha512-taP8R9kYGlCW5OzkVR0UIWRCnG6rSxeWWuA7tnU5b9t5MniibOnDY219NhisTeDhJAeGT8cEnrhVWZ9A5yD+vg==}
-    dependencies:
-      acorn: 8.12.0
-      fast-glob: 3.3.2
-      magic-string: 0.30.10
-      vite-plugin-dynamic-import: 1.5.0
-    dev: false
-
-  /vite-plugin-dynamic-import@1.5.0:
-    resolution: {integrity: sha512-Qp85c+AVJmLa8MLni74U4BDiWpUeFNx7NJqbGZyR2XJOU7mgW0cb7nwlAMucFyM4arEd92Nfxp4j44xPi6Fu7g==}
-    dependencies:
-      acorn: 8.12.0
-      es-module-lexer: 1.5.4
-      fast-glob: 3.3.2
-      magic-string: 0.30.10
-    dev: false
 
   /vite-plugin-svgr@4.2.0(typescript@5.5.2)(vite@5.3.2):
     resolution: {integrity: sha512-SC7+FfVtNQk7So0XMjrrtLAbEC8qjFPifyD7+fs/E6aaNdVde6umlVVh0QuwDLdOMu7vp5RiGFsB70nj5yo0XA==}


### PR DESCRIPTION
Now that we're using ESM in our component libraries, we no longer need to tell Vite to pre-bundle them. This prevents needing to clean each time we change the components. Vite now treats our component libraries as standard source, and we're good to go.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added `vite-plugin-commonjs` dependency for better compatibility.
  - Removed `@types/rimraf` dev dependency.

- **Refactor**
  - Simplified and optimised the Vite configuration by restructuring the `viteConfig` function.
  - Enhanced dependency management by explicitly listing dependencies to include and exclude for better optimisation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->