### PR TITLE
Enhancement / Allow configuration of Fastify Instance from start()

### DIFF
--- a/src/examples/federation/integration/Dockerfile
+++ b/src/examples/federation/integration/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:18-alpine
 WORKDIR /app
 COPY index.js index.js
-ENV PORT=4001
+ENV GRAPHWEAVER_API_PORT=4001
 EXPOSE 4001
 CMD node index.js

--- a/src/packages/builder/src/util.ts
+++ b/src/packages/builder/src/util.ts
@@ -147,11 +147,11 @@ export const addStartFunctionIfNeeded = () => ({
 			// Otherwise this is a standalone instance so we need to start the server
 			console.log('Appending start command.');
 			const startCommand = `\n
-				console.log('Starting server on port: ' + (process.env.PORT ?? '9001'));
+				console.log('Starting server on port: ' + (process.env.GRAPHWEAVER_API_PORT ?? '9001'));
 				graphweaver.start({
-					host: process.env.HOST ?? '::',
-					port: Number(process.env.PORT ?? '9001'),
-					path: process.env.PATH ?? '/',
+					host: process.env.GRAPHWEAVER_API_HOST ?? '::',
+					port: Number(process.env.GRAPHWEAVER_API_PORT ?? '9001'),
+					path: process.env.GRAPHWEAVER_API_PATH ?? '/',
 				});`;
 
 			return { contents: `${input}${startCommand}` };

--- a/src/packages/server/src/integrations/fastify.ts
+++ b/src/packages/server/src/integrations/fastify.ts
@@ -1,4 +1,4 @@
-import Fastify, { FastifyRegisterOptions } from 'fastify';
+import Fastify, { FastifyInstance, FastifyRegisterOptions } from 'fastify';
 import { ApolloServer, BaseContext } from '@apollo/server';
 import cors from '@fastify/cors';
 import fastifyApollo, { fastifyApolloDrainPlugin } from '@as-integrations/fastify';
@@ -10,10 +10,11 @@ export type StartServerOptions = {
 	path: string;
 	port: number;
 	host?: string;
+	configureFastify?: (fastify: FastifyInstance) => Promise<void> | void;
 };
 
 export const startStandaloneServer = async <TContext extends BaseContext>(
-	{ port, host }: StartServerOptions,
+	{ port, host, path, configureFastify }: StartServerOptions,
 	apollo: ApolloServer<TContext>,
 	plugins: Set<GraphweaverPlugin<void>>
 ) => {
@@ -21,15 +22,14 @@ export const startStandaloneServer = async <TContext extends BaseContext>(
 
 	const fastify = Fastify();
 
+	await configureFastify?.(fastify);
+
 	apollo.addPlugin(fastifyApolloDrainPlugin(fastify));
 
 	await apollo.start();
-
 	await fastify.register(cors);
 
-	const options: FastifyRegisterOptions<any> = {
-		path: '/',
-	};
+	const options: FastifyRegisterOptions<any> = { path: path ?? '/' };
 	await fastify.register(fastifyApollo(apollo), options);
 
 	fastify.addHook('onRequest', (_, __, done) => {
@@ -41,6 +41,4 @@ export const startStandaloneServer = async <TContext extends BaseContext>(
 		port,
 		host: host ?? '::',
 	});
-
-	return fastify;
 };

--- a/src/packages/server/src/integrations/fastify.ts
+++ b/src/packages/server/src/integrations/fastify.ts
@@ -41,4 +41,6 @@ export const startStandaloneServer = async <TContext extends BaseContext>(
 		port,
 		host: host ?? '::',
 	});
+
+	return fastify;
 };

--- a/src/packages/server/src/server.ts
+++ b/src/packages/server/src/server.ts
@@ -142,10 +142,10 @@ export default class Graphweaver<TContext extends BaseContext> {
 		});
 	}
 
-	public async start({ host, port, path }: StartServerOptions): Promise<void> {
+	public async start({ host, port, path }: StartServerOptions) {
 		logger.info(`Graphweaver start called`);
 
-		await startStandaloneServer(
+		return await startStandaloneServer(
 			{ host, port, path },
 			this.server,
 			this.graphweaverPlugins as Set<GraphweaverPlugin<void>>

--- a/src/packages/server/src/server.ts
+++ b/src/packages/server/src/server.ts
@@ -142,11 +142,11 @@ export default class Graphweaver<TContext extends BaseContext> {
 		});
 	}
 
-	public async start({ host, port, path }: StartServerOptions) {
+	public async start(options: StartServerOptions) {
 		logger.info(`Graphweaver start called`);
 
-		return await startStandaloneServer(
-			{ host, port, path },
+		await startStandaloneServer(
+			options,
 			this.server,
 			this.graphweaverPlugins as Set<GraphweaverPlugin<void>>
 		);


### PR DESCRIPTION
Allow configuration of Fastify instance from `GraphweaverServer.start()`.

Potential breaking change in configuration: Previously if you were running in Fastify mode, we would read `PORT`, `HOST`, and `PATH` environment variables and apply just `PORT` and `HOST`. This PR renames them to `GRAPHWEAVER_API_PORT`, `GRAPHWEAVER_API_HOST` and `GRAPHWEAVER_API_PATH` respectively, now respecting the path config.

This change was made because the old names were easy to clash with other configurations. If you were relying on these, just rename them with the `GRAPHWEAVER_API_` prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The `startStandaloneServer` function now returns the `fastify` instance, allowing users to configure and interact with the server instance post-start.
	- The `start` method in the `Graphweaver` class has been updated to directly return the result of starting the server, enhancing flexibility in handling the server's start operation.
	- Environment variables have been updated for better clarity regarding server configuration, such as changing `PORT` to `GRAPHWEAVER_API_PORT`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->