### PR TITLE
Fix / Add Type Policy for AggregationResult objects.

### DIFF
--- a/src/packages/apollo-client/src/index.ts
+++ b/src/packages/apollo-client/src/index.ts
@@ -62,7 +62,10 @@ const generateTypePolicyFields = (entities: Entity[]) => {
 };
 
 export const generateTypePolicies = (entities: Entity[]) => {
-	const result: TypePolicies = {};
+	const result: TypePolicies = {
+		// AggregationResult objects don't have any ID field at all, so they cannot be cached.
+		AggregationResult: { keyFields: [] },
+	};
 
 	for (const entity of entities) {
 		if (result[entity.name]) throw new Error(`Duplicate entity name: '${entity.name}'`);


### PR DESCRIPTION
Add type policy for AggregationResult objects to let Apollo know they have no ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced caching logic to appropriately handle `AggregationResult` entities, preventing caching errors.
  
- **Bug Fixes**
	- Improved application stability by ensuring that `AggregationResult` entities are processed without caching attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->