### PR TITLE
Chore / Remove React Data Grid

### DIFF
--- a/src/packages/admin-ui/package.json
+++ b/src/packages/admin-ui/package.json
@@ -28,7 +28,6 @@
 		"graphql": "16.9.0",
 		"prop-types": "15.8.1",
 		"react": "18.3.1",
-		"react-data-grid": "7.0.0-beta.44",
 		"react-dom": "18.3.1",
 		"react-modal": "3.16.1",
 		"react-router-dom": "6.25.1"

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -77,7 +77,7 @@ importers:
         version: 6.3.3
       '@mikro-orm/knex':
         specifier: 6.3.3
-        version: 6.3.3(@mikro-orm/core@6.3.3)(pg@8.12.0)(sqlite3@5.1.7)
+        version: 6.3.3(@mikro-orm/core@6.3.3)(mysql2@3.11.0)(pg@8.12.0)
       '@mikro-orm/sqlite':
         specifier: 6.3.3
         version: 6.3.3(@mikro-orm/core@6.3.3)(pg@8.12.0)
@@ -362,7 +362,7 @@ importers:
         version: 6.3.3
       '@mikro-orm/postgresql':
         specifier: 6.3.3
-        version: 6.3.3(@mikro-orm/core@6.3.3)
+        version: 6.3.3(@mikro-orm/core@6.3.3)(mysql2@3.11.0)
       graphql:
         specifier: 16.9.0
         version: 16.9.0
@@ -417,7 +417,7 @@ importers:
         version: 6.3.3
       '@mikro-orm/knex':
         specifier: 6.3.3
-        version: 6.3.3(@mikro-orm/core@6.3.3)(pg@8.12.0)(sqlite3@5.1.7)
+        version: 6.3.3(@mikro-orm/core@6.3.3)(mysql2@3.11.0)(pg@8.12.0)
       '@mikro-orm/sqlite':
         specifier: 6.3.3
         version: 6.3.3(@mikro-orm/core@6.3.3)(pg@8.12.0)
@@ -561,9 +561,6 @@ importers:
       react:
         specifier: 18.3.1
         version: 18.3.1
-      react-data-grid:
-        specifier: 7.0.0-beta.44
-        version: 7.0.0-beta.44(react-dom@18.3.1)(react@18.3.1)
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
@@ -1173,7 +1170,7 @@ importers:
         version: 6.3.3
       '@mikro-orm/postgresql':
         specifier: 6.3.3
-        version: 6.3.3(@mikro-orm/core@6.3.3)
+        version: 6.3.3(@mikro-orm/core@6.3.3)(mysql2@3.11.0)
       '@mikro-orm/sqlite':
         specifier: 6.3.3
         version: 6.3.3(@mikro-orm/core@6.3.3)(pg@8.12.0)
@@ -1278,7 +1275,7 @@ importers:
     dependencies:
       '@mikro-orm/knex':
         specifier: 6.3.3
-        version: 6.3.3(@mikro-orm/core@6.3.3)(pg@8.12.0)(sqlite3@5.1.7)
+        version: 6.3.3(@mikro-orm/core@6.3.3)(mysql2@3.11.0)(pg@8.12.0)
       '@mikro-orm/sqlite':
         specifier: 6.3.3
         version: 6.3.3(@mikro-orm/core@6.3.3)(pg@8.12.0)
@@ -1337,13 +1334,13 @@ importers:
     optionalDependencies:
       '@mikro-orm/knex':
         specifier: 6.3.3
-        version: 6.3.3(@mikro-orm/core@6.3.3)(pg@8.12.0)(sqlite3@5.1.7)
+        version: 6.3.3(@mikro-orm/core@6.3.3)(mysql2@3.11.0)(pg@8.12.0)
       '@mikro-orm/mysql':
         specifier: 6.3.3
         version: 6.3.3(@mikro-orm/core@6.3.3)(pg@8.12.0)
       '@mikro-orm/postgresql':
         specifier: 6.3.3
-        version: 6.3.3(@mikro-orm/core@6.3.3)
+        version: 6.3.3(@mikro-orm/core@6.3.3)(mysql2@3.11.0)
       '@mikro-orm/sqlite':
         specifier: 6.3.3
         version: 6.3.3(@mikro-orm/core@6.3.3)(pg@8.12.0)
@@ -6148,30 +6145,6 @@ packages:
       - mariadb
       - mysql
       - pg
-      - pg-native
-      - sqlite3
-      - supports-color
-      - tedious
-    dev: false
-
-  /@mikro-orm/postgresql@6.3.3(@mikro-orm/core@6.3.3):
-    resolution: {integrity: sha512-nNjRd+l6U/m38SNBN8bsXrDL7KEQmpzWlOHG90yIs8zLjohlOx++2CFhVaSeabQ2GdT4CTJJcPpld9+V5lSJrg==}
-    engines: {node: '>= 18.12.0'}
-    peerDependencies:
-      '@mikro-orm/core': ^6.0.0
-    dependencies:
-      '@mikro-orm/core': 6.3.3
-      '@mikro-orm/knex': 6.3.3(@mikro-orm/core@6.3.3)(pg@8.12.0)(sqlite3@5.1.7)
-      pg: 8.12.0
-      postgres-array: 3.0.2
-      postgres-date: 2.1.0
-      postgres-interval: 4.0.2
-    transitivePeerDependencies:
-      - better-sqlite3
-      - libsql
-      - mariadb
-      - mysql
-      - mysql2
       - pg-native
       - sqlite3
       - supports-color
@@ -15764,17 +15737,6 @@ packages:
       tslib: 2.6.3
     transitivePeerDependencies:
       - react-dom
-    dev: false
-
-  /react-data-grid@7.0.0-beta.44(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-VTql8VPBJEf7E+zkrqYW+jaQT1/m47dxigWzPq59QESJ8LhU59kHyzIx06BUpjdZKdK/tzbWaw2yyJpKoNnt5g==}
-    peerDependencies:
-      react: ^18.0
-      react-dom: ^18.0
-    dependencies:
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
     dev: false
 
   /react-dom@18.3.1(react@18.3.1):


### PR DESCRIPTION
We're no longer using react-data-grid, so we should remove it from the dependency list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
    - Removed the dependency on `react-data-grid` in the `admin-ui` package, simplifying the dependency tree and potentially improving performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->