### PR TITLE
Fix / Read only entity display in admin UI

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -19,7 +19,7 @@
 		"build:types": "turbo --filter \"!./examples/**\" build:types",
 		"build:js": "turbo --filter \"!./examples/**\" build:js",
 		"build:watch": "concurrently -prefix \"none\" \"pnpm build:js --watch\" \"pnpm -r build:types\"",
-		"clean": "./clean.sh && pnpm build",
+		"clean": "./clean.sh && pnpm force:build",
 		"force:build": "TURBO_FORCE=true pnpm build",
 		"format": "pnpm prettier",
 		"packages:pack": "turbo --filter \"!./examples/**\" package:pack -- --pack-destination ../../.packs",

--- a/src/packages/core/src/metadata-service/resolver.ts
+++ b/src/packages/core/src/metadata-service/resolver.ts
@@ -73,9 +73,10 @@ export const resolveAdminUiMetadata = (hooks?: Hooks) => {
 			const attributes = new AdminUiEntityAttributeMetadata();
 			attributes.exportPageSize = entity.adminUIOptions?.exportPageSize;
 			attributes.isReadOnly =
-				entity.adminUIOptions?.readonly ||
-				entity.apiOptions?.excludeFromBuiltInOperations ||
-				entity.apiOptions?.excludeFromBuiltInWriteOperations;
+				entity.adminUIOptions?.readonly ??
+				entity.apiOptions?.excludeFromBuiltInOperations ??
+				entity.apiOptions?.excludeFromBuiltInWriteOperations ??
+				false;
 
 			let defaultSummaryField: 'name' | 'title' | undefined = undefined;
 			const primaryKeyField = graphweaverMetadata.primaryKeyFieldForEntity(entity);

--- a/src/packages/core/src/metadata-service/resolver.ts
+++ b/src/packages/core/src/metadata-service/resolver.ts
@@ -72,7 +72,11 @@ export const resolveAdminUiMetadata = (hooks?: Hooks) => {
 
 			const attributes = new AdminUiEntityAttributeMetadata();
 			attributes.exportPageSize = entity.adminUIOptions?.exportPageSize;
-			attributes.isReadOnly = entity.adminUIOptions?.readonly;
+			attributes.isReadOnly =
+				!provider ||
+				entity.adminUIOptions?.readonly ||
+				entity.apiOptions?.excludeFromBuiltInOperations ||
+				entity.apiOptions?.excludeFromBuiltInWriteOperations;
 
 			let defaultSummaryField: 'name' | 'title' | undefined = undefined;
 			const primaryKeyField = graphweaverMetadata.primaryKeyFieldForEntity(entity);

--- a/src/packages/core/src/metadata-service/resolver.ts
+++ b/src/packages/core/src/metadata-service/resolver.ts
@@ -73,7 +73,6 @@ export const resolveAdminUiMetadata = (hooks?: Hooks) => {
 			const attributes = new AdminUiEntityAttributeMetadata();
 			attributes.exportPageSize = entity.adminUIOptions?.exportPageSize;
 			attributes.isReadOnly =
-				!provider ||
 				entity.adminUIOptions?.readonly ||
 				entity.apiOptions?.excludeFromBuiltInOperations ||
 				entity.apiOptions?.excludeFromBuiltInWriteOperations;

--- a/src/packages/end-to-end/src/__tests__/api/sqlite/query/read-only-entity.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/sqlite/query/read-only-entity.test.ts
@@ -121,5 +121,5 @@ test('Should return isReadOnly attribute for each entity in getAdminUiMetadata',
 
 	const artistEntity = result?.entities.find((entity) => entity.name === 'Artist');
 	expect(artistEntity).not.toBeNull();
-	expect(artistEntity?.attributes?.isReadOnly).toBeNull();
+	expect(artistEntity?.attributes?.isReadOnly).toEqual(false);
 });

--- a/src/packages/end-to-end/src/__tests__/ui/auth/virtual-entities.test.ts
+++ b/src/packages/end-to-end/src/__tests__/ui/auth/virtual-entities.test.ts
@@ -18,12 +18,12 @@ test('should show virtual entities', async ({ page }) => {
 	await page.getByRole('link', { name: 'mikro-orm-my-sql' }).click();
 	await page.getByTestId('TaskCountByTag-entity-link').click();
 
-	expect(await page.getByRole('row').nth(1).getByRole('cell').nth(2).innerText()).toBe('urgent');
-	expect(await page.getByRole('row').nth(1).getByRole('cell').nth(3).innerText()).toBe('3');
-	expect(await page.getByRole('row').nth(2).getByRole('cell').nth(2).innerText()).toBe(
+	expect(await page.getByRole('row').nth(1).getByRole('cell').nth(1).innerText()).toBe('urgent');
+	expect(await page.getByRole('row').nth(1).getByRole('cell').nth(2).innerText()).toBe('3');
+	expect(await page.getByRole('row').nth(2).getByRole('cell').nth(1).innerText()).toBe(
 		'waiting-for-decision'
 	);
-	expect(await page.getByRole('row').nth(2).getByRole('cell').nth(3).innerText()).toBe('2');
+	expect(await page.getByRole('row').nth(2).getByRole('cell').nth(2).innerText()).toBe('2');
 
 	expect(await page.getByRole('row').count()).toBe(4);
 });

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -16387,7 +16387,7 @@ packages:
       node-schedule: 2.1.1
       p-memoize: 7.1.1
       tree-kill: 1.2.2
-      tsx: 4.16.3
+      tsx: 4.16.5
       velocityjs: 2.0.6
       ws: 8.18.0
     transitivePeerDependencies:


### PR DESCRIPTION
Currently the admin UI only acts read only for an entity when we explicitly set `adminUIOptions.readOnly`. This is still a useful flag, but we can also deduce that we should also be showing entities as readonly if `excludeFromBuiltInOperations` or `excludeFromBuiltInWriteOperations` is true as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced logic for determining the read-only state of attributes in the admin UI, improving entity interaction based on configuration.

- **Chores**
	- Updated the build process to use a more aggressive approach, ensuring the latest changes are reflected without cache interference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->