### PR TITLE
Improvement / More Robust JSON Field / Better Read Only default in Admin Area

### DIFF
--- a/src/packages/admin-ui-components/src/detail-panel/component.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/component.tsx
@@ -48,11 +48,20 @@ export enum PanelMode {
 const isFieldReadonly = (field: EntityField | CustomField<unknown>) =>
 	field.type === 'ID' || field.type === 'ID!' || field.attributes?.isReadOnly;
 
-const getField = ({ field, autoFocus }: { field: EntityField; autoFocus: boolean }) => {
-	const isReadonly = isFieldReadonly(field);
+const getField = ({
+	field,
+	autoFocus,
+	panelMode,
+}: {
+	field: EntityField;
+	autoFocus: boolean;
+	panelMode: PanelMode;
+}) => {
+	// In Create mode, all readonly fields should be writeable.
+	const isReadonly = panelMode !== PanelMode.CREATE && isFieldReadonly(field);
 
 	if (field.type === 'JSON') {
-		return <JSONField name={field.name} autoFocus={autoFocus} />;
+		return <JSONField name={field.name} autoFocus={autoFocus} disabled={isReadonly} />;
 	}
 
 	if (field.type === 'Boolean') {
@@ -91,13 +100,21 @@ const getField = ({ field, autoFocus }: { field: EntityField; autoFocus: boolean
 	);
 };
 
-const DetailField = ({ field, autoFocus }: { field: EntityField; autoFocus: boolean }) => {
+const DetailField = ({
+	field,
+	autoFocus,
+	panelMode,
+}: {
+	field: EntityField;
+	autoFocus: boolean;
+	panelMode: PanelMode;
+}) => {
 	const isRequired = !(field.type === 'ID' || field.type === 'ID!') && field.attributes?.isRequired;
 	return (
 		<div className={styles.detailField} data-testid={`detail-panel-field-${field.name}`}>
 			<DetailPanelFieldLabel fieldName={field.name} required={isRequired} />
 
-			{getField({ field, autoFocus })}
+			{getField({ field, autoFocus, panelMode })}
 		</div>
 	);
 };
@@ -162,22 +179,31 @@ const DetailForm = ({
 					field.type !== 'custom' &&
 					isValueEmpty(values[field.name])
 				) {
-					errors[field.name] = 'Required';
+					errors[field.name] = 'Field is Required';
+				}
+
+				if (field.type === 'JSON') {
+					// Let's ensure we can parse the JSON.
+					try {
+						JSON.parse(values[field.name]);
+					} catch (error) {
+						errors[field.name] = 'Invalid JSON';
+					}
 				}
 			}
 
-			const fieldsInError = Object.keys(errors);
-			if (fieldsInError.length === 0) return {};
+			const groupedByError: Record<string, string[]> = {};
+			for (const [field, error] of Object.entries(errors)) {
+				if (!groupedByError[error]) groupedByError[error] = [];
+				groupedByError[error].push(field);
+			}
+			const message = Object.entries(groupedByError)
+				.map(([error, fields]) => `Error ${error}: ${fields.join(', ')}`)
+				.join('\n');
 
 			// TODO EXOGW-150: instead of using toast, we should use a formik error message on the form itself
-			toast.error(
-				`${fieldsInError.join(', ')} ${fieldsInError.length > 1 ? 'are' : 'is a'} required field${
-					fieldsInError.length > 1 ? 's' : ''
-				}.`,
-				{
-					duration: 5000,
-				}
-			);
+			toast.error(message, { duration: 5000 });
+
 			return errors;
 		},
 		[detailFields]
@@ -238,6 +264,7 @@ const DetailForm = ({
 										key={field.name}
 										field={field}
 										autoFocus={field === firstEditableField}
+										panelMode={panelMode}
 									/>
 								);
 							}

--- a/src/packages/admin-ui-components/src/detail-panel/fields/json-field.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/fields/json-field.tsx
@@ -1,16 +1,36 @@
+import clsx from 'clsx';
 import { useField } from 'formik';
 
 import { useAutoFocus } from '../../hooks';
+import styles from '../styles.module.css';
 
-export const JSONField = ({ name, autoFocus }: { name: string; autoFocus: boolean }) => {
-	const [_, meta] = useField({ name, multiple: false });
-	const { initialValue } = meta;
+export const JSONField = ({
+	name,
+	autoFocus,
+	disabled,
+}: {
+	name: string;
+	autoFocus: boolean;
+	disabled?: boolean;
+}) => {
+	const [field, meta] = useField({ name, multiple: false });
+	const inputRef = useAutoFocus<HTMLTextAreaElement>(autoFocus);
 
-	const inputRef = useAutoFocus<HTMLInputElement>(autoFocus);
+	if (disabled) {
+		return (
+			<code ref={inputRef} tabIndex={0}>
+				{JSON.stringify(meta.value, null, 4)}
+			</code>
+		);
+	}
 
 	return (
-		<code ref={inputRef} tabIndex={0}>
-			{JSON.stringify(initialValue, null, 4)}
-		</code>
+		<textarea
+			{...field}
+			id={name}
+			ref={inputRef}
+			rows={6}
+			className={clsx(styles.textInputField, styles.textArea)}
+		/>
 	);
 };

--- a/src/packages/admin-ui-components/src/detail-panel/styles.module.css
+++ b/src/packages/admin-ui-components/src/detail-panel/styles.module.css
@@ -59,6 +59,10 @@
 	opacity: 0.5;
 }
 
+.textArea {
+	height: 150px;
+}
+
 .modalOverlay {
 	position: fixed;
 	inset: 0px;


### PR DESCRIPTION
- Read only form fields now allow for input when creating entities.
- JSON field now renders as `<code>` when it's readonly and `<textarea>` when it's not.
- Saving with a JSON field now validates that the JSON value parses before save.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced field behaviour with new panel modes, allowing better control over editable states.
  - Introduced a `disabled` prop in the JSONField component for read-only functionality.
  
- **Bug Fixes**
  - Improved error handling in detail forms by grouping errors by messages for clearer user feedback. 

- **Style**
  - Added a new CSS class for text areas to ensure consistent height throughout the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->