### PR TITLE
Chore / Derive dependency versions for generated projects from installed package versions

### DIFF
--- a/src/packages/cli/package.json
+++ b/src/packages/cli/package.json
@@ -42,7 +42,8 @@
 		"@types/semver": "7.5.8",
 		"@types/validate-npm-package-name": "4.0.2",
 		"@types/yargs": "17.0.32",
-		"prettier": "3.3.3"
+		"prettier": "3.3.3",
+		"typescript": "5.5.4"
 	},
 	"keywords": [
 		"graphql",

--- a/src/packages/cli/src/index.ts
+++ b/src/packages/cli/src/index.ts
@@ -11,7 +11,7 @@ import {
 } from '@exogee/graphweaver-builder';
 import { Backend, init } from './init';
 import { importDataSource } from './import';
-import pkg from '../package.json';
+import { version } from '../package.json';
 import { generateTypes, printSchema } from './tasks';
 import * as path from 'path';
 
@@ -304,7 +304,7 @@ yargs
 			}
 		},
 	})
-	.version(pkg.version)
+	.version(version)
 	.showHelpOnFail(true)
 	.help('help')
 	.command({

--- a/src/packages/cli/src/init/backend.ts
+++ b/src/packages/cli/src/init/backend.ts
@@ -9,7 +9,7 @@ export const packagesForBackend = (backend: Backend, version?: string): Record<s
 				'@mikro-orm/core': MIKRO_ORM_TARGET_VERSION,
 				'@mikro-orm/knex': MIKRO_ORM_TARGET_VERSION,
 				'@mikro-orm/postgresql': MIKRO_ORM_TARGET_VERSION,
-				pg: '8.11.3',
+				pg: '8.12.0',
 			};
 
 		case Backend.Mysql:
@@ -18,7 +18,7 @@ export const packagesForBackend = (backend: Backend, version?: string): Record<s
 				'@mikro-orm/core': MIKRO_ORM_TARGET_VERSION,
 				'@mikro-orm/knex': MIKRO_ORM_TARGET_VERSION,
 				'@mikro-orm/mysql': MIKRO_ORM_TARGET_VERSION,
-				mysql2: '3.6.2',
+				mysql2: '3.10.3',
 			};
 
 		case Backend.Sqlite:

--- a/src/packages/cli/src/init/constants.ts
+++ b/src/packages/cli/src/init/constants.ts
@@ -1,8 +1,14 @@
-import { version } from '../../package.json';
+import { version, devDependencies } from '../../package.json';
 import { peerDependencies as mikroPackagePeerDependencies } from '../../../mikroorm/package.json';
+import { dependencies as graphweaverServerDependencies } from '../../../server/package.json';
 
+export const AS_INTEGRATIONS_AWS_LAMBDA_TARGET_VERSION =
+	graphweaverServerDependencies['@as-integrations/aws-lambda'];
+export const GRAPHQL_TARGET_VERSION = graphweaverServerDependencies.graphql;
 export const GRAPHWEAVER_TARGET_VERSION = version;
 export const MIKRO_ORM_TARGET_VERSION = mikroPackagePeerDependencies['@mikro-orm/core'];
+export const NODE_TYPES_TARGET_VERSION = devDependencies['@types/node'];
+export const TYPESCRIPT_TARGET_VERSION = devDependencies.typescript;
 
 export const graphweaverVersion = (versionOverride?: string, packageName?: string) => {
 	if (versionOverride === 'local' && packageName) {

--- a/src/packages/cli/src/init/template.ts
+++ b/src/packages/cli/src/init/template.ts
@@ -1,6 +1,12 @@
 import { writeFileSync, mkdirSync } from 'fs';
 import { packagesForBackend } from './backend';
-import { graphweaverVersion } from './constants';
+import {
+	graphweaverVersion,
+	AS_INTEGRATIONS_AWS_LAMBDA_TARGET_VERSION,
+	GRAPHQL_TARGET_VERSION,
+	NODE_TYPES_TARGET_VERSION,
+	TYPESCRIPT_TARGET_VERSION,
+} from './constants';
 import { Backend } from '.';
 
 export const makePackageJson = (projectName: string, backends: Backend[], version?: string) => {
@@ -20,17 +26,17 @@ export const makePackageJson = (projectName: string, backends: Backend[], versio
 			import: 'graphweaver import',
 		},
 		dependencies: {
-			'@as-integrations/aws-lambda': '3.1.0',
+			'@as-integrations/aws-lambda': AS_INTEGRATIONS_AWS_LAMBDA_TARGET_VERSION,
 			'@exogee/graphweaver': graphweaverVersion(version, '@exogee/graphweaver'),
 			'@exogee/graphweaver-scalars': graphweaverVersion(version, '@exogee/graphweaver-scalars'),
 			'@exogee/graphweaver-server': graphweaverVersion(version, '@exogee/graphweaver-server'),
 			...backendPackages,
-			graphql: '16.9.0',
+			graphql: GRAPHQL_TARGET_VERSION,
 		},
 		devDependencies: {
-			'@types/node': '20.14.11',
+			'@types/node': NODE_TYPES_TARGET_VERSION,
 			graphweaver: graphweaverVersion(version, 'graphweaver'),
-			typescript: '5.5.4',
+			typescript: TYPESCRIPT_TARGET_VERSION,
 		},
 	};
 

--- a/src/packages/cli/src/init/template.ts
+++ b/src/packages/cli/src/init/template.ts
@@ -28,9 +28,9 @@ export const makePackageJson = (projectName: string, backends: Backend[], versio
 			graphql: '16.9.0',
 		},
 		devDependencies: {
-			'@types/node': '20.14.9',
+			'@types/node': '20.14.11',
 			graphweaver: graphweaverVersion(version, 'graphweaver'),
-			typescript: '5.5.2',
+			typescript: '5.5.4',
 		},
 	};
 

--- a/src/packages/server/package.json
+++ b/src/packages/server/package.json
@@ -36,7 +36,8 @@
 		"@escape.tech/graphql-armor-types": "0.6.0",
 		"@types/graphql-deduplicator": "2.0.2",
 		"esbuild": "0.23.0",
-		"glob": "10.4.3"
+		"glob": "10.4.3",
+		"typescript": "5.5.4"
 	},
 	"keywords": [
 		"graphql",

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -1021,6 +1021,9 @@ importers:
       prettier:
         specifier: 3.3.3
         version: 3.3.3
+      typescript:
+        specifier: 5.5.4
+        version: 5.5.4
 
   packages/config:
     dependencies:
@@ -1442,6 +1445,9 @@ importers:
       glob:
         specifier: 10.4.3
         version: 10.4.3
+      typescript:
+        specifier: 5.5.4
+        version: 5.5.4
 
   packages/storage-provider:
     dependencies:


### PR DESCRIPTION
Changes approach to dependencies in generated projects so they always use whatever our packages are using. This way when we install dependabot updates the template will automatically get updated too for everything except `pg` and `mysql2` because they're optional dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated dependencies for PostgreSQL and MySQL, enhancing performance and stability.
	- Added TypeScript as a dependency, improving development capabilities and type checking.

- **Bug Fixes**
	- Dependency updates may resolve previous issues, improving the overall user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->