### PR TITLE
Fix / Switch Vite Entry Point to ESM

### DIFF
--- a/src/packages/builder/src/build/frontend.ts
+++ b/src/packages/builder/src/build/frontend.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import { build } from 'vite';
 import { rimraf } from 'rimraf';
 import { config } from '@exogee/graphweaver-config';
 
@@ -10,6 +9,10 @@ export interface FrontendBuildOptions {
 }
 
 export const buildFrontend = async ({ adminUiBase }: FrontendBuildOptions) => {
+	// We're using the async import here because we're in CJS and vite's CJS entry point is
+	// deprecated. Once we move to ESM, we can use the ESM entry point directly above.
+	const { build } = await import('vite');
+
 	// Clear the folder
 	await rimraf(path.join('.graphweaver', 'admin-ui'));
 

--- a/src/packages/builder/src/bundle/analyse.ts
+++ b/src/packages/builder/src/bundle/analyse.ts
@@ -1,9 +1,13 @@
 import path from 'path';
-import { PluginOption, build } from 'vite';
+import type { PluginOption } from 'vite';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { viteConfig } from '../vite-config';
 
 export const analyseBundle = async () => {
+	// We're using the async import here because we're in CJS and vite's CJS entry point is
+	// deprecated. Once we move to ESM, we can use the ESM entry point directly above.
+	const { build } = await import('vite');
+
 	const rootDirectory = path.resolve(
 		require.resolve('@exogee/graphweaver-admin-ui'),
 		'..',

--- a/src/packages/builder/src/start/frontend.ts
+++ b/src/packages/builder/src/start/frontend.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { ViteDevServer, createServer } from 'vite';
+import type { ViteDevServer } from 'vite';
 import { viteConfig } from '../vite-config';
 import { config } from '@exogee/graphweaver-config';
 
@@ -25,6 +25,10 @@ export const startFrontend = async ({ host, port }: StartOptions) => {
 
 		const backendUrl = new URL('/', 'http://localhost');
 		backendUrl.port = String((port || 9000) + 1);
+
+		// We're using the async import here because we're in CJS and vite's CJS entry point is
+		// deprecated. Once we move to ESM, we can use the ESM entry point directly above.
+		const { createServer } = await import('vite');
 		server = await createServer(
 			onResolveViteConfiguration(
 				viteConfig({

--- a/src/packages/builder/src/vite-config.ts
+++ b/src/packages/builder/src/vite-config.ts
@@ -1,6 +1,6 @@
 import react from '@vitejs/plugin-react';
 import graphweaver from 'vite-plugin-graphweaver';
-import { InlineConfig } from 'vite';
+import type { InlineConfig } from 'vite';
 import path from 'path';
 
 export interface ViteConfigOptions {

--- a/src/packages/vite-plugin-graphweaver/src/index.ts
+++ b/src/packages/vite-plugin-graphweaver/src/index.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'vite';
+import type { Plugin } from 'vite';
 import { loadCustomPages, loadCustomFields } from './loaders';
 
 const resolved = (virtualModuleId: string) => `\0${virtualModuleId}`;


### PR DESCRIPTION
Fix warning on startup about deprecated CJS entry point for Vite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated import methods for key functions to support future transitions to ECMAScript Modules (ESM), enhancing flexibility.
  
- **Refactor**
	- Transitioned specific imports to type-only imports, improving type-checking performance and reducing output size.

- **Bug Fixes**
	- Addressed deprecation issues related to the CommonJS entry point for Vite, ensuring continued compatibility and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->