### PR TITLE
Feature / Add excludeFromFederation Metadata Option

### DIFF
--- a/src/examples/federation/src/backend/schema/hidden-entity.ts
+++ b/src/examples/federation/src/backend/schema/hidden-entity.ts
@@ -1,0 +1,12 @@
+import { Entity, Field, ID } from '@exogee/graphweaver';
+
+@Entity('HiddenEntity', {
+	apiOptions: { excludeFromBuiltInOperations: true, excludeFromFederation: true },
+})
+export class HiddenEntity {
+	@Field(() => ID, { primaryKeyField: true })
+	id!: string;
+
+	@Field(() => String, { nullable: true })
+	name?: string;
+}

--- a/src/examples/federation/src/backend/schema/product.ts
+++ b/src/examples/federation/src/backend/schema/product.ts
@@ -12,6 +12,7 @@ import { ProductDimension } from './product-dimension';
 import { ProductResearch } from './product-research';
 import { User } from './user';
 import { data } from '../data';
+import { HiddenEntity } from './hidden-entity';
 
 class JsonDataProvider extends BaseDataProvider<Product> {
 	async findOne(filter: Filter<Product>) {
@@ -66,4 +67,9 @@ export class Product {
 
 	@RelationshipField(() => [ProductResearch], { id: 'research' })
 	research!: ProductResearch;
+
+	// Because HiddenEntity is excluded from federation, this property should not be included in the schema
+	// returned in the _service { sdl } query, but will be visible with standard introspection.
+	@RelationshipField(() => [HiddenEntity], { id: 'hiddenEntityId', nullable: true })
+	hiddenEntities!: HiddenEntity[];
 }

--- a/src/examples/federation/src/frontend/types.generated.ts
+++ b/src/examples/federation/src/frontend/types.generated.ts
@@ -138,6 +138,12 @@ export type DeprecatedProductsPaginationInput = {
   orderBy?: InputMaybe<DeprecatedProductsOrderByInput>;
 };
 
+export type HiddenEntity = {
+  __typename?: 'HiddenEntity';
+  id: Scalars['ID']['output'];
+  name?: Maybe<Scalars['String']['output']>;
+};
+
 export type InventoriesOrderByInput = {
   id?: InputMaybe<Sort>;
 };
@@ -159,6 +165,7 @@ export type Product = {
   __typename?: 'Product';
   createdBy?: Maybe<User>;
   dimensions?: Maybe<ProductDimension>;
+  hiddenEntities?: Maybe<Array<HiddenEntity>>;
   id: Scalars['ID']['output'];
   notes?: Maybe<Scalars['String']['output']>;
   package?: Maybe<Scalars['String']['output']>;

--- a/src/examples/federation/src/types.generated.ts
+++ b/src/examples/federation/src/types.generated.ts
@@ -138,6 +138,12 @@ export type DeprecatedProductsPaginationInput = {
   orderBy?: InputMaybe<DeprecatedProductsOrderByInput>;
 };
 
+export type HiddenEntity = {
+  __typename?: 'HiddenEntity';
+  id: Scalars['ID']['output'];
+  name?: Maybe<Scalars['String']['output']>;
+};
+
 export type InventoriesOrderByInput = {
   id?: InputMaybe<Sort>;
 };
@@ -159,6 +165,7 @@ export type Product = {
   __typename?: 'Product';
   createdBy?: Maybe<User>;
   dimensions?: Maybe<ProductDimension>;
+  hiddenEntities?: Maybe<Array<HiddenEntity>>;
   id: Scalars['ID']['output'];
   notes?: Maybe<Scalars['String']['output']>;
   package?: Maybe<Scalars['String']['output']>;

--- a/src/packages/core/src/federation/directives.ts
+++ b/src/packages/core/src/federation/directives.ts
@@ -3,7 +3,7 @@ import { DirectiveLocation } from 'graphql';
 import { graphweaverMetadata } from '..';
 import { LinkPurpose } from './enums';
 import { FieldSetGraphQLType, LinkImportGraphQLType } from './scalars';
-import { getEntityTargets } from './utils';
+import { EXCLUDED_FROM_FEDERATION_ENTITY_FILTER } from './utils';
 
 const addKeyDirective = () => {
 	// directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
@@ -25,7 +25,9 @@ const addKeyDirective = () => {
 	});
 
 	// Add the key directive to all entities
-	const entities = Array.from(getEntityTargets());
+	const entities = Array.from(graphweaverMetadata.entities()).filter(
+		EXCLUDED_FROM_FEDERATION_ENTITY_FILTER
+	);
 
 	for (const entity of entities) {
 		// Ensure that the entity has a primary key field

--- a/src/packages/core/src/federation/entities.ts
+++ b/src/packages/core/src/federation/entities.ts
@@ -8,12 +8,20 @@ import {
 } from '..';
 import { AnyGraphQLType } from './scalars';
 import { getOne } from '../resolvers';
-import { getEntityTargets } from './utils';
+import { EXCLUDED_FROM_FEDERATION_ENTITY_FILTER } from './utils';
 
 export const addEntitiesQuery = () => {
 	const EntitiesUnion = graphweaverMetadata.collectUnionTypeInformation({
 		name: '_Entity',
-		getTypes: () => Array.from(getEntityTargets()),
+		getTypes: () =>
+			Array.from(graphweaverMetadata.entities())
+				.filter(
+					// The _service entity should not be included in the _entities union specifically
+					// but we don't want to omit it from the whole SDL returned by the _service query itself
+					// so we're just going to filter it out explicitly here.
+					(entity) => EXCLUDED_FROM_FEDERATION_ENTITY_FILTER(entity) && entity.name !== '_service'
+				)
+				.map((entity) => graphQLTypeForEntity(entity, EXCLUDED_FROM_FEDERATION_ENTITY_FILTER)),
 	});
 
 	graphweaverMetadata.addQuery({
@@ -42,7 +50,11 @@ export const addEntitiesQuery = () => {
 				if (!metadata?.target) {
 					throw new Error(`Could not locate metadata for the '${entity.__typename}' entity`);
 				}
-				const graphQLType = graphQLTypeForEntity(metadata);
+
+				// If it's excluded from federation, we don't want it in the _entities response.
+				if (metadata.apiOptions?.excludeFromFederation) continue;
+
+				const graphQLType = graphQLTypeForEntity(metadata, EXCLUDED_FROM_FEDERATION_ENTITY_FILTER);
 
 				// This is a fake GraphQL Resolve Info we pass to ourselves so the resolver will return the correct
 				// result type. The only thing we read in it is the return type, so we'll just stub that.
@@ -52,11 +64,11 @@ export const addEntitiesQuery = () => {
 
 				// each entity in representations is a request for a single instance of that entity
 				const results = await getOne({
-					source: {} as Source, // @todo: What should this be?
+					source: {} as Source,
 					args: { input: entity },
 					context,
 					info: infoFacade as GraphQLResolveInfo,
-					fields: {} as ResolveTree, // @todo: What should this be?
+					fields: {} as ResolveTree,
 				});
 
 				res.push(results);

--- a/src/packages/core/src/federation/service.ts
+++ b/src/packages/core/src/federation/service.ts
@@ -1,14 +1,16 @@
 import { graphweaverMetadata } from '..';
 import { Entity, Field } from '../decorators';
 import { printSchemaWithDirectives } from '@graphql-tools/utils';
-import { buildFederationSchema } from './utils';
+import { EXCLUDED_FROM_FEDERATION_ENTITY_FILTER, buildFederationSchema } from './utils';
 
 export const addServiceQuery = ({
 	schemaDirectives,
 }: {
 	schemaDirectives?: Record<string, any>;
 }) => {
-	@Entity('_service', { apiOptions: { excludeFromBuiltInOperations: true } })
+	@Entity('_service', {
+		apiOptions: { excludeFromBuiltInOperations: true },
+	})
 	class Service {
 		@Field(() => String)
 		sdl!: string;
@@ -22,7 +24,14 @@ export const addServiceQuery = ({
 		getType: () => Service,
 		resolver: () => {
 			return {
-				sdl: printSchemaWithDirectives(buildFederationSchema({ schemaDirectives })),
+				sdl: printSchemaWithDirectives(
+					buildFederationSchema({
+						schemaDirectives,
+
+						// For the _service query, we want to include all entities except for entities that have been marked as excluded from federation
+						filterEntities: EXCLUDED_FROM_FEDERATION_ENTITY_FILTER,
+					})
+				),
 			};
 		},
 	});

--- a/src/packages/core/src/metadata-service/entity-attribute.ts
+++ b/src/packages/core/src/metadata-service/entity-attribute.ts
@@ -1,13 +1,12 @@
 import { Entity, Field } from '../decorators';
 
 @Entity('AdminUiEntityAttributeMetadata', {
-	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { inaccessible: true },
+	apiOptions: { excludeFromBuiltInOperations: true, excludeFromFederation: true },
 })
 export class AdminUiEntityAttributeMetadata {
-	@Field(() => Boolean, { nullable: true, directives: { inaccessible: true } })
+	@Field(() => Boolean, { nullable: true })
 	isReadOnly?: boolean;
 
-	@Field(() => Number, { nullable: true, directives: { inaccessible: true } })
+	@Field(() => Number, { nullable: true })
 	exportPageSize?: number;
 }

--- a/src/packages/core/src/metadata-service/entity.ts
+++ b/src/packages/core/src/metadata-service/entity.ts
@@ -12,34 +12,33 @@ graphweaverMetadata.collectEnumInformation({
 });
 
 @Entity('AdminUiEntityMetadata', {
-	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { inaccessible: true },
+	apiOptions: { excludeFromBuiltInOperations: true, excludeFromFederation: true },
 })
 export class AdminUiEntityMetadata {
-	@Field(() => String, { directives: { inaccessible: true } })
+	@Field(() => String)
 	name!: string;
 
-	@Field(() => String, { directives: { inaccessible: true } })
+	@Field(() => String)
 	plural!: string;
 
-	@Field(() => String, { nullable: true, directives: { inaccessible: true } })
+	@Field(() => String, { nullable: true })
 	backendId?: string | null;
 
-	@Field(() => String, { nullable: true, directives: { inaccessible: true } })
+	@Field(() => String, { nullable: true })
 	summaryField?: string | null;
 
-	@Field(() => String, { directives: { inaccessible: true } })
+	@Field(() => String)
 	primaryKeyField!: string;
 
-	@Field(() => [AdminUiFieldMetadata], { directives: { inaccessible: true } })
+	@Field(() => [AdminUiFieldMetadata])
 	fields?: AdminUiFieldMetadata[] = [];
 
-	@Field(() => GraphQLJSON, { nullable: true, directives: { inaccessible: true } })
+	@Field(() => GraphQLJSON, { nullable: true })
 	defaultFilter?: Filter<unknown>;
 
-	@Field(() => AdminUiEntityAttributeMetadata, { directives: { inaccessible: true } })
+	@Field(() => AdminUiEntityAttributeMetadata)
 	attributes?: AdminUiEntityAttributeMetadata;
 
-	@Field(() => [AggregationType], { directives: { inaccessible: true } })
+	@Field(() => [AggregationType])
 	supportedAggregationTypes!: AggregationType[];
 }

--- a/src/packages/core/src/metadata-service/enum-value.ts
+++ b/src/packages/core/src/metadata-service/enum-value.ts
@@ -1,13 +1,12 @@
 import { Entity, Field } from '../decorators';
 
 @Entity('AdminUiEnumValueMetadata', {
-	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { inaccessible: true },
+	apiOptions: { excludeFromBuiltInOperations: true, excludeFromFederation: true },
 })
 export class AdminUiEnumValueMetadata {
-	@Field(() => String, { directives: { inaccessible: true } })
+	@Field(() => String)
 	name!: string;
 
-	@Field(() => String, { directives: { inaccessible: true } })
+	@Field(() => String)
 	value!: string;
 }

--- a/src/packages/core/src/metadata-service/enum.ts
+++ b/src/packages/core/src/metadata-service/enum.ts
@@ -2,14 +2,13 @@ import { Entity, Field } from '../decorators';
 import { AdminUiEnumValueMetadata } from './enum-value';
 
 @Entity('AdminUiEnumMetadata', {
-	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { inaccessible: true },
+	apiOptions: { excludeFromBuiltInOperations: true, excludeFromFederation: true },
 })
 export class AdminUiEnumMetadata {
-	@Field(() => String, { directives: { inaccessible: true } })
+	@Field(() => String)
 	name!: string;
 
-	@Field(() => [AdminUiEnumValueMetadata], { directives: { inaccessible: true } })
+	@Field(() => [AdminUiEnumValueMetadata])
 	values() {
 		return [];
 	}

--- a/src/packages/core/src/metadata-service/field-attribute.ts
+++ b/src/packages/core/src/metadata-service/field-attribute.ts
@@ -1,13 +1,12 @@
 import { Entity, Field } from '../decorators';
 
 @Entity('AdminUiFieldAttributeMetadata', {
-	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { inaccessible: true },
+	apiOptions: { excludeFromBuiltInOperations: true, excludeFromFederation: true },
 })
 export class AdminUiFieldAttributeMetadata {
-	@Field(() => Boolean, { directives: { inaccessible: true } })
+	@Field(() => Boolean)
 	isReadOnly!: boolean;
 
-	@Field(() => Boolean, { directives: { inaccessible: true } })
+	@Field(() => Boolean)
 	isRequired!: boolean;
 }

--- a/src/packages/core/src/metadata-service/field-extensions.ts
+++ b/src/packages/core/src/metadata-service/field-extensions.ts
@@ -1,10 +1,9 @@
 import { Entity, Field } from '../decorators';
 
 @Entity('AdminUiFieldExtensionsMetadata', {
-	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { inaccessible: true },
+	apiOptions: { excludeFromBuiltInOperations: true, excludeFromFederation: true },
 })
 export class AdminUiFieldExtensionsMetadata {
-	@Field(() => String, { nullable: true, directives: { inaccessible: true } })
+	@Field(() => String, { nullable: true })
 	key?: string;
 }

--- a/src/packages/core/src/metadata-service/field.ts
+++ b/src/packages/core/src/metadata-service/field.ts
@@ -4,37 +4,30 @@ import { AdminUiFieldAttributeMetadata } from './field-attribute';
 import { AdminUiFieldExtensionsMetadata } from './field-extensions';
 
 @Entity('AdminUiFieldMetadata', {
-	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { inaccessible: true },
+	apiOptions: { excludeFromBuiltInOperations: true, excludeFromFederation: true },
 })
 export class AdminUiFieldMetadata {
-	@Field(() => String, { directives: { inaccessible: true } })
+	@Field(() => String)
 	name!: string;
 
-	@Field(() => String, { directives: { inaccessible: true } })
+	@Field(() => String)
 	type!: string;
 
-	@Field(() => String, { nullable: true, directives: { inaccessible: true } })
+	@Field(() => String, { nullable: true })
 	relationshipType?: string;
 
-	@Field(() => String, { nullable: true, directives: { inaccessible: true } })
+	@Field(() => String, { nullable: true })
 	relatedEntity?: string;
 
-	@Field(() => AdminUiFilterMetadata, { nullable: true, directives: { inaccessible: true } })
+	@Field(() => AdminUiFilterMetadata, { nullable: true })
 	filter?: AdminUiFilterMetadata;
 
-	@Field(() => AdminUiFieldAttributeMetadata, {
-		nullable: true,
-		directives: { inaccessible: true },
-	})
+	@Field(() => AdminUiFieldAttributeMetadata, { nullable: true })
 	attributes?: AdminUiFieldAttributeMetadata;
 
-	@Field(() => AdminUiFieldExtensionsMetadata, {
-		nullable: true,
-		directives: { inaccessible: true },
-	})
+	@Field(() => AdminUiFieldExtensionsMetadata, { nullable: true })
 	extensions?: AdminUiFieldExtensionsMetadata;
 
-	@Field(() => Boolean, { nullable: true, directives: { inaccessible: true } })
+	@Field(() => Boolean, { nullable: true })
 	isArray?: boolean;
 }

--- a/src/packages/core/src/metadata-service/filter.ts
+++ b/src/packages/core/src/metadata-service/filter.ts
@@ -8,10 +8,9 @@ graphweaverMetadata.collectEnumInformation({
 });
 
 @Entity('AdminUiFilterMetadata', {
-	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { inaccessible: true },
+	apiOptions: { excludeFromBuiltInOperations: true, excludeFromFederation: true },
 })
 export class AdminUiFilterMetadata {
-	@Field(() => AdminUIFilterType, { directives: { inaccessible: true } })
+	@Field(() => AdminUIFilterType)
 	type!: AdminUIFilterType;
 }

--- a/src/packages/core/src/metadata-service/metadata.ts
+++ b/src/packages/core/src/metadata-service/metadata.ts
@@ -3,13 +3,12 @@ import { AdminUiEntityMetadata } from './entity';
 import { AdminUiEnumMetadata } from './enum';
 
 @Entity('AdminUiMetadata', {
-	apiOptions: { excludeFromBuiltInOperations: true },
-	directives: { inaccessible: true },
+	apiOptions: { excludeFromBuiltInOperations: true, excludeFromFederation: true },
 })
 export class AdminUiMetadata {
-	@Field(() => [AdminUiEntityMetadata], { directives: { inaccessible: true } })
+	@Field(() => [AdminUiEntityMetadata])
 	public entities: AdminUiEntityMetadata[] = [];
 
-	@Field(() => [AdminUiEnumMetadata], { directives: { inaccessible: true } })
+	@Field(() => [AdminUiEnumMetadata])
 	public enums: AdminUiEnumMetadata[] = [];
 }

--- a/src/packages/core/src/metadata.ts
+++ b/src/packages/core/src/metadata.ts
@@ -17,6 +17,11 @@ export interface EntityMetadata<G = unknown, D = unknown> {
 	primaryKeyField?: keyof G;
 
 	apiOptions?: {
+		// This means that the entity will not be returned in federation queries to the _service { sdl } query.
+		// In most cases it'd be better to use @inaccessible, but in some cases you truly do want a private entity
+		// that is usable in your Graphweaver instance but is not part of the schema we tell the federation router about.
+		excludeFromFederation?: boolean;
+
 		// This means that the entity should not be given the default list, find one, create, update, and delete
 		// operations. This is useful for entities that you're defining the API for yourself. Setting this to true
 		// enables excludeFromFiltering as well.

--- a/src/packages/core/src/schema-builder.ts
+++ b/src/packages/core/src/schema-builder.ts
@@ -62,23 +62,39 @@ const allOperations = new Set([
 	...mathOperations,
 ]);
 
-const entityTypes = new Map<string, GraphQLObjectType>();
-const inputTypes = new Map<string, GraphQLInputObjectType>();
-const enumTypes = new Map<string, GraphQLEnumType>();
-const unionTypes = new Map<string, GraphQLUnionType>();
-const filterTypes = new Map<string, GraphQLInputObjectType>();
-const insertTypes = new Map<string, GraphQLInputObjectType>();
-const updateTypes = new Map<string, GraphQLInputObjectType>();
-const createOrUpdateTypes = new Map<string, GraphQLInputObjectType>();
-const paginationTypes = new Map<string, GraphQLInputObjectType>();
+class TypeCache {
+	public readonly entityTypes = new Map<string, GraphQLObjectType>();
+	public readonly inputTypes = new Map<string, GraphQLInputObjectType>();
+	public readonly enumTypes = new Map<string, GraphQLEnumType>();
+	public readonly unionTypes = new Map<string, GraphQLUnionType>();
+	public readonly filterTypes = new Map<string, GraphQLInputObjectType>();
+	public readonly insertTypes = new Map<string, GraphQLInputObjectType>();
+	public readonly updateTypes = new Map<string, GraphQLInputObjectType>();
+	public readonly createOrUpdateTypes = new Map<string, GraphQLInputObjectType>();
+	public readonly paginationTypes = new Map<string, GraphQLInputObjectType>();
+}
+type EntityFilter = (entity: EntityMetadata<any, any>) => boolean;
+const typeCaches = new Map<EntityFilter | undefined, TypeCache>();
+
+const typeCacheForEntityFilter = (entityFilter: EntityFilter | undefined) => {
+	if (!typeCaches.has(entityFilter)) {
+		typeCaches.set(entityFilter, new TypeCache());
+	}
+
+	return typeCaches.get(entityFilter)!;
+};
 
 const scalarShouldGetLikeOperations = (scalar: GraphQLScalarType) => scalar === GraphQLString;
 const scalarShouldGetMathOperations = (
 	scalar: GraphQLScalarType | NumberConstructor | DateConstructor | BigIntConstructor
 ) => scalar === Number || scalar === Date || scalar === BigInt || scalar.name === 'ISOString';
 
-const graphQLTypeForEnum = (enumMetadata: EnumMetadata<any>) => {
-	let enumType = enumTypes.get(enumMetadata.name);
+const graphQLTypeForEnum = (
+	enumMetadata: EnumMetadata<any>,
+	entityFilter: EntityFilter | undefined
+) => {
+	const typeCache = typeCacheForEntityFilter(entityFilter);
+	let enumType = typeCache.enumTypes.get(enumMetadata.name);
 
 	if (!enumType) {
 		const values: GraphQLEnumValueConfigMap = {};
@@ -91,14 +107,18 @@ const graphQLTypeForEnum = (enumMetadata: EnumMetadata<any>) => {
 			values,
 		});
 
-		enumTypes.set(enumMetadata.name, enumType);
+		typeCache.enumTypes.set(enumMetadata.name, enumType);
 	}
 
 	return enumType;
 };
 
-const graphQLTypeForUnion = (unionMetadata: UnionMetadata) => {
-	let unionType = unionTypes.get(unionMetadata.name);
+const graphQLTypeForUnion = (
+	unionMetadata: UnionMetadata,
+	entityFilter: EntityFilter | undefined
+) => {
+	const typeCache = typeCacheForEntityFilter(entityFilter);
+	let unionType = typeCache.unionTypes.get(unionMetadata.name);
 
 	if (!unionType) {
 		const entitiesInUnion = unionMetadata.getTypes();
@@ -115,7 +135,7 @@ const graphQLTypeForUnion = (unionMetadata: UnionMetadata) => {
 
 		// Map types to GraphQL types
 		const graphQLTypes = entitiesInUnion.map((type) => {
-			const entityType = entityTypes.get(type.name);
+			const entityType = typeCache.entityTypes.get(type.name);
 			if (!entityType) {
 				throw new Error(`Union ${unionMetadata.name} has non-entity types.`);
 			}
@@ -128,7 +148,7 @@ const graphQLTypeForUnion = (unionMetadata: UnionMetadata) => {
 			types: graphQLTypes,
 		});
 
-		unionTypes.set(unionMetadata.name, unionType);
+		typeCache.unionTypes.set(unionMetadata.name, unionType);
 	}
 
 	return new GraphQLNonNull(new GraphQLList(unionType));
@@ -211,11 +231,15 @@ const graphQLScalarForTypeScriptType = (type: TypeValue): GraphQLScalarType => {
 	}
 };
 
-const graphQLTypeForScalarEnumOrUnion = (metadata: unknown, type: TypeValue) => {
+const graphQLTypeForScalarEnumOrUnion = (
+	metadata: unknown,
+	type: TypeValue,
+	entityFilter: EntityFilter | undefined
+) => {
 	if (isEnumMetadata(metadata)) {
-		return graphQLTypeForEnum(metadata);
+		return graphQLTypeForEnum(metadata, entityFilter);
 	} else if (isUnionMetadata(metadata)) {
-		return graphQLTypeForUnion(metadata);
+		return graphQLTypeForUnion(metadata, entityFilter);
 	}
 
 	return graphQLScalarForTypeScriptType(type);
@@ -229,8 +253,12 @@ type GraphQLInputTypes =
 	| GraphQLList<any>
 	| GraphQLNonNull<any>;
 
-const graphQLTypeForInput = (input: InputTypeMetadata<any, any>) => {
-	let inputType = inputTypes.get(input.name);
+const graphQLTypeForInput = (
+	input: InputTypeMetadata<any, any>,
+	entityFilter: EntityFilter | undefined
+) => {
+	const typeCache = typeCacheForEntityFilter(entityFilter);
+	let inputType = typeCache.inputTypes.get(input.name);
 
 	if (!inputType) {
 		inputType = new GraphQLInputObjectType({
@@ -245,9 +273,9 @@ const graphQLTypeForInput = (input: InputTypeMetadata<any, any>) => {
 					let graphQLType: GraphQLInputTypes | undefined = undefined;
 
 					if (isInputMetadata(metadata)) {
-						graphQLType = graphQLTypeForInput(metadata);
+						graphQLType = graphQLTypeForInput(metadata, entityFilter);
 					} else {
-						graphQLType = graphQLTypeForScalarEnumOrUnion(metadata, fieldType);
+						graphQLType = graphQLTypeForScalarEnumOrUnion(metadata, fieldType, entityFilter);
 					}
 
 					// If it's an array, wrap it in a list and make it not nullable within the list.
@@ -268,15 +296,19 @@ const graphQLTypeForInput = (input: InputTypeMetadata<any, any>) => {
 		});
 	}
 
-	inputTypes.set(input.name, inputType);
+	typeCache.inputTypes.set(input.name, inputType);
 
 	return inputType;
 };
 
 // This is exported because deep within the create or update logic we need to stub a GraphQLResolveInfo object.
 // It's not meant to be used as a public API, please use the SchemaBuilder export unless you have a good reason not to.
-export const graphQLTypeForEntity = (entity: EntityMetadata<any, any>) => {
-	let entityType = entityTypes.get(entity.name);
+export const graphQLTypeForEntity = (
+	entity: EntityMetadata<any, any>,
+	entityFilter: EntityFilter | undefined
+) => {
+	const typeCache = typeCacheForEntityFilter(entityFilter);
+	let entityType = typeCache.entityTypes.get(entity.name);
 
 	if (!entityType) {
 		entityType = new GraphQLObjectType({
@@ -296,20 +328,23 @@ export const graphQLTypeForEntity = (entity: EntityMetadata<any, any>) => {
 					const args: ObjMap<GraphQLArgumentConfig> = {};
 
 					if (isEntityMetadata(metadata)) {
-						graphQLType = graphQLTypeForEntity(metadata);
+						// If the entity filter says no, we don't need to build out this field.
+						if (entityFilter && !entityFilter(metadata)) continue;
+
+						graphQLType = graphQLTypeForEntity(metadata, entityFilter);
 
 						if (metadata.provider) {
 							resolve = resolvers.baseResolver(resolvers.listRelationshipField);
 
 							if (metadata.provider.backendProviderConfig?.filter) {
 								args['filter'] = {
-									type: filterTypeForEntity(metadata),
+									type: filterTypeForEntity(metadata, entityFilter),
 								};
 							}
 						}
 					} else {
 						// Ok, it's some kind of in-built scalar we need to map.
-						graphQLType = graphQLTypeForScalarEnumOrUnion(metadata, fieldType);
+						graphQLType = graphQLTypeForScalarEnumOrUnion(metadata, fieldType, entityFilter);
 					}
 
 					// If it's an array, wrap it in a list and make it not nullable within the list.
@@ -351,7 +386,7 @@ export const graphQLTypeForEntity = (entity: EntityMetadata<any, any>) => {
 						fields[`${field.name}_aggregate`] = {
 							type: aggregationResult,
 							args: {
-								filter: { type: filterTypeForEntity(metadata) },
+								filter: { type: filterTypeForEntity(metadata, entityFilter) },
 							},
 
 							// TODO: Why is any required here?
@@ -366,14 +401,18 @@ export const graphQLTypeForEntity = (entity: EntityMetadata<any, any>) => {
 			},
 		});
 
-		entityTypes.set(entity.name, entityType);
+		typeCache.entityTypes.set(entity.name, entityType);
 	}
 
 	return entityType;
 };
 
-const filterTypeForEntity = (entity: EntityMetadata<any, any>) => {
-	let filterType = filterTypes.get(entity.name);
+const filterTypeForEntity = (
+	entity: EntityMetadata<any, any>,
+	entityFilter: EntityFilter | undefined
+) => {
+	const typeCache = typeCacheForEntityFilter(entityFilter);
+	let filterType = typeCache.filterTypes.get(entity.name);
 	if (!filterType) {
 		filterType = new GraphQLInputObjectType({
 			name: `${entity.plural}ListFilter`,
@@ -386,6 +425,9 @@ const filterTypeForEntity = (entity: EntityMetadata<any, any>) => {
 					const metadata = graphweaverMetadata.metadataForType(fieldType);
 
 					if (isEntityMetadata(metadata)) {
+						// If the entity filter says no, we don't need to build out this field.
+						if (entityFilter && !entityFilter(metadata)) continue;
+
 						if (
 							// These conditions are separate from the `if` above because we don't want to
 							// go down the else if chain for entities regardless of whether these options
@@ -394,7 +436,7 @@ const filterTypeForEntity = (entity: EntityMetadata<any, any>) => {
 							!metadata.apiOptions?.excludeFromFiltering
 						) {
 							fields[field.name] = {
-								type: filterTypeForEntity(metadata),
+								type: filterTypeForEntity(metadata, entityFilter),
 							};
 						}
 					} else if (isScalarType(fieldType)) {
@@ -437,17 +479,21 @@ const filterTypeForEntity = (entity: EntityMetadata<any, any>) => {
 			},
 		});
 
-		filterTypes.set(entity.name, filterType);
+		typeCache.filterTypes.set(entity.name, filterType);
 	}
 
 	return filterType;
 };
 
-const paginationTypeForEntity = (entity: EntityMetadata<any, any>) => {
-	let paginationType = paginationTypes.get(entity.name);
+const paginationTypeForEntity = (
+	entity: EntityMetadata<any, any>,
+	entityFilter: EntityFilter | undefined
+) => {
+	const typeCache = typeCacheForEntityFilter(entityFilter);
+	let paginationType = typeCache.paginationTypes.get(entity.name);
 	const sortEnumMetadata = graphweaverMetadata.getEnumByName('Sort');
 	if (!sortEnumMetadata) throw new Error('Could not locate Sort enum, which should be built in.');
-	const sortEnum = graphQLTypeForEnum(sortEnumMetadata);
+	const sortEnum = graphQLTypeForEnum(sortEnumMetadata, entityFilter);
 
 	if (!paginationType) {
 		paginationType = new GraphQLInputObjectType({
@@ -491,14 +537,19 @@ const paginationTypeForEntity = (entity: EntityMetadata<any, any>) => {
 			},
 		});
 
-		paginationTypes.set(entity.name, paginationType);
+		typeCache.paginationTypes.set(entity.name, paginationType);
 	}
 
 	return paginationType;
 };
 
 const generateGraphQLInputFieldsForEntity =
-	(entity: EntityMetadata<any, any>, input: 'insert' | 'update' | 'createOrUpdate') => () => {
+	(
+		entity: EntityMetadata<any, any>,
+		input: 'insert' | 'update' | 'createOrUpdate',
+		entityFilter: EntityFilter | undefined
+	) =>
+	() => {
 		const fields: ObjMap<GraphQLInputFieldConfig> = {};
 		for (const field of Object.values(entity.fields)) {
 			// If it's excluded from built-in write operations, skip it.
@@ -523,12 +574,15 @@ const generateGraphQLInputFieldsForEntity =
 			const { fieldType, metadata, isList } = getFieldTypeWithMetadata(field.getType);
 
 			if (isEntityMetadata(metadata)) {
+				// If the entity filter says no, we don't need to build out this field.
+				if (entityFilter && !entityFilter(metadata)) continue;
+
 				// This if is separate to stop us cascading down to the scalar branch for entities that
 				if (
 					!metadata.apiOptions?.excludeFromBuiltInOperations &&
 					!metadata.apiOptions?.excludeFromBuiltInWriteOperations
 				) {
-					let type: GraphQLInputType = createOrUpdateTypeForEntity(metadata);
+					let type: GraphQLInputType = createOrUpdateTypeForEntity(metadata, entityFilter);
 
 					if (isList) {
 						// If it's a many relationship we need to wrap in non-null and list.
@@ -539,7 +593,11 @@ const generateGraphQLInputFieldsForEntity =
 				}
 			} else {
 				fields[field.name] = {
-					type: graphQLTypeForScalarEnumOrUnion(metadata, fieldType) as GraphQLInputType,
+					type: graphQLTypeForScalarEnumOrUnion(
+						metadata,
+						fieldType,
+						entityFilter
+					) as GraphQLInputType,
 				};
 			}
 
@@ -557,55 +615,70 @@ const generateGraphQLInputFieldsForEntity =
 		return fields;
 	};
 
-const insertTypeForEntity = (entity: EntityMetadata<any, any>) => {
-	let insertType = insertTypes.get(entity.name);
+const insertTypeForEntity = (
+	entity: EntityMetadata<any, any>,
+	entityFilter: EntityFilter | undefined
+) => {
+	const typeCache = typeCacheForEntityFilter(entityFilter);
+	let insertType = typeCache.insertTypes.get(entity.name);
 
 	if (!insertType) {
 		insertType = new GraphQLInputObjectType({
 			name: `${entity.name}InsertInput`,
 			description: `Data needed to create ${entity.plural}.`,
-			fields: generateGraphQLInputFieldsForEntity(entity, 'insert'),
+			fields: generateGraphQLInputFieldsForEntity(entity, 'insert', entityFilter),
 		});
 
-		insertTypes.set(entity.name, insertType);
+		typeCache.insertTypes.set(entity.name, insertType);
 	}
 
 	return insertType;
 };
 
-const createOrUpdateTypeForEntity = (entity: EntityMetadata<any, any>) => {
-	let createOrUpdateType = createOrUpdateTypes.get(entity.name);
+const createOrUpdateTypeForEntity = (
+	entity: EntityMetadata<any, any>,
+	entityFilter: EntityFilter | undefined
+) => {
+	const typeCache = typeCacheForEntityFilter(entityFilter);
+	let createOrUpdateType = typeCache.createOrUpdateTypes.get(entity.name);
 
 	if (!createOrUpdateType) {
 		createOrUpdateType = new GraphQLInputObjectType({
 			name: `${entity.name}CreateOrUpdateInput`,
 			description: `Data needed to create or update ${entity.plural}. If an ID is passed, this is an update, otherwise it's an insert.`,
-			fields: generateGraphQLInputFieldsForEntity(entity, 'createOrUpdate'),
+			fields: generateGraphQLInputFieldsForEntity(entity, 'createOrUpdate', entityFilter),
 		});
 
-		createOrUpdateTypes.set(entity.name, createOrUpdateType);
+		typeCache.createOrUpdateTypes.set(entity.name, createOrUpdateType);
 	}
 
 	return createOrUpdateType;
 };
 
-const updateTypeForEntity = (entity: EntityMetadata<any, any>) => {
-	let updateType = updateTypes.get(entity.name);
+const updateTypeForEntity = (
+	entity: EntityMetadata<any, any>,
+	entityFilter: EntityFilter | undefined
+) => {
+	const typeCache = typeCacheForEntityFilter(entityFilter);
+	let updateType = typeCache.updateTypes.get(entity.name);
 
 	if (!updateType) {
 		updateType = new GraphQLInputObjectType({
 			name: `${entity.name}UpdateInput`,
 			description: `Data needed to update ${entity.plural}. An ID must be passed.`,
-			fields: generateGraphQLInputFieldsForEntity(entity, 'update'),
+			fields: generateGraphQLInputFieldsForEntity(entity, 'update', entityFilter),
 		});
 
-		updateTypes.set(entity.name, updateType);
+		typeCache.updateTypes.set(entity.name, updateType);
 	}
 
 	return updateType;
 };
 
-type SchemaBuildOptions = { schemaDirectives?: Record<string, unknown> };
+type SchemaBuildOptions = {
+	schemaDirectives?: Record<string, unknown>;
+	filterEntities?: (entity: EntityMetadata<any, any>) => boolean;
+};
 
 class SchemaBuilderImplementation {
 	public build(buildOptions?: SchemaBuildOptions) {
@@ -613,10 +686,10 @@ class SchemaBuilderImplementation {
 		// Note: It's really important that this runs before the query and mutation
 		// steps below, as the fields in those reference the types we generate here.
 
-		const directives = Array.from(this.buildDirectives());
-		const types = Array.from(this.buildTypes());
-		const query = this.buildQueryType();
-		const mutation = this.buildMutationType();
+		const directives = Array.from(this.buildDirectives(buildOptions?.filterEntities));
+		const types = Array.from(this.buildTypes(buildOptions?.filterEntities));
+		const query = this.buildQueryType(buildOptions?.filterEntities);
+		const mutation = this.buildMutationType(buildOptions?.filterEntities);
 
 		logger.trace({ types, query, mutation, directives }, 'Built schema');
 
@@ -637,17 +710,19 @@ class SchemaBuilderImplementation {
 		return allOperations.has(filterOperation);
 	}
 
-	private *buildTypes() {
+	private *buildTypes(entityFilter: EntityFilter | undefined) {
 		for (const entity of graphweaverMetadata.entities()) {
+			if (entityFilter && !entityFilter(entity)) continue;
+
 			// The core entity object type
-			yield graphQLTypeForEntity(entity);
+			yield graphQLTypeForEntity(entity, entityFilter);
 
 			if (
 				!entity.apiOptions?.excludeFromBuiltInOperations &&
 				!entity.apiOptions?.excludeFromFiltering
 			) {
 				// The input type for filtering
-				yield filterTypeForEntity(entity);
+				yield filterTypeForEntity(entity, entityFilter);
 			}
 
 			if (
@@ -655,30 +730,30 @@ class SchemaBuilderImplementation {
 				!entity.apiOptions?.excludeFromBuiltInWriteOperations
 			) {
 				// The input type for inserting
-				yield insertTypeForEntity(entity);
+				yield insertTypeForEntity(entity, entityFilter);
 
 				// The input type for inserting
-				yield updateTypeForEntity(entity);
+				yield updateTypeForEntity(entity, entityFilter);
 
 				// The input type for creating or updating
-				yield createOrUpdateTypeForEntity(entity);
+				yield createOrUpdateTypeForEntity(entity, entityFilter);
 			}
 
 			// The input type for pagination and sorting
 			// This is only emitted if the entity has a provider, as it's only used for querying.
 			if (entity.provider) {
-				yield paginationTypeForEntity(entity);
+				yield paginationTypeForEntity(entity, entityFilter);
 			}
 		}
 
 		// Also emit all our input types.
 		for (const input of graphweaverMetadata.inputTypes()) {
-			yield graphQLTypeForInput(input);
+			yield graphQLTypeForInput(input, entityFilter);
 		}
 
 		// Also emit all our enums.
 		for (const enumType of graphweaverMetadata.enums()) {
-			yield graphQLTypeForEnum(enumType);
+			yield graphQLTypeForEnum(enumType, entityFilter);
 		}
 
 		// We have some singleton types to emit here too.
@@ -686,7 +761,10 @@ class SchemaBuilderImplementation {
 		yield deleteInput;
 	}
 
-	private graphQLTypeForArgs(args?: ArgsMetadata): GraphQLFieldConfigArgumentMap {
+	private graphQLTypeForArgs(
+		entityFilter: EntityFilter | undefined,
+		args?: ArgsMetadata
+	): GraphQLFieldConfigArgumentMap {
 		const map: GraphQLFieldConfigArgumentMap = {};
 		if (!args) return map;
 
@@ -697,9 +775,9 @@ class SchemaBuilderImplementation {
 
 			let inputType: GraphQLInputTypes;
 			if (isInputMetadata(metadata)) {
-				inputType = graphQLTypeForInput(metadata);
+				inputType = graphQLTypeForInput(metadata, entityFilter);
 			} else {
-				inputType = graphQLTypeForScalarEnumOrUnion(metadata, fieldType);
+				inputType = graphQLTypeForScalarEnumOrUnion(metadata, fieldType, entityFilter);
 			}
 
 			if (isArgMetadata(details) && !details.nullable) {
@@ -722,13 +800,15 @@ class SchemaBuilderImplementation {
 		return map;
 	}
 
-	private buildQueryType() {
+	private buildQueryType(entityFilter: EntityFilter | undefined) {
 		return new GraphQLObjectType({
 			name: 'Query',
 			fields: () => {
 				const fields: ThunkObjMap<GraphQLFieldConfig<any, any, any>> = {};
 
 				for (const entity of graphweaverMetadata.entities()) {
+					// If the entityFilter says no, skip it.
+					if (entityFilter && !entityFilter(entity)) continue;
 					// If it's excluded from built-in operations, skip it.
 					if (entity.apiOptions?.excludeFromBuiltInOperations) continue;
 					// If this entity does not have a data provider, skip it.
@@ -741,7 +821,7 @@ class SchemaBuilderImplementation {
 					}
 					fields[oneQueryName] = {
 						description: `Get a single ${entity.name}.`,
-						type: graphQLTypeForEntity(entity),
+						type: graphQLTypeForEntity(entity, entityFilter),
 						args: {
 							id: { type: new GraphQLNonNull(ID) },
 						},
@@ -755,10 +835,10 @@ class SchemaBuilderImplementation {
 					}
 					fields[listQueryName] = {
 						description: `Get multiple ${entity.plural}.`,
-						type: new GraphQLList(graphQLTypeForEntity(entity)),
+						type: new GraphQLList(graphQLTypeForEntity(entity, entityFilter)),
 						args: {
-							filter: { type: filterTypeForEntity(entity) },
-							pagination: { type: paginationTypeForEntity(entity) },
+							filter: { type: filterTypeForEntity(entity, entityFilter) },
+							pagination: { type: paginationTypeForEntity(entity, entityFilter) },
 						},
 						resolve: resolvers.baseResolver(resolvers.list),
 					};
@@ -769,7 +849,7 @@ class SchemaBuilderImplementation {
 							description: `Get aggregated data for ${entity.plural}.`,
 							type: aggregationResult,
 							args: {
-								filter: { type: filterTypeForEntity(entity) },
+								filter: { type: filterTypeForEntity(entity, entityFilter) },
 							},
 							resolve: resolvers.baseResolver(resolvers.aggregate(entity)),
 						};
@@ -783,22 +863,30 @@ class SchemaBuilderImplementation {
 					}
 
 					const { fieldType, metadata } = getFieldTypeWithMetadata(customQuery.getType);
-					const customArgs = this.graphQLTypeForArgs(customQuery.args);
+					const customArgs = this.graphQLTypeForArgs(entityFilter, customQuery.args);
 
 					if (isEntityMetadata(metadata)) {
+						// If the entity filter says no, we will ignore their custom query because it references
+						// an entity that is filtered out of this schema.
+						if (entityFilter && !entityFilter(metadata)) continue;
+
 						// We're no longer checking for `excludeFromBuiltInOperations` here because this is
 						// a user or system defined additional query, so by definition it needs to be included here.
 						fields[customQuery.name] = {
 							...customQuery,
 							args: customArgs,
-							type: graphQLTypeForEntity(metadata),
+							type: graphQLTypeForEntity(metadata, entityFilter),
 							resolve: trace(resolvers.baseResolver(customQuery.resolver)),
 							extensions: {
 								directives: customQuery.directives ?? {},
 							},
 						};
 					} else {
-						const type: GraphQLOutputType = graphQLTypeForScalarEnumOrUnion(metadata, fieldType);
+						const type: GraphQLOutputType = graphQLTypeForScalarEnumOrUnion(
+							metadata,
+							fieldType,
+							entityFilter
+						);
 
 						fields[customQuery.name] = {
 							...customQuery,
@@ -816,13 +904,16 @@ class SchemaBuilderImplementation {
 		});
 	}
 
-	private buildMutationType() {
+	private buildMutationType(entityFilter: EntityFilter | undefined) {
 		const mutation = new GraphQLObjectType({
 			name: 'Mutation',
 			fields: () => {
 				const fields: ThunkObjMap<GraphQLFieldConfig<any, any, any>> = {};
 
 				for (const entity of graphweaverMetadata.entities()) {
+					// If the entityFilter says no, skip it.
+					if (entityFilter && !entityFilter(entity)) continue;
+
 					// If it's excluded from built-in operations, skip it.
 					if (entity.apiOptions?.excludeFromBuiltInOperations) continue;
 					if (entity.apiOptions?.excludeFromBuiltInWriteOperations) continue;
@@ -837,9 +928,9 @@ class SchemaBuilderImplementation {
 					}
 					fields[createOneName] = {
 						description: `Create a single ${entity.name}.`,
-						type: graphQLTypeForEntity(entity),
+						type: graphQLTypeForEntity(entity, entityFilter),
 						args: {
-							input: { type: new GraphQLNonNull(insertTypeForEntity(entity)) },
+							input: { type: new GraphQLNonNull(insertTypeForEntity(entity, entityFilter)) },
 						},
 						resolve: resolvers.baseResolver(resolvers.createOrUpdate),
 					};
@@ -851,11 +942,11 @@ class SchemaBuilderImplementation {
 					}
 					fields[createManyName] = {
 						description: `Create many ${entity.plural}.`,
-						type: new GraphQLList(graphQLTypeForEntity(entity)),
+						type: new GraphQLList(graphQLTypeForEntity(entity, entityFilter)),
 						args: {
 							input: {
 								type: new GraphQLNonNull(
-									new GraphQLList(new GraphQLNonNull(insertTypeForEntity(entity)))
+									new GraphQLList(new GraphQLNonNull(insertTypeForEntity(entity, entityFilter)))
 								),
 							},
 						},
@@ -869,9 +960,9 @@ class SchemaBuilderImplementation {
 					}
 					fields[updateOneName] = {
 						description: `Update a single ${entity.name}.`,
-						type: graphQLTypeForEntity(entity),
+						type: graphQLTypeForEntity(entity, entityFilter),
 						args: {
-							input: { type: new GraphQLNonNull(updateTypeForEntity(entity)) },
+							input: { type: new GraphQLNonNull(updateTypeForEntity(entity, entityFilter)) },
 						},
 						resolve: resolvers.baseResolver(resolvers.createOrUpdate),
 					};
@@ -883,11 +974,11 @@ class SchemaBuilderImplementation {
 					}
 					fields[updateManyName] = {
 						description: `Update many ${entity.plural}.`,
-						type: new GraphQLList(graphQLTypeForEntity(entity)),
+						type: new GraphQLList(graphQLTypeForEntity(entity, entityFilter)),
 						args: {
 							input: {
 								type: new GraphQLNonNull(
-									new GraphQLList(new GraphQLNonNull(updateTypeForEntity(entity)))
+									new GraphQLList(new GraphQLNonNull(updateTypeForEntity(entity, entityFilter)))
 								),
 							},
 						},
@@ -901,11 +992,13 @@ class SchemaBuilderImplementation {
 					}
 					fields[createOrUpdateManyName] = {
 						description: `Create or update many ${entity.plural}.`,
-						type: new GraphQLList(graphQLTypeForEntity(entity)),
+						type: new GraphQLList(graphQLTypeForEntity(entity, entityFilter)),
 						args: {
 							input: {
 								type: new GraphQLNonNull(
-									new GraphQLList(new GraphQLNonNull(createOrUpdateTypeForEntity(entity)))
+									new GraphQLList(
+										new GraphQLNonNull(createOrUpdateTypeForEntity(entity, entityFilter))
+									)
 								),
 							},
 						},
@@ -937,7 +1030,7 @@ class SchemaBuilderImplementation {
 						description: `Delete many ${entity.plural} with a filter.`,
 						type: GraphQLBoolean,
 						args: {
-							filter: { type: new GraphQLNonNull(filterTypeForEntity(entity)) },
+							filter: { type: new GraphQLNonNull(filterTypeForEntity(entity, entityFilter)) },
 						},
 						resolve: resolvers.baseResolver(resolvers.deleteMany(entity)),
 					};
@@ -951,15 +1044,19 @@ class SchemaBuilderImplementation {
 
 					const type = customMutation.getType();
 					const metadata = graphweaverMetadata.metadataForType(type);
-					const customArgs = this.graphQLTypeForArgs(customMutation.args);
+					const customArgs = this.graphQLTypeForArgs(entityFilter, customMutation.args);
 
 					if (isEntityMetadata(metadata)) {
+						// If the entity filter says no, we will ignore their custom mutation because it references
+						// an entity that is filtered out of this schema.
+						if (entityFilter && !entityFilter(metadata)) continue;
+
 						// We're no longer checking for `excludeFromBuiltInOperations` here because this is
 						// a user or system defined additional query, so by definition it needs to be included here.
 						fields[customMutation.name] = {
 							...customMutation,
 							args: customArgs,
-							type: graphQLTypeForEntity(metadata),
+							type: graphQLTypeForEntity(metadata, entityFilter),
 							resolve: trace(resolvers.baseResolver(customMutation.resolver)),
 							extensions: {
 								directives: customMutation.directives ?? {},
@@ -989,13 +1086,13 @@ class SchemaBuilderImplementation {
 		return mutation;
 	}
 
-	private *buildDirectives() {
+	private *buildDirectives(entityFilter: EntityFilter | undefined) {
 		for (const directive of graphweaverMetadata.directives()) {
 			const directiveType = new GraphQLDirective({
 				name: directive.name,
 				description: directive.description,
 				locations: directive.locations,
-				args: this.graphQLTypeForArgs(directive.args),
+				args: this.graphQLTypeForArgs(entityFilter, directive.args),
 				isRepeatable: directive.isRepeatable,
 			});
 

--- a/src/packages/core/src/utils/create-or-update-entities.ts
+++ b/src/packages/core/src/utils/create-or-update-entities.ts
@@ -45,7 +45,7 @@ const runChildCreateOrUpdate = <G = unknown>(
 	data: Partial<G> | Partial<G>[],
 	context: BaseContext
 ): Promise<G | G[]> => {
-	const graphQLType = graphQLTypeForEntity(entityMetadata);
+	const graphQLType = graphQLTypeForEntity(entityMetadata, undefined);
 
 	// This is a fake GraphQL Resolve Info we pass to ourselves so the resolver will return the correct
 	// result type. The only thing we read in it is the return type, so we'll just stub that.

--- a/src/packages/end-to-end/src/__tests__/api/metadata/exclude-from-federation.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/metadata/exclude-from-federation.test.ts
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 import assert from 'assert';
 import Graphweaver from '@exogee/graphweaver-server';
 import { Field, ID, Entity, BaseDataProvider, RelationshipField } from '@exogee/graphweaver';
-import { Kind, ObjectTypeDefinitionNode, isObjectType, parse } from 'graphql';
+import { Kind, ObjectTypeDefinitionNode, parse } from 'graphql';
 
 // ESLint, I know it looks like the entities in this file aren't used, but they actually are.
 /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/src/packages/end-to-end/src/__tests__/api/metadata/exclude-from-federation.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/metadata/exclude-from-federation.test.ts
@@ -1,0 +1,107 @@
+import gql from 'graphql-tag';
+import assert from 'assert';
+import Graphweaver from '@exogee/graphweaver-server';
+import { Field, ID, Entity, BaseDataProvider, RelationshipField } from '@exogee/graphweaver';
+import { Kind, ObjectTypeDefinitionNode, isObjectType, parse } from 'graphql';
+
+// ESLint, I know it looks like the entities in this file aren't used, but they actually are.
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+test('should include User in the schema but not in the federation _service { sdl } query', async () => {
+	@Entity('Task', {
+		provider: new BaseDataProvider('task'),
+	})
+	class Task {
+		@Field(() => ID)
+		id!: string;
+
+		@RelationshipField(() => User, { relatedField: 'id' })
+		userId!: string;
+	}
+
+	@Entity('User', {
+		provider: new BaseDataProvider('user'),
+		apiOptions: { excludeFromFederation: true },
+	})
+	class User {
+		@Field(() => ID)
+		id!: string;
+
+		@Field(() => String)
+		name!: string;
+	}
+	const graphweaver = new Graphweaver({ enableFederation: true });
+
+	// Federation _service { sdl } query should not include User
+	const response = await graphweaver.server.executeOperation<{ _service: { sdl: string } }>({
+		query: gql`
+			query {
+				_service {
+					sdl
+				}
+			}
+		`,
+	});
+	assert(response.body.kind === 'single');
+	assert(response.body.singleResult.data?._service !== undefined);
+
+	const document = parse(response.body.singleResult.data?._service.sdl);
+
+	// The User type shouldn't exist at all
+	expect(
+		document.definitions.find(
+			(definition) =>
+				definition.kind === Kind.OBJECT_TYPE_DEFINITION && definition.name.value === 'User'
+		)
+	).toBeUndefined();
+
+	// And the user field on task shouldn't exist either
+	const taskType = document.definitions.find(
+		(definition) =>
+			definition.kind === Kind.OBJECT_TYPE_DEFINITION && definition.name.value === 'Task'
+	) as ObjectTypeDefinitionNode;
+	expect(taskType.fields?.length).toBe(1);
+	expect(taskType.fields?.[0].name.value).toBe('id');
+
+	// But the normal introspection should
+	const introspection = await graphweaver.server.executeOperation<{
+		__schema: { types: { name: string; fields: { name: string }[] }[] };
+	}>({
+		query: gql`
+			query {
+				__schema {
+					types {
+						kind
+						name
+						fields {
+							name
+						}
+					}
+				}
+			}
+		`,
+	});
+	assert(introspection.body.kind === 'single');
+	const mutations = introspection.body.singleResult.data?.__schema?.types?.find(
+		(type: any) => type.name === 'Mutation'
+	);
+	assert(mutations);
+	const mutationNames = mutations.fields.map((field: any) => field.name);
+
+	expect(mutationNames).toContain('createUsers');
+	expect(mutationNames).toContain('createUser');
+	expect(mutationNames).toContain('updateUsers');
+	expect(mutationNames).toContain('createOrUpdateUsers');
+	expect(mutationNames).toContain('updateUser');
+	expect(mutationNames).toContain('deleteUser');
+	expect(mutationNames).toContain('deleteUsers');
+
+	const queries = introspection.body.singleResult.data?.__schema?.types?.find(
+		(type: any) => type.name === 'Query'
+	);
+	assert(queries);
+	const queryNames = queries.fields.map((field: any) => field.name);
+
+	expect(queryNames).toContain('user');
+	expect(queryNames).toContain('users');
+});

--- a/src/packages/server/src/index.ts
+++ b/src/packages/server/src/index.ts
@@ -137,9 +137,7 @@ export default class Graphweaver<TContext extends BaseContext> {
 				// It is recommended to ensure that federated subgraphs are not directly exposed to the public Internet. This feature is disabled by default for security reasons.
 				if (this.config.enableFederationTracing) plugins.push(ApolloServerPluginInlineTrace());
 
-				this.schema = buildFederationSchema({
-					schemaDirectives: this.config.schemaDirectives,
-				});
+				this.schema = buildFederationSchema({ schemaDirectives: this.config.schemaDirectives });
 			} else {
 				this.schema = SchemaBuilder.build({ schemaDirectives: this.config.schemaDirectives });
 			}


### PR DESCRIPTION
This PR adds a feature to entities. You can now specify `apiOptions { excludeFromFederation: true }`. When you do this, the entity exists, it gets all of its normal operations, but anything referencing that entity is omitted from the `_service { sdl }` response sent to federation routers.

This should not be needed in most cases, but is useful if you have a private data set that you want to have accessible in GraphQL, but can't make compliant with the requirements of Federation for whatever reason.

We use this for our `_graphweaver` metadata query, as multiple graphweaver instances will never return the same values from these queries, and nor should they.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced exclusion of specific entities from federation queries for improved schema management.

- **Tests**
  - Added test cases to verify the exclusion of the `User` entity from federation `_service { sdl }` query.
  - Ensured correct presence and introspection of other entities and operations in the schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->