### PR TITLE
Feature / Allow Federation Namespacing, Fix S in _Service

### DIFF
--- a/src/examples/aws-cognito/src/frontend/types.generated.ts
+++ b/src/examples/aws-cognito/src/frontend/types.generated.ts
@@ -93,6 +93,7 @@ export type AdminUiMetadata = {
   __typename?: 'AdminUiMetadata';
   entities: Array<AdminUiEntityMetadata>;
   enums: Array<AdminUiEnumMetadata>;
+  federationSubgraphName?: Maybe<Scalars['String']['output']>;
 };
 
 export type AggregationResult = {

--- a/src/examples/aws-cognito/src/types.generated.ts
+++ b/src/examples/aws-cognito/src/types.generated.ts
@@ -93,6 +93,7 @@ export type AdminUiMetadata = {
   __typename?: 'AdminUiMetadata';
   entities: Array<AdminUiEntityMetadata>;
   enums: Array<AdminUiEnumMetadata>;
+  federationSubgraphName?: Maybe<Scalars['String']['output']>;
 };
 
 export type AggregationResult = {

--- a/src/examples/databases/src/frontend/types.generated.ts
+++ b/src/examples/databases/src/frontend/types.generated.ts
@@ -93,6 +93,7 @@ export type AdminUiMetadata = {
   __typename?: 'AdminUiMetadata';
   entities: Array<AdminUiEntityMetadata>;
   enums: Array<AdminUiEnumMetadata>;
+  federationSubgraphName?: Maybe<Scalars['String']['output']>;
 };
 
 export type AggregationResult = {

--- a/src/examples/databases/src/types.generated.ts
+++ b/src/examples/databases/src/types.generated.ts
@@ -93,6 +93,7 @@ export type AdminUiMetadata = {
   __typename?: 'AdminUiMetadata';
   entities: Array<AdminUiEntityMetadata>;
   enums: Array<AdminUiEnumMetadata>;
+  federationSubgraphName?: Maybe<Scalars['String']['output']>;
 };
 
 export type AggregationResult = {

--- a/src/examples/federation/src/backend/index.ts
+++ b/src/examples/federation/src/backend/index.ts
@@ -12,7 +12,7 @@ graphweaverMetadata.collectDirectiveTypeInformation({
 });
 
 export const graphweaver = new Graphweaver({
-	enableFederation: true,
+	federationSubgraphName: 'example',
 	enableFederationTracing: true,
 	schemaDirectives: {
 		composeDirective: {

--- a/src/examples/federation/src/frontend/types.generated.ts
+++ b/src/examples/federation/src/frontend/types.generated.ts
@@ -96,10 +96,11 @@ export type AdminUiMetadata = {
   __typename?: 'AdminUiMetadata';
   entities: Array<AdminUiEntityMetadata>;
   enums: Array<AdminUiEnumMetadata>;
+  federationSubgraphName?: Maybe<Scalars['String']['output']>;
 };
 
-export type AggregationResult = {
-  __typename?: 'AggregationResult';
+export type AggregationResultFromExampleSubgraph = {
+  __typename?: 'AggregationResultFromExampleSubgraph';
   count: Scalars['Int']['output'];
 };
 
@@ -332,7 +333,7 @@ export type UsersPaginationInput = {
 export type _Entity = CaseStudy | DeprecatedProduct | Inventory | Product | ProductDimension | ProductResearch | ProductVariation | User;
 
 export type _Service = {
-  __typename?: '_service';
+  __typename?: '_Service';
   sdl: Scalars['String']['output'];
 };
 

--- a/src/examples/federation/src/types.generated.ts
+++ b/src/examples/federation/src/types.generated.ts
@@ -96,10 +96,11 @@ export type AdminUiMetadata = {
   __typename?: 'AdminUiMetadata';
   entities: Array<AdminUiEntityMetadata>;
   enums: Array<AdminUiEnumMetadata>;
+  federationSubgraphName?: Maybe<Scalars['String']['output']>;
 };
 
-export type AggregationResult = {
-  __typename?: 'AggregationResult';
+export type AggregationResultFromExampleSubgraph = {
+  __typename?: 'AggregationResultFromExampleSubgraph';
   count: Scalars['Int']['output'];
 };
 
@@ -332,7 +333,7 @@ export type UsersPaginationInput = {
 export type _Entity = CaseStudy | DeprecatedProduct | Inventory | Product | ProductDimension | ProductResearch | ProductVariation | User;
 
 export type _Service = {
-  __typename?: '_service';
+  __typename?: '_Service';
   sdl: Scalars['String']['output'];
 };
 

--- a/src/examples/rest/src/frontend/types.generated.ts
+++ b/src/examples/rest/src/frontend/types.generated.ts
@@ -93,6 +93,7 @@ export type AdminUiMetadata = {
   __typename?: 'AdminUiMetadata';
   entities: Array<AdminUiEntityMetadata>;
   enums: Array<AdminUiEnumMetadata>;
+  federationSubgraphName?: Maybe<Scalars['String']['output']>;
 };
 
 export type AggregationResult = {

--- a/src/examples/rest/src/types.generated.ts
+++ b/src/examples/rest/src/types.generated.ts
@@ -93,6 +93,7 @@ export type AdminUiMetadata = {
   __typename?: 'AdminUiMetadata';
   entities: Array<AdminUiEntityMetadata>;
   enums: Array<AdminUiEnumMetadata>;
+  federationSubgraphName?: Maybe<Scalars['String']['output']>;
 };
 
 export type AggregationResult = {

--- a/src/examples/rest/types.generated.ts
+++ b/src/examples/rest/types.generated.ts
@@ -93,6 +93,7 @@ export type AdminUiMetadata = {
   __typename?: 'AdminUiMetadata';
   entities: Array<AdminUiEntityMetadata>;
   enums: Array<AdminUiEnumMetadata>;
+  federationSubgraphName?: Maybe<Scalars['String']['output']>;
 };
 
 export type AggregationResult = {

--- a/src/examples/s3-storage/src/backend/index.ts
+++ b/src/examples/s3-storage/src/backend/index.ts
@@ -2,5 +2,5 @@ import Graphweaver from '@exogee/graphweaver-server';
 
 import './schema';
 
-export const graphweaver = new Graphweaver({ federationSubgraphName: 'test' });
+export const graphweaver = new Graphweaver();
 export const handler = graphweaver.handler();

--- a/src/examples/s3-storage/src/backend/index.ts
+++ b/src/examples/s3-storage/src/backend/index.ts
@@ -2,5 +2,5 @@ import Graphweaver from '@exogee/graphweaver-server';
 
 import './schema';
 
-export const graphweaver = new Graphweaver();
+export const graphweaver = new Graphweaver({ federationSubgraphName: 'test' });
 export const handler = graphweaver.handler();

--- a/src/examples/s3-storage/src/frontend/types.generated.ts
+++ b/src/examples/s3-storage/src/frontend/types.generated.ts
@@ -19,6 +19,9 @@ export type Scalars = {
   Float: { input: number; output: number; }
   /** The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
   JSON: { input: any; output: any; }
+  _Any: { input: any; output: any; }
+  federation__FieldSet: { input: any; output: any; }
+  link__Import: { input: any; output: any; }
 };
 
 export type AdminUiEntityAttributeMetadata = {
@@ -93,10 +96,11 @@ export type AdminUiMetadata = {
   __typename?: 'AdminUiMetadata';
   entities: Array<AdminUiEntityMetadata>;
   enums: Array<AdminUiEnumMetadata>;
+  federationSubgraphName?: Maybe<Scalars['String']['output']>;
 };
 
-export type AggregationResult = {
-  __typename?: 'AggregationResult';
+export type AggregationResultFromTestSubgraph = {
+  __typename?: 'AggregationResultFromTestSubgraph';
   count: Scalars['Int']['output'];
 };
 
@@ -108,17 +112,17 @@ export type DeleteOneFilterInput = {
   id: Scalars['ID']['input'];
 };
 
-export type Media = {
-  __typename?: 'Media';
-  filename: Scalars['String']['output'];
-  type: MediaType;
-  url: Scalars['String']['output'];
-};
-
 /** Data needed to create or update MultipleMedia. If an ID is passed, this is an update, otherwise it's an insert. */
 export type MediaCreateOrUpdateInput = {
   filename?: InputMaybe<Scalars['String']['input']>;
   type?: InputMaybe<MediaType>;
+};
+
+export type MediaFromTestSubgraph = {
+  __typename?: 'MediaFromTestSubgraph';
+  filename: Scalars['String']['output'];
+  type: MediaType;
+  url: Scalars['String']['output'];
 };
 
 /** Data needed to create MultipleMedia. */
@@ -224,15 +228,24 @@ export type MutationUpdateSubmissionsArgs = {
 
 export type Query = {
   __typename?: 'Query';
+  /** Union of all types in this subgraph. This information is needed by the Apollo federation gateway. */
+  _entities: Array<Maybe<_Entity>>;
   /** Query used by the Admin UI to introspect the schema and metadata. */
   _graphweaver?: Maybe<AdminUiMetadata>;
+  /** The sdl representing the federated service capabilities. Includes federation directives, removes federation types, and includes rest of full schema after schema directives have been applied. */
+  _service?: Maybe<_Service>;
   getDownloadUrl?: Maybe<Scalars['String']['output']>;
   /** Get a single Submission. */
   submission?: Maybe<Submission>;
   /** Get multiple Submissions. */
   submissions?: Maybe<Array<Maybe<Submission>>>;
   /** Get aggregated data for Submissions. */
-  submissions_aggregate?: Maybe<AggregationResult>;
+  submissions_aggregate?: Maybe<AggregationResultFromTestSubgraph>;
+};
+
+
+export type Query_EntitiesArgs = {
+  representations?: InputMaybe<Array<Scalars['_Any']['input']>>;
 };
 
 
@@ -264,7 +277,7 @@ export enum Sort {
 export type Submission = {
   __typename?: 'Submission';
   id: Scalars['ID']['output'];
-  image?: Maybe<Media>;
+  image?: Maybe<MediaFromTestSubgraph>;
 };
 
 /** Data needed to create or update Submissions. If an ID is passed, this is an update, otherwise it's an insert. */
@@ -304,3 +317,15 @@ export type SubmissionsPaginationInput = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<SubmissionsOrderByInput>;
 };
+
+export type _Entity = MediaFromTestSubgraph | Submission;
+
+export type _Service = {
+  __typename?: '_Service';
+  sdl: Scalars['String']['output'];
+};
+
+export enum Link__Purpose {
+  Execution = 'EXECUTION',
+  Security = 'SECURITY'
+}

--- a/src/examples/s3-storage/src/types.generated.ts
+++ b/src/examples/s3-storage/src/types.generated.ts
@@ -19,6 +19,9 @@ export type Scalars = {
   Float: { input: number; output: number; }
   /** The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
   JSON: { input: any; output: any; }
+  _Any: { input: any; output: any; }
+  federation__FieldSet: { input: any; output: any; }
+  link__Import: { input: any; output: any; }
 };
 
 export type AdminUiEntityAttributeMetadata = {
@@ -93,10 +96,11 @@ export type AdminUiMetadata = {
   __typename?: 'AdminUiMetadata';
   entities: Array<AdminUiEntityMetadata>;
   enums: Array<AdminUiEnumMetadata>;
+  federationSubgraphName?: Maybe<Scalars['String']['output']>;
 };
 
-export type AggregationResult = {
-  __typename?: 'AggregationResult';
+export type AggregationResultFromTestSubgraph = {
+  __typename?: 'AggregationResultFromTestSubgraph';
   count: Scalars['Int']['output'];
 };
 
@@ -108,17 +112,17 @@ export type DeleteOneFilterInput = {
   id: Scalars['ID']['input'];
 };
 
-export type Media = {
-  __typename?: 'Media';
-  filename: Scalars['String']['output'];
-  type: MediaType;
-  url: Scalars['String']['output'];
-};
-
 /** Data needed to create or update MultipleMedia. If an ID is passed, this is an update, otherwise it's an insert. */
 export type MediaCreateOrUpdateInput = {
   filename?: InputMaybe<Scalars['String']['input']>;
   type?: InputMaybe<MediaType>;
+};
+
+export type MediaFromTestSubgraph = {
+  __typename?: 'MediaFromTestSubgraph';
+  filename: Scalars['String']['output'];
+  type: MediaType;
+  url: Scalars['String']['output'];
 };
 
 /** Data needed to create MultipleMedia. */
@@ -224,15 +228,24 @@ export type MutationUpdateSubmissionsArgs = {
 
 export type Query = {
   __typename?: 'Query';
+  /** Union of all types in this subgraph. This information is needed by the Apollo federation gateway. */
+  _entities: Array<Maybe<_Entity>>;
   /** Query used by the Admin UI to introspect the schema and metadata. */
   _graphweaver?: Maybe<AdminUiMetadata>;
+  /** The sdl representing the federated service capabilities. Includes federation directives, removes federation types, and includes rest of full schema after schema directives have been applied. */
+  _service?: Maybe<_Service>;
   getDownloadUrl?: Maybe<Scalars['String']['output']>;
   /** Get a single Submission. */
   submission?: Maybe<Submission>;
   /** Get multiple Submissions. */
   submissions?: Maybe<Array<Maybe<Submission>>>;
   /** Get aggregated data for Submissions. */
-  submissions_aggregate?: Maybe<AggregationResult>;
+  submissions_aggregate?: Maybe<AggregationResultFromTestSubgraph>;
+};
+
+
+export type Query_EntitiesArgs = {
+  representations?: InputMaybe<Array<Scalars['_Any']['input']>>;
 };
 
 
@@ -264,7 +277,7 @@ export enum Sort {
 export type Submission = {
   __typename?: 'Submission';
   id: Scalars['ID']['output'];
-  image?: Maybe<Media>;
+  image?: Maybe<MediaFromTestSubgraph>;
 };
 
 /** Data needed to create or update Submissions. If an ID is passed, this is an update, otherwise it's an insert. */
@@ -304,3 +317,15 @@ export type SubmissionsPaginationInput = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<SubmissionsOrderByInput>;
 };
+
+export type _Entity = MediaFromTestSubgraph | Submission;
+
+export type _Service = {
+  __typename?: '_Service';
+  sdl: Scalars['String']['output'];
+};
+
+export enum Link__Purpose {
+  Execution = 'EXECUTION',
+  Security = 'SECURITY'
+}

--- a/src/examples/sqlite/src/frontend/types.generated.ts
+++ b/src/examples/sqlite/src/frontend/types.generated.ts
@@ -95,6 +95,7 @@ export type AdminUiMetadata = {
   __typename?: 'AdminUiMetadata';
   entities: Array<AdminUiEntityMetadata>;
   enums: Array<AdminUiEnumMetadata>;
+  federationSubgraphName?: Maybe<Scalars['String']['output']>;
 };
 
 export type AggregationResult = {

--- a/src/examples/sqlite/src/types.generated.ts
+++ b/src/examples/sqlite/src/types.generated.ts
@@ -95,6 +95,7 @@ export type AdminUiMetadata = {
   __typename?: 'AdminUiMetadata';
   entities: Array<AdminUiEntityMetadata>;
   enums: Array<AdminUiEnumMetadata>;
+  federationSubgraphName?: Maybe<Scalars['String']['output']>;
 };
 
 export type AggregationResult = {

--- a/src/packages/admin-ui-components/src/detail-panel/component.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/component.tsx
@@ -12,6 +12,7 @@ import {
 	CustomField,
 	decodeSearchParams,
 	EntityField,
+	federationNameForEntity,
 	queryForEntity,
 	routeFor,
 	useSchema,
@@ -48,7 +49,15 @@ export enum PanelMode {
 const isFieldReadonly = (field: EntityField | CustomField<unknown>) =>
 	field.type === 'ID' || field.type === 'ID!' || field.attributes?.isReadOnly;
 
-const getField = ({ field, autoFocus }: { field: EntityField; autoFocus: boolean }) => {
+const getField = ({
+	field,
+	autoFocus,
+	federationSubgraphName,
+}: {
+	field: EntityField;
+	autoFocus: boolean;
+	federationSubgraphName?: string;
+}) => {
 	const isReadonly = isFieldReadonly(field);
 
 	if (field.relationshipType) {
@@ -67,7 +76,7 @@ const getField = ({ field, autoFocus }: { field: EntityField; autoFocus: boolean
 		return <BooleanField name={field.name} autoFocus={autoFocus} />;
 	}
 
-	if (field.type === 'Media') {
+	if (field.type === federationNameForEntity('Media', federationSubgraphName)) {
 		return <MediaField field={field} autoFocus={autoFocus} />;
 	}
 
@@ -91,13 +100,21 @@ const getField = ({ field, autoFocus }: { field: EntityField; autoFocus: boolean
 	);
 };
 
-const DetailField = ({ field, autoFocus }: { field: EntityField; autoFocus: boolean }) => {
+const DetailField = ({
+	field,
+	autoFocus,
+	federationSubgraphName,
+}: {
+	field: EntityField;
+	autoFocus: boolean;
+	federationSubgraphName?: string;
+}) => {
 	const isRequired = !(field.type === 'ID' || field.type === 'ID!') && field.attributes?.isRequired;
 	return (
 		<div className={styles.detailField}>
 			<DetailPanelFieldLabel fieldName={field.name} required={isRequired} />
 
-			{getField({ field, autoFocus })}
+			{getField({ field, autoFocus, federationSubgraphName })}
 		</div>
 	);
 };
@@ -106,13 +123,15 @@ const CustomFieldComponent = ({
 	field,
 	entity,
 	panelMode,
+	federationSubgraphName,
 }: {
 	field: CustomField;
 	entity: Record<string, any>;
 	panelMode: PanelMode;
+	federationSubgraphName?: string;
 }) => (
 	<div className={styles.detailField}>
-		{field.component({ entity, context: 'detail-form', panelMode })}
+		{field.component({ entity, context: 'detail-form', panelMode, federationSubgraphName })}
 	</div>
 );
 
@@ -139,6 +158,7 @@ const DetailForm = ({
 	onCancel,
 	onSubmit,
 	persistName,
+	federationSubgraphName,
 	isReadOnly,
 	panelMode,
 }: {
@@ -147,6 +167,7 @@ const DetailForm = ({
 	onSubmit: (values: any, actions: FormikHelpers<any>) => void;
 	onCancel: () => void;
 	persistName: string;
+	federationSubgraphName?: string;
 	isReadOnly?: boolean;
 	panelMode: PanelMode;
 }) => {
@@ -230,6 +251,7 @@ const DetailForm = ({
 										field={field as CustomField}
 										entity={initialValues}
 										panelMode={panelMode}
+										federationSubgraphName={federationSubgraphName}
 									/>
 								);
 							} else {
@@ -238,6 +260,7 @@ const DetailForm = ({
 										key={field.name}
 										field={field}
 										autoFocus={field === firstEditableField}
+										federationSubgraphName={federationSubgraphName}
 									/>
 								);
 							}
@@ -481,6 +504,7 @@ export const DetailPanel = () => {
 								persistName={persistName}
 								isReadOnly={selectedEntity.attributes.isReadOnly}
 								panelMode={panelMode}
+								federationSubgraphName={federationSubgraphName}
 							/>
 						)}
 					</>

--- a/src/packages/admin-ui-components/src/detail-panel/component.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/component.tsx
@@ -269,14 +269,14 @@ export const DetailPanel = () => {
 	const { id, entity } = useParams();
 	const navigate = useNavigate();
 	const { selectedEntity } = useSelectedEntity();
-	const { entityByName, entityByType } = useSchema();
+	const { entityByName, entityByType, federationSubgraphName } = useSchema();
 
 	if (!selectedEntity) throw new Error('There should always be a selected entity at this point.');
 
 	const panelMode = id === 'graphweaver-admin-new-entity' ? PanelMode.CREATE : PanelMode.EDIT;
 
 	const { data, loading, error } = useQuery<{ result: ResultBaseType }>(
-		queryForEntity(selectedEntity, entityByName),
+		queryForEntity(selectedEntity, entityByName, federationSubgraphName),
 		{
 			variables: { id },
 			skip: panelMode === PanelMode.CREATE,
@@ -347,8 +347,12 @@ export const DetailPanel = () => {
 		{} as Record<string, any>
 	);
 
-	const [updateEntity] = useMutation(generateUpdateEntityMutation(selectedEntity, entityByType));
-	const [createEntity] = useMutation(generateCreateEntityMutation(selectedEntity, entityByType));
+	const [updateEntity] = useMutation(
+		generateUpdateEntityMutation(selectedEntity, entityByType, federationSubgraphName)
+	);
+	const [createEntity] = useMutation(
+		generateCreateEntityMutation(selectedEntity, entityByType, federationSubgraphName)
+	);
 
 	const slideAnimationTime = useMemo(() => {
 		const slideAnimationTimeCssVar = getComputedStyle(document.documentElement)

--- a/src/packages/admin-ui-components/src/detail-panel/graphql.ts
+++ b/src/packages/admin-ui-components/src/detail-panel/graphql.ts
@@ -3,22 +3,24 @@ import { Entity, generateGqlSelectForEntityFields } from '../utils';
 
 export const generateUpdateEntityMutation = (
 	entity: Entity,
-	entityByType: (entityType: string) => Entity
+	entityByType: (entityType: string) => Entity,
+	federationSubgraphName?: string
 ) => gql`
     mutation updateEntity ($input: ${entity.name}UpdateInput!){
       update${entity.name} (input: $input) {
-        ${generateGqlSelectForEntityFields(entity, entityByType)}
+        ${generateGqlSelectForEntityFields(entity, entityByType, federationSubgraphName)}
       }
     }
   `;
 
 export const generateCreateEntityMutation = (
 	entity: Entity,
-	entityByType: (entityType: string) => Entity
+	entityByType: (entityType: string) => Entity,
+	federationSubgraphName?: string
 ) => gql`
     mutation createEntity ($input: ${entity.name}InsertInput!){
       create${entity.name} (input: $input) {
-        ${generateGqlSelectForEntityFields(entity, entityByType)}
+        ${generateGqlSelectForEntityFields(entity, entityByType, federationSubgraphName)}
       }
     }
   `;

--- a/src/packages/admin-ui-components/src/export-modal/graphql.ts
+++ b/src/packages/admin-ui-components/src/export-modal/graphql.ts
@@ -1,14 +1,18 @@
 import { gql } from '@apollo/client';
 import { Entity, generateGqlSelectForEntityFields } from '../utils';
 
-export const GetEntity = (entity: Entity, entityByType?: (entityType: string) => Entity) => {
+export const listEntityForExport = (
+	entity: Entity,
+	entityByType?: (entityType: string) => Entity,
+	federationSubgraphName?: string
+) => {
 	const pluralName = entity.plural;
 	const queryName = pluralName[0].toLowerCase() + pluralName.slice(1);
 
 	return gql`
-		query getEntity ($filter: ${pluralName}ListFilter, $pagination: ${pluralName}PaginationInput) {
+		query entityCSVExport($filter: ${pluralName}ListFilter, $pagination: ${pluralName}PaginationInput) {
 			result: ${queryName}(filter: $filter, pagination: $pagination) {
-				${generateGqlSelectForEntityFields(entity, entityByType)}
+				${generateGqlSelectForEntityFields(entity, entityByType, federationSubgraphName)}
 			}
 		}
 	`;

--- a/src/packages/admin-ui-components/src/filter-bar/component.tsx
+++ b/src/packages/admin-ui-components/src/filter-bar/component.tsx
@@ -3,7 +3,14 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import toast from 'react-hot-toast';
 
 import { Button } from '../button';
-import { AdminUIFilterType, decodeSearchParams, Filter, routeFor, useSchema } from '../utils';
+import {
+	AdminUIFilterType,
+	decodeSearchParams,
+	federationNameForEntity,
+	Filter,
+	routeFor,
+	useSchema,
+} from '../utils';
 import {
 	BooleanFilter,
 	validateFilter,
@@ -20,7 +27,7 @@ export const FilterBar = ({ iconBefore }: { iconBefore?: ReactNode }) => {
 	const { entity: entityName, id } = useParams();
 	if (!entityName) throw new Error('There should always be an entity at this point.');
 	const [search] = useSearchParams();
-	const { entityByName } = useSchema();
+	const { entityByName, federationSubgraphName } = useSchema();
 	const navigate = useNavigate();
 	const searchParams = decodeSearchParams(search);
 	const filters = searchParams.filters ?? entityByName(entityName).defaultFilter;
@@ -31,8 +38,12 @@ export const FilterBar = ({ iconBefore }: { iconBefore?: ReactNode }) => {
 		// we plan to redo this filter bar so that it is a drop down
 		// for now the workaround is to reduce the number of filters to 5
 		const fields = entity.fields
-			// filter out rowEntity.fields with the JSON type
-			.filter((field) => field.type !== 'JSON')
+			// filter out rowEntity.fields with the JSON and Media types because they're not filterable
+			.filter(
+				(field) =>
+					field.type !== 'JSON' &&
+					field.type !== federationNameForEntity('Media', federationSubgraphName)
+			)
 			.slice(0, 5);
 
 		return fields;

--- a/src/packages/admin-ui-components/src/table/component.tsx
+++ b/src/packages/admin-ui-components/src/table/component.tsx
@@ -15,6 +15,7 @@ import {
 	routeFor,
 	SortField,
 	decodeSearchParams,
+	federationNameForEntity,
 } from '../utils';
 import { Spinner } from '../spinner';
 
@@ -42,7 +43,8 @@ const hideImage = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
 
 const columnsForEntity = <T extends TableRowItem>(
 	entity: Entity,
-	entityByType: (type: string) => Entity
+	entityByType: (type: string) => Entity,
+	federationSubgraphName?: string
 ): Column<T, unknown>[] => {
 	const entityColumns = [
 		...(entity.attributes.isReadOnly ? [] : [SelectColumn]),
@@ -81,7 +83,7 @@ const columnsForEntity = <T extends TableRowItem>(
 							return null;
 						}
 					}
-				: field.type === 'Media'
+				: field.type === federationNameForEntity('Media', federationSubgraphName)
 					? ({ row }: RenderCellProps<T, unknown>) => {
 							const media = row[field.name as keyof typeof row] as {
 								url: string;
@@ -189,7 +191,7 @@ export const Table = <T extends TableRowItem>({
 	);
 	const navigate = useNavigate();
 	const { id } = useParams();
-	const { entityByType } = useSchema();
+	const { entityByType, federationSubgraphName } = useSchema();
 	const [search] = useSearchParams();
 	const { selectedEntity } = useSelectedEntity();
 	if (!selectedEntity) throw new Error('There should always be a selected entity at this point.');
@@ -306,7 +308,7 @@ export const Table = <T extends TableRowItem>({
 	return (
 		<>
 			<DataGrid
-				columns={columnsForEntity<T>(selectedEntity, entityByType)}
+				columns={columnsForEntity<T>(selectedEntity, entityByType, federationSubgraphName)}
 				rows={rows}
 				rowKeyGetter={rowKeyGetter}
 				sortColumns={sortColumns}

--- a/src/packages/admin-ui-components/src/utils/data-loading.ts
+++ b/src/packages/admin-ui-components/src/utils/data-loading.ts
@@ -6,18 +6,18 @@ import { generateGqlSelectForEntityFields } from './graphql';
 
 export const PAGE_SIZE = 50;
 
-export const queryForEntity = (entity: Entity, entityByType?: (type: string) => Entity) => {
+export const queryForEntity = (
+	entity: Entity,
+	entityByType?: (type: string) => Entity,
+	federationSubgraphName?: string
+) => {
 	// If the entity is called SomeThing then the query name is someThing.
 	const queryName = entity.name[0].toLowerCase() + entity.name.slice(1);
 
-	// TODO: Is there a better way to build this than a big string?
-	//
-	// We looked into generating an AST here but it's really verbose and
-	// doesn't seem that much cleaner than just generating a string.
 	return gql`
 		query AdminUIDetail($id: ID!) {
 			result: ${queryName}(id: $id) {
-				${generateGqlSelectForEntityFields(entity, entityByType)}
+				${generateGqlSelectForEntityFields(entity, entityByType, federationSubgraphName)}
 			}
 		}
 	`;

--- a/src/packages/admin-ui-components/src/utils/graphql.ts
+++ b/src/packages/admin-ui-components/src/utils/graphql.ts
@@ -1,9 +1,11 @@
 import { gql } from '@apollo/client';
 import { Entity } from './use-schema';
+import { federationNameForEntity } from './utils';
 
 export const SCHEMA_QUERY = gql`
 	query graphweaver {
 		result: _graphweaver {
+			federationSubgraphName
 			entities {
 				name
 				plural
@@ -47,7 +49,8 @@ export const SCHEMA_QUERY = gql`
 
 export const generateGqlSelectForEntityFields = (
 	entity: Entity,
-	entityByType?: (entityType: string) => Entity
+	entityByType?: (entityType: string) => Entity,
+	federationSubgraphName?: string
 ) =>
 	entity.fields
 		.map((field) => {
@@ -63,7 +66,7 @@ export const generateGqlSelectForEntityFields = (
 					label: ${relatedEntity?.summaryField ?? relatedEntity?.primaryKeyField}
 				}`;
 			} else {
-				if (field.type === 'Media') {
+				if (field.type === federationNameForEntity('Media', federationSubgraphName)) {
 					return `${field.name} { filename, type, url }`;
 				}
 				return field.name;

--- a/src/packages/admin-ui-components/src/utils/use-schema.ts
+++ b/src/packages/admin-ui-components/src/utils/use-schema.ts
@@ -86,6 +86,7 @@ export interface CustomFieldArgs<T = unknown> {
 	entity: T;
 	context: 'table' | 'detail-form';
 	panelMode: PanelMode;
+	federationSubgraphName?: string;
 }
 
 export interface CustomField<T = unknown> extends EntityField {

--- a/src/packages/admin-ui-components/src/utils/use-schema.ts
+++ b/src/packages/admin-ui-components/src/utils/use-schema.ts
@@ -8,6 +8,7 @@ import { PanelMode } from '../detail-panel';
 export interface Schema {
 	entities: Entity[];
 	enums: Enum[];
+	federationSubgraphName?: string;
 }
 
 export interface Enum {
@@ -168,6 +169,7 @@ export const useSchema = () => {
 		error,
 		entities: Object.keys(entityMap),
 		backends: Object.keys(dataSourceMap),
+		federationSubgraphName: data?.result?.federationSubgraphName,
 		entityByName: (entityName: string) => entityMap[entityName],
 		entityByType: (entityType: string) => {
 			const entityName = entityType.replaceAll(/[^a-zA-Z\d]/g, '');

--- a/src/packages/admin-ui-components/src/utils/utils.ts
+++ b/src/packages/admin-ui-components/src/utils/utils.ts
@@ -11,13 +11,16 @@ export const isNumeric = (item: unknown): boolean => {
 
 export const getOrderByQuery = (entity: Entity, sort?: SortField[]) => ({
 	...(sort
-		? sort.reduce((acc, { field, direction }) => ({ ...acc, [field]: direction }), {})
+		? sort.reduce(
+				(acc, { field, direction }) => {
+					acc[field] = direction;
+					return acc;
+				},
+				{} as Record<string, 'ASC' | 'DESC'>
+			)
 		: { [entity.primaryKeyField]: 'ASC' }),
 });
-		? sort.reduce((acc, { field, direction }) => {
-			acc[field] = direction;
-			return acc;
-		}, {})
+
 export const federationNameForEntity = (entityName: string, federationSubgraphName?: string) => {
 	if (!federationSubgraphName) return entityName;
 

--- a/src/packages/admin-ui-components/src/utils/utils.ts
+++ b/src/packages/admin-ui-components/src/utils/utils.ts
@@ -14,3 +14,9 @@ export const getOrderByQuery = (entity: Entity, sort?: SortField[]) => ({
 		? sort.reduce((acc, { field, direction }) => ({ ...acc, [field]: direction }), {})
 		: { [entity.primaryKeyField]: 'ASC' }),
 });
+
+export const federationNameForEntity = (entityName: string, federationSubgraphName?: string) => {
+	if (!federationSubgraphName) return entityName;
+
+	return `${entityName}From${federationSubgraphName.charAt(0).toUpperCase() + federationSubgraphName.slice(1)}Subgraph`;
+};

--- a/src/packages/admin-ui-components/src/utils/utils.ts
+++ b/src/packages/admin-ui-components/src/utils/utils.ts
@@ -14,7 +14,10 @@ export const getOrderByQuery = (entity: Entity, sort?: SortField[]) => ({
 		? sort.reduce((acc, { field, direction }) => ({ ...acc, [field]: direction }), {})
 		: { [entity.primaryKeyField]: 'ASC' }),
 });
-
+		? sort.reduce((acc, { field, direction }) => {
+			acc[field] = direction;
+			return acc;
+		}, {})
 export const federationNameForEntity = (entityName: string, federationSubgraphName?: string) => {
 	if (!federationSubgraphName) return entityName;
 

--- a/src/packages/admin-ui/src/pages/list/component.tsx
+++ b/src/packages/admin-ui/src/pages/list/component.tsx
@@ -46,7 +46,7 @@ export const ListWithSelectedEntity = () => {
 	if (!entity) throw new Error('There should always be an entity at this point.');
 	const navigate = useNavigate();
 	const [search] = useSearchParams();
-	const { entityByName } = useSchema();
+	const { entityByName, federationSubgraphName } = useSchema();
 	const [showExportModal, setShowExportModal] = useState(false);
 	const { sort, page, filters } = decodeSearchParams(search);
 
@@ -62,7 +62,7 @@ export const ListWithSelectedEntity = () => {
 	const { data, loading, error, fetchMore } = useQuery<{
 		result: TableRowItem[];
 		aggregate?: { count: number };
-	}>(queryForEntityPage(entity, entityByName), {
+	}>(queryForEntityPage(entity, entityByName, federationSubgraphName), {
 		variables: queryVariables,
 		notifyOnNetworkStatusChange: true,
 	});

--- a/src/packages/admin-ui/src/pages/list/graphql.ts
+++ b/src/packages/admin-ui/src/pages/list/graphql.ts
@@ -5,7 +5,11 @@ import {
 	generateGqlSelectForEntityFields,
 } from '@exogee/graphweaver-admin-ui-components';
 
-export const queryForEntityPage = (entityName: string, entityByType: (type: string) => Entity) => {
+export const queryForEntityPage = (
+	entityName: string,
+	entityByType: (type: string) => Entity,
+	federationSubgraphName?: string
+) => {
 	const entity = entityByType(entityName);
 	const pluralName = entity.plural;
 	const queryName = pluralName[0].toLowerCase() + pluralName.slice(1);
@@ -14,7 +18,7 @@ export const queryForEntityPage = (entityName: string, entityByType: (type: stri
 	return gql`
 		query AdminUIListPage($filter: ${pluralName}ListFilter, $pagination: ${pluralName}PaginationInput) {
 			result: ${queryName}(filter: $filter, pagination: $pagination) {
-				${generateGqlSelectForEntityFields(entity, entityByType)}
+				${generateGqlSelectForEntityFields(entity, entityByType, federationSubgraphName)}
 			}
 			${entityCanCount ? `aggregate: ${queryName}_aggregate(filter: $filter) { count }` : ''}
 		}

--- a/src/packages/auth/src/decorators/hooks/acl.ts
+++ b/src/packages/auth/src/decorators/hooks/acl.ts
@@ -132,7 +132,7 @@ const generatePermissionListFromFields = <G>(
 	const permissionsList: RequiredPermission[] = [`${entityMetadata.name}:${AccessType.Read}`];
 
 	for (const [entityName, fields] of Object.entries(requestedFields.fieldsByTypeName)) {
-		if (entityName === 'AggregationResult') {
+		if (entityName === graphweaverMetadata.federationNameForGraphQLTypeName('AggregationResult')) {
 			// We just need to record that they're trying to read the entity information via an aggregation and move on.
 			permissionsList.push(`${entityMetadata.name}:${AccessType.Read}`);
 		} else {
@@ -206,7 +206,7 @@ const getFilterArgumentsOnFields = (entityMetadata: EntityMetadata, resolveTree:
 	}
 
 	for (const [entityName, fields] of Object.entries(resolveTree.fieldsByTypeName)) {
-		if (entityName === 'AggregationResult') {
+		if (entityName === graphweaverMetadata.federationNameForGraphQLTypeName('AggregationResult')) {
 			// We just need to record that they're trying to read the entity information via an aggregation and move on.
 			permissionsList.push(`${entityMetadata.name}:${AccessType.Read}`);
 		} else {

--- a/src/packages/core/src/federation/entities.ts
+++ b/src/packages/core/src/federation/entities.ts
@@ -14,14 +14,12 @@ export const addEntitiesQuery = () => {
 	const EntitiesUnion = graphweaverMetadata.collectUnionTypeInformation({
 		name: '_Entity',
 		getTypes: () =>
-			Array.from(graphweaverMetadata.entities())
-				.filter(
-					// The _service entity should not be included in the _entities union specifically
-					// but we don't want to omit it from the whole SDL returned by the _service query itself
-					// so we're just going to filter it out explicitly here.
-					(entity) => EXCLUDED_FROM_FEDERATION_ENTITY_FILTER(entity) && entity.name !== '_service'
-				)
-				.map((entity) => graphQLTypeForEntity(entity, EXCLUDED_FROM_FEDERATION_ENTITY_FILTER)),
+			Array.from(graphweaverMetadata.entities()).filter(
+				// The _Service entity should not be included in the _Entity union specifically
+				// but we don't want to omit it from the whole SDL returned by the _service query itself
+				// so we're just going to filter it out explicitly here.
+				(entity) => EXCLUDED_FROM_FEDERATION_ENTITY_FILTER(entity) && entity.name !== '_Service'
+			),
 	});
 
 	graphweaverMetadata.addQuery({

--- a/src/packages/core/src/federation/index.ts
+++ b/src/packages/core/src/federation/index.ts
@@ -1,3 +1,4 @@
+import { graphweaverMetadata } from '..';
 import { addDirectives } from './directives';
 import { addEntitiesQuery } from './entities';
 import { addEnums } from './enums';
@@ -7,9 +8,13 @@ export { buildFederationSchema } from './utils';
 
 export const enableFederation = ({
 	schemaDirectives,
+	federationSubgraphName,
 }: {
 	schemaDirectives?: Record<string, any>;
+	federationSubgraphName: string;
 }) => {
+	graphweaverMetadata.federationSubgraphName = federationSubgraphName;
+
 	addEnums();
 	addDirectives();
 	addServiceQuery({ schemaDirectives });

--- a/src/packages/core/src/federation/service.ts
+++ b/src/packages/core/src/federation/service.ts
@@ -8,7 +8,7 @@ export const addServiceQuery = ({
 }: {
 	schemaDirectives?: Record<string, any>;
 }) => {
-	@Entity('_service', {
+	@Entity('_Service', {
 		apiOptions: { excludeFromBuiltInOperations: true },
 	})
 	class Service {

--- a/src/packages/core/src/field-resolver.ts
+++ b/src/packages/core/src/field-resolver.ts
@@ -25,7 +25,7 @@ export const fieldResolver = async (
 
 		const parent = info.parentType.name;
 		const key = info.fieldName;
-		const metadata = graphweaverMetadata.getEntityByName(parent);
+		const metadata = (info.parentType.extensions.graphweaverSchemaInfo as any)?.sourceEntity;
 		if (!metadata) throw new Error(`Could not locate metadata for the '${parent}' entity`);
 
 		const relationship = metadata.fields[key];

--- a/src/packages/core/src/metadata-service/metadata.ts
+++ b/src/packages/core/src/metadata-service/metadata.ts
@@ -11,4 +11,7 @@ export class AdminUiMetadata {
 
 	@Field(() => [AdminUiEnumMetadata])
 	public enums: AdminUiEnumMetadata[] = [];
+
+	@Field(() => String, { nullable: true })
+	public federationSubgraphName?: string;
 }

--- a/src/packages/core/src/metadata-service/resolver.ts
+++ b/src/packages/core/src/metadata-service/resolver.ts
@@ -9,7 +9,6 @@ import {
 	graphweaverMetadata,
 	getFieldTypeWithMetadata,
 	ResolverOptions,
-	EntityMetadata,
 } from '..';
 
 const mapFilterType = (field: AdminUiFieldMetadata): AdminUIFilterType => {

--- a/src/packages/core/src/resolvers.ts
+++ b/src/packages/core/src/resolvers.ts
@@ -60,16 +60,19 @@ const _getOne = async <G>(
 		throw new Error('Graphweaver getOne resolver can only be used to return single objects.');
 	}
 
-	const { name } = info.returnType;
-	const entity = graphweaverMetadata.getEntityByName(name);
-	trace?.span.updateName(`Resolver - GetOne ${name}`);
+	const entity = (info.returnType.extensions.graphweaverSchemaInfo as any)
+		?.sourceEntity as EntityMetadata<any, any>;
 
 	if (!entity) {
-		throw new Error(`Entity ${name} not found in metadata.`);
+		throw new Error(
+			`GraphQL type ${info.returnType} could not be mapped back to a source entity via graphweaverSchemaInfo extension.`
+		);
 	}
 
+	trace?.span.updateName(`Resolver - GetOne ${entity.name}`);
+
 	if (!entity.provider) {
-		throw new Error(`Entity ${name} does not have a provider, cannot resolve.`);
+		throw new Error(`Entity ${entity.name} does not have a provider, cannot resolve.`);
 	}
 
 	const primaryKeyField = graphweaverMetadata.primaryKeyFieldForEntity(entity);
@@ -119,16 +122,21 @@ const _list = async <G, D>(
 		throw new Error('Graphweaver list resolver can only be used to return lists of objects.');
 	}
 
-	const { name } = info.returnType.ofType;
-	const entity = graphweaverMetadata.getEntityByName<any, any>(name);
-	trace?.span.updateName(`Resolver - List ${name}`);
+	const entity = (info.returnType.ofType.extensions.graphweaverSchemaInfo as any)
+		?.sourceEntity as EntityMetadata<any, any>;
 
 	if (!entity) {
-		throw new Error(`Entity ${name} not found in metadata.`);
+		throw new Error(
+			`GraphQL type ${info.returnType.ofType} could not be mapped back to a source entity via graphweaverSchemaInfo extension.`
+		);
 	}
 
+	trace?.span.updateName(`Resolver - List ${entity.name}`);
+
 	if (!entity.provider) {
-		throw new Error(`Entity ${name} does not have a provider, cannot resolve list operation.`);
+		throw new Error(
+			`Entity ${entity.name} does not have a provider, cannot resolve list operation.`
+		);
 	}
 
 	const hookManager = hookManagerMap.get(entity.name);
@@ -182,26 +190,30 @@ const _createOrUpdate = async <G, D>(
 ) => {
 	logger.trace({ input, context, info }, 'Create or Update resolver called.');
 
-	let name;
+	let graphQLType;
 
 	if (isObjectType(info.returnType)) {
-		name = info.returnType.name;
+		graphQLType = info.returnType;
 	} else if (isListType(info.returnType) && isObjectType(info.returnType.ofType)) {
-		name = info.returnType.ofType.name;
+		graphQLType = info.returnType.ofType;
 	} else {
 		throw new Error('Could not determine entity name from return type.');
 	}
 
-	trace?.span.updateName(`Resolver - CreateOrUpdate ${name}`);
-	const entity = graphweaverMetadata.getEntityByName<G, D>(name);
+	const entity = (graphQLType.extensions.graphweaverSchemaInfo as any)
+		?.sourceEntity as EntityMetadata<any, any>;
 
 	if (!entity) {
-		throw new Error(`Entity ${name} not found in metadata.`);
+		throw new Error(
+			`GraphQL type ${graphQLType} could not be mapped back to a source entity via graphweaverSchemaInfo extension.`
+		);
 	}
+
+	trace?.span.updateName(`Resolver - CreateOrUpdate ${entity.name}`);
 
 	if (!entity.provider) {
 		throw new Error(
-			`Entity ${name} does not have a provider, cannot resolve create or update operation.`
+			`Entity ${entity.name} does not have a provider, cannot resolve create or update operation.`
 		);
 	}
 
@@ -290,149 +302,190 @@ const _createOrUpdate = async <G, D>(
 	});
 };
 
-// This is a function generator where you can bind it to the correct entity when creating it, as we cannot look up the entity name / type from the info object.
-export const deleteOne = (entity: EntityMetadata<any, any>) =>
-	trace(
-		async <G extends { name: string }>(
-			{ args: { filter }, context, fields }: ResolverOptions<{ filter: Filter<G> }>,
-			trace?: Trace
-		) => {
-			trace?.span.updateName(`Resolver - DeleteOne ${entity.name}`);
-			if (!entity.provider) {
-				throw new Error(
-					`Entity ${entity.name} does not have a provider, cannot resolve delete operation.`
-				);
-			}
+const _deleteOne = async <G extends { name: string }>(
+	{ args: { filter }, info, context, fields }: ResolverOptions<{ filter: Filter<G> }>,
+	trace?: Trace
+) => {
+	const field = info.schema.getMutationType()?.getFields()[info.fieldName];
+	if (!field) {
+		throw new Error(`Could not find field ${info.fieldName} in mutation type.`);
+	}
 
-			const hookManager = hookManagerMap.get(entity.name);
-			const params: DeleteHookParams<G> = {
-				args: { filter },
-				context,
-				fields,
-				transactional: false,
-			};
+	const entity = (field.extensions.graphweaverSchemaInfo as any).sourceEntity as EntityMetadata<
+		any,
+		any
+	>;
 
-			const hookParams = hookManager
-				? await hookManager.runHooks(HookRegister.BEFORE_DELETE, params)
-				: params;
+	if (!entity) {
+		throw new Error(
+			`GraphQL mutation field ${info.fieldName} could not be mapped back to a source entity via graphweaverSchemaInfo extension.`
+		);
+	}
 
-			if (!hookParams.args?.filter) throw new Error('No delete filter specified cannot continue.');
+	trace?.span.updateName(`Resolver - DeleteOne ${entity.name}`);
 
-			const success = await entity.provider.deleteOne(hookParams.args.filter);
+	if (!entity.provider) {
+		throw new Error(
+			`Entity ${entity.name} does not have a provider, cannot resolve delete operation.`
+		);
+	}
 
-			hookManager &&
-				(await hookManager.runHooks(HookRegister.AFTER_DELETE, {
-					...hookParams,
-					deleted: success,
-				}));
-
-			return success;
-		}
-	);
-
-export const deleteMany = (entity: EntityMetadata<any, any>) =>
-	trace(
-		async <G>(
-			{ args: { filter }, context, fields }: ResolverOptions<{ filter: Filter<G> }>,
-			trace?: Trace
-		) => {
-			trace?.span.updateName(`Resolver - DeleteMany ${entity.name}`);
-			if (!entity.provider) {
-				throw new Error(
-					`Entity ${entity.name} does not have a provider, cannot resolve delete operation.`
-				);
-			}
-			return withTransaction(entity.provider, async () => {
-				if (!entity.provider?.deleteMany)
-					throw new Error('Provider has not implemented DeleteMany.');
-
-				const hookManager = hookManagerMap.get(entity.name);
-				const params: DeleteManyHookParams<G> = {
-					args: { filter },
-					context,
-					fields,
-					transactional: !!entity.provider.withTransaction,
-				};
-
-				const hookParams = hookManager
-					? await hookManager.runHooks(HookRegister.BEFORE_DELETE, params)
-					: params;
-
-				if (!hookParams.args?.filter) throw new Error('No delete ids specified cannot continue.');
-
-				const success = await entity.provider.deleteMany(hookParams.args?.filter);
-
-				hookManager &&
-					(await hookManager.runHooks(HookRegister.AFTER_DELETE, {
-						...hookParams,
-						deleted: success,
-					}));
-
-				return success;
-			});
-		}
-	);
-
-// This is a function generator where you can bind it to the correct entity when creating it, as we cannot look up the entity name / type from the info object.
-export const aggregate =
-	(entity: EntityMetadata<any, any>) =>
-	async <G extends { name: string }>({
+	const hookManager = hookManagerMap.get(entity.name);
+	const params: DeleteHookParams<G> = {
 		args: { filter },
 		context,
 		fields,
-	}: ResolverOptions<{ filter: Filter<G> }>) => {
-		if (!entity.provider) {
-			throw new Error(
-				`Entity ${entity.name} does not have a provider, cannot resolve aggregate operation.`
-			);
-		}
+		transactional: false,
+	};
 
-		if (!entity.provider.aggregate) {
-			throw new Error(
-				'Provider has not implemented aggregate, cannot resolve aggregate operation.'
-			);
-		}
+	const hookParams = hookManager
+		? await hookManager.runHooks(HookRegister.BEFORE_DELETE, params)
+		: params;
 
-		const requestedFields = fields.fieldsByTypeName.AggregationResult;
-		const requestedAggregations = new Set<AggregationType>();
-		if (requestedFields.count) requestedAggregations.add(AggregationType.COUNT);
+	if (!hookParams.args?.filter) throw new Error('No delete filter specified cannot continue.');
+
+	const success = await entity.provider.deleteOne(hookParams.args.filter);
+
+	hookManager &&
+		(await hookManager.runHooks(HookRegister.AFTER_DELETE, {
+			...hookParams,
+			deleted: success,
+		}));
+
+	return success;
+};
+
+const _deleteMany = async <G>(
+	{ args: { filter }, context, info, fields }: ResolverOptions<{ filter: Filter<G> }>,
+	trace?: Trace
+) => {
+	const field = info.schema.getMutationType()?.getFields()[info.fieldName];
+	if (!field) {
+		throw new Error(`Could not find field ${info.fieldName} in mutation type.`);
+	}
+
+	const entity = (field.extensions.graphweaverSchemaInfo as any).sourceEntity as EntityMetadata<
+		any,
+		any
+	>;
+
+	if (!entity) {
+		throw new Error(
+			`GraphQL mutation field ${info.fieldName} could not be mapped back to a source entity via graphweaverSchemaInfo extension.`
+		);
+	}
+
+	trace?.span.updateName(`Resolver - DeleteMany ${entity.name}`);
+	if (!entity.provider) {
+		throw new Error(
+			`Entity ${entity.name} does not have a provider, cannot resolve delete operation.`
+		);
+	}
+	return withTransaction(entity.provider, async () => {
+		if (!entity.provider?.deleteMany) throw new Error('Provider has not implemented DeleteMany.');
 
 		const hookManager = hookManagerMap.get(entity.name);
-		const params: ReadHookParams<G> = {
+		const params: DeleteManyHookParams<G> = {
 			args: { filter },
 			context,
 			fields,
 			transactional: !!entity.provider.withTransaction,
 		};
+
 		const hookParams = hookManager
-			? await hookManager.runHooks(HookRegister.BEFORE_READ, params)
+			? await hookManager.runHooks(HookRegister.BEFORE_DELETE, params)
 			: params;
 
-		const transformedFilter =
-			hookParams.args?.filter &&
-			isTransformableGraphQLEntityClass(entity.target) &&
-			entity.target.toBackendEntityFilter
-				? entity.target.toBackendEntityFilter(hookParams.args?.filter)
-				: (hookParams.args?.filter as Filter<any> | undefined);
+		if (!hookParams.args?.filter) throw new Error('No delete ids specified cannot continue.');
 
-		const flattenedFilter = await QueryManager.flattenFilter<any>({
-			entityName: entity.name,
-			filter: transformedFilter,
-		});
+		const success = await entity.provider.deleteMany(hookParams.args?.filter);
 
-		const success = await entity.provider.aggregate(flattenedFilter, requestedAggregations);
-
-		// If a hook manager is installed, run the after read hooks for this operation.
-		// We don't actually have any entities to pass to the hook, so we'll just pass an empty array.
-		if (hookManager) {
-			await hookManager.runHooks(HookRegister.AFTER_READ, {
+		hookManager &&
+			(await hookManager.runHooks(HookRegister.AFTER_DELETE, {
 				...hookParams,
-				entities: [],
-			});
-		}
+				deleted: success,
+			}));
 
 		return success;
+	});
+};
+
+// This is a function generator where you can bind it to the correct entity when creating it, as we cannot look up the entity name / type from the info object.
+const _aggregate = async <G extends { name: string }>(
+	{ args: { filter }, context, info, fields }: ResolverOptions<{ filter: Filter<G> }>,
+	trace?: Trace
+) => {
+	const field = info.schema.getQueryType()?.getFields()[info.fieldName];
+	if (!field) {
+		throw new Error(`Could not find field ${info.fieldName} in mutation type.`);
+	}
+
+	const entity = (field.extensions.graphweaverSchemaInfo as any).sourceEntity as EntityMetadata<
+		any,
+		any
+	>;
+
+	if (!entity) {
+		throw new Error(
+			`GraphQL mutation field ${info.fieldName} could not be mapped back to a source entity via graphweaverSchemaInfo extension.`
+		);
+	}
+
+	if (!entity.provider) {
+		throw new Error(
+			`Entity ${entity.name} does not have a provider, cannot resolve aggregate operation.`
+		);
+	}
+
+	if (!entity.provider.aggregate) {
+		throw new Error('Provider has not implemented aggregate, cannot resolve aggregate operation.');
+	}
+
+	trace?.span.updateName(`Resolver - Aggregate ${entity.name}`);
+
+	const requestedFields =
+		fields.fieldsByTypeName[
+			graphweaverMetadata.federationNameForGraphQLTypeName('AggregationResult')
+		];
+	const requestedAggregations = new Set<AggregationType>();
+	if (requestedFields.count) requestedAggregations.add(AggregationType.COUNT);
+
+	const hookManager = hookManagerMap.get(entity.name);
+	const params: ReadHookParams<G> = {
+		args: { filter },
+		context,
+		fields,
+		transactional: !!entity.provider.withTransaction,
 	};
+	const hookParams = hookManager
+		? await hookManager.runHooks(HookRegister.BEFORE_READ, params)
+		: params;
+
+	const transformedFilter =
+		hookParams.args?.filter &&
+		isTransformableGraphQLEntityClass(entity.target) &&
+		entity.target.toBackendEntityFilter
+			? entity.target.toBackendEntityFilter(hookParams.args?.filter)
+			: (hookParams.args?.filter as Filter<any> | undefined);
+
+	const flattenedFilter = await QueryManager.flattenFilter<any>({
+		entityName: entity.name,
+		filter: transformedFilter,
+	});
+
+	const success = await entity.provider.aggregate(flattenedFilter, requestedAggregations);
+
+	// If a hook manager is installed, run the after read hooks for this operation.
+	// We don't actually have any entities to pass to the hook, so we'll just pass an empty array.
+	if (hookManager) {
+		await hookManager.runHooks(HookRegister.AFTER_READ, {
+			...hookParams,
+			entities: [],
+		});
+	}
+
+	return success;
+};
 
 const _listRelationshipField = async <G, D, R, C extends BaseContext>(
 	{ source, args: { filter }, context, fields, info }: ResolverOptions<{ filter: Filter<R> }, C, G>,
@@ -590,115 +643,127 @@ const _listRelationshipField = async <G, D, R, C extends BaseContext>(
 };
 
 // This is a function generator where you can bind it to the correct entity when creating it, as we cannot look up the entity name / type from the info object.
-export const aggregateRelationshipField =
-	(parentEntity: EntityMetadata<any, any>, field: FieldMetadata) =>
-	async <G, D, R, C extends BaseContext>({
-		args: { filter },
-		context,
-		source,
-		fields,
-	}: ResolverOptions<{ filter: Filter<R> }, C, G>): Promise<AggregationResult> => {
-		logger.trace('Resolving aggregated relationship field');
+export const aggregateRelationshipField = (
+	parentEntity: EntityMetadata<any, any>,
+	field: FieldMetadata
+) =>
+	trace(
+		async <G, D, R, C extends BaseContext>(
+			{ args: { filter }, context, source, fields }: ResolverOptions<{ filter: Filter<R> }, C, G>,
+			trace?: Trace
+		): Promise<AggregationResult> => {
+			logger.trace('Resolving aggregated relationship field');
 
-		const requestedFields = fields.fieldsByTypeName.AggregationResult;
-		const requestedAggregations = new Set<AggregationType>();
-		if (requestedFields.count) requestedAggregations.add(AggregationType.COUNT);
+			const requestedFields =
+				fields.fieldsByTypeName[
+					graphweaverMetadata.federationNameForGraphQLTypeName('AggregationResult')
+				];
+			const requestedAggregations = new Set<AggregationType>();
+			if (requestedFields.count) requestedAggregations.add(AggregationType.COUNT);
 
-		logger.trace(requestedAggregations, 'Requested aggregations');
+			logger.trace(requestedAggregations, 'Requested aggregations');
 
-		if (requestedAggregations.size === 0) {
-			logger.trace(requestedAggregations, 'No requested aggregations, returning.');
-			return {};
-		}
+			if (requestedAggregations.size === 0) {
+				logger.trace(requestedAggregations, 'No requested aggregations, returning.');
+				return {};
+			}
 
-		const { id, relatedField } = field.relationshipInfo ?? {};
+			trace?.span.updateName(
+				`Resolver - AggregateRelationshipField ${parentEntity.name}.${field.name}`
+			);
 
-		let idValue: ID | undefined = undefined;
-		if (id && typeof id === 'function') {
-			// If the id is a function, we'll call it with the source data to get the id value.
-			idValue = id(dataEntityForGraphQLEntity<G, D>(source as any));
-		} else if (id) {
-			// else if the id is a string, we'll try to get the value from the source data.
-			const valueOfForeignKey = dataEntityForGraphQLEntity<G, D>(source as any)?.[id as keyof D];
+			const { id, relatedField } = field.relationshipInfo ?? {};
 
-			// If the value is a string or number, we'll use it as the id value.
-			if (
-				typeof valueOfForeignKey === 'string' ||
-				typeof valueOfForeignKey === 'number' ||
-				typeof valueOfForeignKey === 'bigint'
-			) {
-				idValue = valueOfForeignKey;
-			} else {
-				// The ID value must be a string or a number otherwise we'll throw an error.
+			let idValue: ID | undefined = undefined;
+			if (id && typeof id === 'function') {
+				// If the id is a function, we'll call it with the source data to get the id value.
+				idValue = id(dataEntityForGraphQLEntity<G, D>(source as any));
+			} else if (id) {
+				// else if the id is a string, we'll try to get the value from the source data.
+				const valueOfForeignKey = dataEntityForGraphQLEntity<G, D>(source as any)?.[id as keyof D];
+
+				// If the value is a string or number, we'll use it as the id value.
+				if (
+					typeof valueOfForeignKey === 'string' ||
+					typeof valueOfForeignKey === 'number' ||
+					typeof valueOfForeignKey === 'bigint'
+				) {
+					idValue = valueOfForeignKey;
+				} else {
+					// The ID value must be a string or a number otherwise we'll throw an error.
+					throw new Error(
+						'Could not determine id value for relationship field only string or numbers are supported.'
+					);
+				}
+			}
+
+			const { fieldType } = getFieldTypeWithMetadata(field.getType);
+			const gqlEntityType = fieldType as { new (...args: any[]): R };
+
+			const relatedEntityMetadata = graphweaverMetadata.metadataForType(gqlEntityType);
+			if (!isEntityMetadata(relatedEntityMetadata)) {
 				throw new Error(
-					'Could not determine id value for relationship field only string or numbers are supported.'
+					`Related entity ${gqlEntityType.name} not found in metadata or not an entity.`
 				);
 			}
-		}
+			const sourcePrimaryKeyField = graphweaverMetadata.primaryKeyFieldForEntity(
+				parentEntity
+			) as keyof G;
+			const relatedPrimaryKeyField =
+				graphweaverMetadata.primaryKeyFieldForEntity(relatedEntityMetadata);
 
-		const { fieldType } = getFieldTypeWithMetadata(field.getType);
-		const gqlEntityType = fieldType as { new (...args: any[]): R };
+			// We need to construct a filter for the related entity and _and it with the user supplied filter.
+			const _and: Filter<R>[] = [];
 
-		const relatedEntityMetadata = graphweaverMetadata.metadataForType(gqlEntityType);
-		if (!isEntityMetadata(relatedEntityMetadata)) {
-			throw new Error(
-				`Related entity ${gqlEntityType.name} not found in metadata or not an entity.`
+			// If we have a user supplied filter, add it to the _and array.
+			if (filter) _and.push(filter);
+
+			// Lets check the relationship type and add the appropriate filter.
+			if (idValue) {
+				_and.push({ [relatedPrimaryKeyField]: idValue } as Filter<R>);
+			} else if (relatedField) {
+				_and.push({
+					[relatedField]: { [sourcePrimaryKeyField]: source[sourcePrimaryKeyField] },
+				} as Filter<R>);
+			}
+
+			const relatedEntityFilter = { _and } as Filter<R>;
+
+			const params: ReadHookParams<R> = {
+				args: { filter: relatedEntityFilter },
+				context,
+				fields,
+				transactional: !!parentEntity.provider?.withTransaction,
+			};
+			const hookManager = hookManagerMap.get(gqlEntityType.name);
+			const hookParams = hookManager
+				? await hookManager.runHooks(HookRegister.BEFORE_READ, params)
+				: params;
+
+			logger.trace('Aggregating with related field');
+
+			const result = await relatedEntityMetadata.provider?.aggregate?.(
+				relatedEntityFilter,
+				requestedAggregations
 			);
+
+			if (!result) throw new Error('No result from aggregation.');
+
+			logger.trace('Running after read hooks');
+			if (hookManager) {
+				await hookManager.runHooks(HookRegister.AFTER_READ, hookParams);
+			}
+
+			logger.trace('After read hooks ran');
+
+			return result;
 		}
-		const sourcePrimaryKeyField = graphweaverMetadata.primaryKeyFieldForEntity(
-			parentEntity
-		) as keyof G;
-		const relatedPrimaryKeyField =
-			graphweaverMetadata.primaryKeyFieldForEntity(relatedEntityMetadata);
-
-		// We need to construct a filter for the related entity and _and it with the user supplied filter.
-		const _and: Filter<R>[] = [];
-
-		// If we have a user supplied filter, add it to the _and array.
-		if (filter) _and.push(filter);
-
-		// Lets check the relationship type and add the appropriate filter.
-		if (idValue) {
-			_and.push({ [relatedPrimaryKeyField]: idValue } as Filter<R>);
-		} else if (relatedField) {
-			_and.push({
-				[relatedField]: { [sourcePrimaryKeyField]: source[sourcePrimaryKeyField] },
-			} as Filter<R>);
-		}
-
-		const relatedEntityFilter = { _and } as Filter<R>;
-
-		const params: ReadHookParams<R> = {
-			args: { filter: relatedEntityFilter },
-			context,
-			fields,
-			transactional: !!parentEntity.provider?.withTransaction,
-		};
-		const hookManager = hookManagerMap.get(gqlEntityType.name);
-		const hookParams = hookManager
-			? await hookManager.runHooks(HookRegister.BEFORE_READ, params)
-			: params;
-
-		logger.trace('Aggregating with related field');
-
-		const result = await relatedEntityMetadata.provider?.aggregate?.(
-			relatedEntityFilter,
-			requestedAggregations
-		);
-
-		if (!result) throw new Error('No result from aggregation.');
-
-		logger.trace('Running after read hooks');
-		if (hookManager) {
-			await hookManager.runHooks(HookRegister.AFTER_READ, hookParams);
-		}
-
-		logger.trace('After read hooks ran');
-
-		return result;
-	};
+	);
 
 export const getOne = trace(_getOne);
 export const list = trace(_list);
 export const listRelationshipField = trace(_listRelationshipField);
 export const createOrUpdate = trace(_createOrUpdate);
+export const deleteOne = trace(_deleteOne);
+export const deleteMany = trace(_deleteMany);
+export const aggregate = trace(_aggregate);

--- a/src/packages/core/src/resolvers.ts
+++ b/src/packages/core/src/resolvers.ts
@@ -184,7 +184,7 @@ const _list = async <G, D>(
 	return result;
 };
 
-const _createOrUpdate = async <G, D>(
+const _createOrUpdate = async <G>(
 	{ args: { input }, context, info, fields }: ResolverOptions<{ input: Partial<G> | Partial<G>[] }>,
 	trace?: Trace
 ) => {

--- a/src/packages/end-to-end/src/__tests__/api/metadata/exclude-from-federation.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/metadata/exclude-from-federation.test.ts
@@ -30,7 +30,7 @@ test('should include User in the schema but not in the federation _service { sdl
 		@Field(() => String)
 		name!: string;
 	}
-	const graphweaver = new Graphweaver({ enableFederation: true });
+	const graphweaver = new Graphweaver({ federationSubgraphName: 'test' });
 
 	// Federation _service { sdl } query should not include User
 	const response = await graphweaver.server.executeOperation<{ _service: { sdl: string } }>({

--- a/src/packages/mikroorm/src/provider/provider.ts
+++ b/src/packages/mikroorm/src/provider/provider.ts
@@ -516,7 +516,7 @@ export class MikroBackendProvider<D> implements BackendProvider<D> {
 	@TraceMethod()
 	public async deleteOne(filter: Filter<D>, trace?: Trace): Promise<boolean> {
 		trace?.span.updateName(`Mikro-Orm - deleteOne ${this.entityType.name}`);
-		logger.trace(`Running delete ${this.entityType.name} with filter ${filter}`);
+		logger.trace(filter, `Running delete ${this.entityType.name} with filter.`);
 		const where = filter ? gqlToMikro(JSON.parse(JSON.stringify(filter))) : undefined;
 		const whereWithAppliedExternalIdFields =
 			where && this.applyExternalIdFields(this.entityType, where);

--- a/src/packages/server/src/index.ts
+++ b/src/packages/server/src/index.ts
@@ -55,7 +55,7 @@ export interface GraphweaverConfig {
 	adminMetadata?: AdminMetadata;
 	// We omit schema here because we will build it from your entities + schema extensions.
 	apolloServerOptions?: Omit<ApolloServerOptionsWithStaticSchema<any>, 'schema'>;
-	enableFederation?: boolean;
+	federationSubgraphName?: string;
 	enableFederationTracing?: boolean;
 	graphQLArmorOptions?: GraphQLArmorConfig;
 	corsOptions?: CorsPluginOptions;
@@ -78,7 +78,6 @@ export default class Graphweaver<TContext extends BaseContext> {
 		apolloServerOptions: {
 			introspection: true,
 		},
-		enableFederation: false,
 		enableFederationTracing: false,
 		graphqlDeduplicator: {
 			enabled: true,
@@ -130,8 +129,11 @@ export default class Graphweaver<TContext extends BaseContext> {
 		logger.trace(graphweaverMetadata.typeCounts, `Graphweaver buildSchemaSync starting.`);
 
 		try {
-			if (this.config.enableFederation) {
-				enableFederation({ schemaDirectives: this.config.schemaDirectives });
+			if (this.config.federationSubgraphName) {
+				enableFederation({
+					federationSubgraphName: this.config.federationSubgraphName,
+					schemaDirectives: this.config.schemaDirectives,
+				});
 
 				// Caution: With this plugin, any client can request a trace for any operation, potentially revealing sensitive server information.
 				// It is recommended to ensure that federated subgraphs are not directly exposed to the public Internet. This feature is disabled by default for security reasons.

--- a/src/packages/storage-provider/src/decorators/media-field.ts
+++ b/src/packages/storage-provider/src/decorators/media-field.ts
@@ -39,7 +39,14 @@ const isMedia = (value: unknown): value is MediaData =>
 		typeof value.type === 'string'
 	);
 
-@Entity('Media')
+@Entity('Media', {
+	apiOptions: {
+		// This allows us to use the Media type in multiple subgraphs at the same time,
+		// so if you have specified a federationSubgraphName in your Graphweaver config,
+		// the Media entity will be called MediaFrom[SubgraphName]Subgraph in the final result.
+		namespaceForFederation: true,
+	},
+})
 export class Media {
 	@Field(() => String)
 	filename!: string;


### PR DESCRIPTION
This PR does two things:

1. **Breaking Change**: Switch from `enableFederation: true` to `federationSubgraphName: 'nameHere'` as the pattern to enable federation. This allows all of our singleton types to get named, for example, `AggregrationResultFromNameHereSubgraph` instead of just `AggregationResult` so that multiple Graphweaver instances can federate alongside each other.
1. Previously, the `_service` query would return an entity called `_service`. The specification requires it to be called `_Service` so this would not compose correctly. This PR renames the entity to `_Service`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `federationSubgraphName` field to multiple modules, enhancing support for federated subgraphs.
  - Introduced new scalar types and updated queries to handle federated subgraph names.

- **Enhancements**
  - Updated various components and utilities to dynamically handle `federationSubgraphName`.
  - Renamed several types and fields to align with federation naming conventions.

- **Bug Fixes**
  - Improved entity filtering and metadata retrieval based on federation subgraph names.

- **Refactor**
  - Refactored multiple functions and resolvers to incorporate `federationSubgraphName` for better schema management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->