### PR TITLE
Fix / Allow Subroutes for Active Dashboard Links by Default

### DIFF
--- a/src/packages/admin-ui-components/src/side-bar/contents/dashboard-row.tsx
+++ b/src/packages/admin-ui-components/src/side-bar/contents/dashboard-row.tsx
@@ -5,12 +5,20 @@ import { TableIcon } from '../../assets';
 
 import styles from '../styles.module.css';
 
-export const DashboardRow = ({ name, route }: { name: string; route: string }) => (
+export const DashboardRow = ({
+	name,
+	route,
+	end,
+}: {
+	name: string;
+	route: string;
+	end?: boolean;
+}) => (
 	<li>
 		<NavLink
 			to={route}
 			className={({ isActive }) => clsx(styles.subListItem, isActive && styles.active)}
-			end
+			end={end}
 		>
 			<TableIcon />
 			{name}


### PR DESCRIPTION
Make end prop configurable `DashboardLinks` and default to false.

**Before**
<img width="539" alt="Screenshot 2024-07-19 at 3 20 09 PM" src="https://github.com/user-attachments/assets/5187292b-a923-4dc8-b7ad-e93cb83ed0ec">

**After**
<img width="813" alt="Screenshot 2024-07-19 at 3 22 56 PM" src="https://github.com/user-attachments/assets/59ff3344-e5b3-4543-b1fd-a9da260b47ea">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `end` property to the `DashboardRow` component for improved navigation control.
	- Enhanced the routing logic to support exact route matching for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->