### PR TITLE
Feature / Add Entity Validation

### DIFF
--- a/src/packages/core/src/schema-builder.ts
+++ b/src/packages/core/src/schema-builder.ts
@@ -737,6 +737,9 @@ class SchemaBuilderImplementation {
 	public build(buildOptions?: SchemaBuildOptions) {
 		const { schemaDirectives } = buildOptions ?? {};
 
+		// Before we get started, let's validate their now complete decorator situation.
+		graphweaverMetadata.validateEntities();
+
 		// Note: It's really important that this runs before the query and mutation
 		// steps below, as the fields in those reference the types we generate here.
 		const directives = Array.from(this.buildDirectives(buildOptions?.filterEntities));

--- a/src/packages/end-to-end/src/__tests__/api/metadata/missing-entity-decorator-validation.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/metadata/missing-entity-decorator-validation.test.ts
@@ -1,0 +1,28 @@
+import { Field, ID, Entity, graphweaverMetadata } from '@exogee/graphweaver';
+
+// ESLint, I know it looks like the entities in this file aren't used, but they actually are.
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+test('should correctly discover the misuse of an entity field decorator on a non-entity', async () => {
+	@Entity('User')
+	class User {
+		@Field(() => ID)
+		id!: string;
+
+		@Field(() => String)
+		name!: string;
+	}
+
+	class Other {
+		@Field(() => String)
+		one!: string;
+
+		two!: string;
+
+		@Field(() => String)
+		three!: string;
+	}
+	expect(graphweaverMetadata.validateEntities).toThrow(
+		`The entity 'Other' is missing the @Entity() decorator from Graphweaver. This is likely because a field was mistakenly decorated with a GraphQL decorator when it is not a GraphQL entity. Fields on this entity are: 'one', 'three'. If this is not a full list of all of the fields on the entity, examine the decorators on these fields closely and make sure they are in the correct files. Are they on a data source entity instead of the GraphQL entity?`
+	);
+});


### PR DESCRIPTION
We accidentally decorated a field on a non-graphql entity with an @Field decorator. This was difficult to debug, and it'd be nice if Graphweaver could help you avoid doing this.

This PR
- Adds metadata validation to catch this scenario which is triggered on the schema build step.
- Adds a test that ensures it continues to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added decorator validation to improve error messages and prevent misuse in GraphQL entity decorations.

- **Tests**
  - Introduced new test cases to verify the correct detection of misused entity field decorators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->