### PR TITLE
Fix / Introspection for one to one relationships

### DIFF
--- a/src/packages/cli/src/import/index.ts
+++ b/src/packages/cli/src/import/index.ts
@@ -175,6 +175,7 @@ export const importDataSource = async (
 		}
 		console.log(`${fileCount} files have been successfully created in the project.`);
 	} catch (err: unknown) {
+		console.error(err);
 		if (isIntrospectionError(err)) {
 			console.warn(`\n\n${err.title}\n${err.message}\n\n`);
 		} else {

--- a/src/packages/end-to-end/databases/postgres.sql
+++ b/src/packages/end-to-end/databases/postgres.sql
@@ -138,6 +138,19 @@ CREATE TABLE "Track"
     CONSTRAINT "PK_Track" PRIMARY KEY  ("TrackId")
 );
 
+-- These are here to test a specific scenario that used to crash the introspection process.
+CREATE TABLE "ToOne" (
+    id text PRIMARY KEY,
+    name text NOT NULL
+);
+
+CREATE UNIQUE INDEX to_one_pkey ON "ToOne"(id text_ops);
+CREATE UNIQUE INDEX to_one_name_key ON "ToOne"(name text_ops);
+
+CREATE TABLE "ToOneKeyOwner" (
+    id text NOT NULL,
+    related_entity_name text NOT NULL REFERENCES "ToOne"(name) ON DELETE CASCADE ON UPDATE CASCADE
+);
 
 
 /*******************************************************************************

--- a/src/packages/end-to-end/databases/postgres.sql
+++ b/src/packages/end-to-end/databases/postgres.sql
@@ -148,7 +148,7 @@ CREATE UNIQUE INDEX to_one_pkey ON "ToOne"(id text_ops);
 CREATE UNIQUE INDEX to_one_name_key ON "ToOne"(name text_ops);
 
 CREATE TABLE "ToOneKeyOwner" (
-    id text NOT NULL,
+    id text PRIMARY KEY,
     related_entity_name text NOT NULL REFERENCES "ToOne"(name) ON DELETE CASCADE ON UPDATE CASCADE
 );
 

--- a/src/packages/mikroorm/src/introspection/files/data-entity-file.ts
+++ b/src/packages/mikroorm/src/introspection/files/data-entity-file.ts
@@ -111,6 +111,10 @@ export class DataEntityFile extends BaseFile {
 	}
 
 	protected getPropertyType(prop: EntityProperty): string {
+		if ([ReferenceKind.ONE_TO_ONE, ReferenceKind.MANY_TO_ONE].includes(prop.kind)) {
+			return prop.type.charAt(0).toUpperCase() + prop.type.slice(1);
+		}
+
 		const columnType = prop.columnTypes?.[0]?.toLowerCase();
 
 		if (['jsonb', 'json', 'any'].includes(columnType)) {

--- a/src/packages/mikroorm/src/introspection/generate.ts
+++ b/src/packages/mikroorm/src/introspection/generate.ts
@@ -298,6 +298,9 @@ export const generate = async (databaseType: DatabaseType, options: ConnectionOp
 	} catch (err) {
 		if (err instanceof IntrospectionError) throw err;
 
+		console.error('Got error during introspection:');
+		console.error(err);
+
 		throw new IntrospectionError(
 			`Warning: Unable to connect to database.`,
 			hasErrorMessage(err) ? err.message : 'Please check the connection settings and try again'


### PR DESCRIPTION
Introspection wasn't working for One to One relationships after the Mikro upgrade to 6.3: #901  

This adds more logging to errors we encounter during introspection to make it a bit easier to debug remotely, and also fixes inference of these types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling and logging for better visibility during data import and introspection processes.
	- Improved handling of entity property types for reference kinds, ensuring consistent capitalization.

- **New Features**
	- Refined logic for determining TypeScript property types, enhancing standardisation for specific reference types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->