### PR TITLE
Errors thrown from the Auth packages should be generic

### DIFF
--- a/src/packages/auth/src/authentication/methods/magic-link.ts
+++ b/src/packages/auth/src/authentication/methods/magic-link.ts
@@ -93,10 +93,14 @@ export class MagicLink extends BaseAuthMethod {
 
 	async generateMagicLink(username: string, ctx: AuthorizationContext) {
 		// check that the user exists
-		const user = await this.getUser(username);
-
-		// if the user does not exist, silently fail
-		if (!user?.id) {
+		let user = undefined;
+		try {
+			user = await this.getUser(username);
+			// if the user does not exist, silently fail
+			if (!user?.id) {
+				throw new Error('User not known, silently fail.');
+			}
+		} catch (err) {
 			logger.warn(`User with username ${username} does not exist or is not active.`);
 			return;
 		}

--- a/src/packages/auth/src/authentication/methods/magic-link.ts
+++ b/src/packages/auth/src/authentication/methods/magic-link.ts
@@ -98,10 +98,10 @@ export class MagicLink extends BaseAuthMethod {
 			user = await this.getUser(username);
 			// if the user does not exist, silently fail
 			if (!user?.id) {
-				throw new Error('User not known, silently fail.');
+				throw new Error('User id not returned from getUser child implementation');
 			}
 		} catch (err) {
-			logger.warn(`User with username ${username} does not exist or is not active.`);
+			logger.warn(`User with username ${username} does not exist or is not active, silently fail.`);
 			return;
 		}
 

--- a/src/packages/auth/src/authentication/methods/password.ts
+++ b/src/packages/auth/src/authentication/methods/password.ts
@@ -157,19 +157,32 @@ export class Password<D extends CredentialStorage> extends BaseAuthMethod {
 		password: string,
 		context: AuthorizationContext
 	): Promise<UserProfile<unknown>> {
-		const credential = await this.provider.findOne({
-			username,
-		});
-
-		if (!credential) throw new AuthenticationError('Bad Request: Authentication Failed');
-		if (!credential.password) throw new AuthenticationError('Bad Request: Authentication Failed');
-
-		if (await verifyPassword(password, credential.password)) {
-			return this.getUserProfile(credential.id, PasswordOperation.LOGIN, context);
+		let credential = undefined;
+		try {
+			credential = await this.provider.findOne({
+				username,
+			});
+		} catch (err) {
+			logger.trace('No credential returned from provider');
+			throw new AuthenticationError('Bad Request: Authentication Failed');
 		}
 
-		this.onUserAuthenticated?.(credential.id, context);
+		if (!credential) {
+			logger.trace('No credential found');
+			throw new AuthenticationError('Bad Request: Authentication Failed');
+		}
+		if (!credential.password) {
+			logger.trace('No password attached to credential');
+			throw new AuthenticationError('Bad Request: Authentication Failed');
+		}
 
+		if (await verifyPassword(password, credential.password)) {
+			const profile = this.getUserProfile(credential.id, PasswordOperation.LOGIN, context);
+			this.onUserAuthenticated?.(credential.id, context);
+			return profile;
+		}
+
+		logger.trace(`Incorrect password for credential ${credential.id}`);
 		throw new AuthenticationError('Bad Request: Authentication Failed');
 	}
 

--- a/src/packages/auth/src/authentication/methods/password.ts
+++ b/src/packages/auth/src/authentication/methods/password.ts
@@ -161,9 +161,8 @@ export class Password<D extends CredentialStorage> extends BaseAuthMethod {
 			username,
 		});
 
-		if (!credential) throw new AuthenticationError('Bad Request: Authentication Failed. (E0001)');
-		if (!credential.password)
-			throw new AuthenticationError('Bad Request: Authentication Failed. (E0002)');
+		if (!credential) throw new AuthenticationError('Bad Request: Authentication Failed');
+		if (!credential.password) throw new AuthenticationError('Bad Request: Authentication Failed');
 
 		if (await verifyPassword(password, credential.password)) {
 			return this.getUserProfile(credential.id, PasswordOperation.LOGIN, context);
@@ -171,7 +170,7 @@ export class Password<D extends CredentialStorage> extends BaseAuthMethod {
 
 		this.onUserAuthenticated?.(credential.id, context);
 
-		throw new AuthenticationError('Unknown username or password, please try again');
+		throw new AuthenticationError('Bad Request: Authentication Failed');
 	}
 
 	async create(

--- a/src/packages/auth/src/authentication/methods/password.ts
+++ b/src/packages/auth/src/authentication/methods/password.ts
@@ -158,22 +158,27 @@ export class Password<D extends CredentialStorage> extends BaseAuthMethod {
 		context: AuthorizationContext
 	): Promise<UserProfile<unknown>> {
 		let credential = undefined;
+
+		// This string should be kept consistent across each error state.
+		// If it changes, it is possible for a hacker to enumerate the user accounts
+		const errResponseString = 'Bad Request: Authentication Failed';
+
 		try {
 			credential = await this.provider.findOne({
 				username,
 			});
 		} catch (err) {
 			logger.trace('No credential returned from provider');
-			throw new AuthenticationError('Bad Request: Authentication Failed');
+			throw new AuthenticationError(errResponseString);
 		}
 
 		if (!credential) {
 			logger.trace('No credential found');
-			throw new AuthenticationError('Bad Request: Authentication Failed');
+			throw new AuthenticationError(errResponseString);
 		}
 		if (!credential.password) {
 			logger.trace('No password attached to credential');
-			throw new AuthenticationError('Bad Request: Authentication Failed');
+			throw new AuthenticationError(errResponseString);
 		}
 
 		if (await verifyPassword(password, credential.password)) {
@@ -183,7 +188,7 @@ export class Password<D extends CredentialStorage> extends BaseAuthMethod {
 		}
 
 		logger.trace(`Incorrect password for credential ${credential.id}`);
-		throw new AuthenticationError('Bad Request: Authentication Failed');
+		throw new AuthenticationError(errResponseString);
 	}
 
 	async create(

--- a/src/packages/end-to-end/src/__tests__/api/auth/password/login.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/auth/password/login.test.ts
@@ -90,7 +90,7 @@ describe('Password Authentication - Login', () => {
 		assert(response.body.kind === 'single');
 		expect(response.body.singleResult.errors).toBeDefined();
 		expect(response.body.singleResult.errors?.[0]?.message).toBe(
-			'Unknown username or password, please try again'
+			'Bad Request: Authentication Failed'
 		);
 	});
 });


### PR DESCRIPTION
This fixes two issues:

1. Generic message for password login fail (This is to reduce enumeration attacks)
2. Catch any errors from the implementation of the magic links data fetch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling for user retrieval in the Magic Link authentication process.
  - Streamlined error messaging during the password authentication process for simplified user feedback.

- **Bug Fixes**
  - Improved clarity and reliability in error handling for both Magic Link generation and password authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->