### PR TITLE
Fix / Add more turborepo global dependencies

### DIFF
--- a/src/turbo.json
+++ b/src/turbo.json
@@ -1,6 +1,11 @@
 {
 	"$schema": "https://turbo.build/schema.json",
-	"globalDependencies": [".env", "tsconfig.json"],
+	"globalDependencies": [
+		".env",
+		"tsconfig.json",
+		"packages/builder/src/**/*.ts",
+		"packages/vite-plugin-graphweaver/src/**/*.ts"
+	],
 	"tasks": {
 		"build:types": {
 			"dependsOn": ["^build:types"],


### PR DESCRIPTION
This PR adds more global dependencies to our turborepo config. This way all packages rebuild when files in `builder` or `vite-plugin-graphweaver` change. Many of the outputs of the build process are actually generated by these packages, so if they change, it's possible that everything needs to get rebuilt, so we need to bust the cache for everything when there are edits in there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded global dependencies to include additional TypeScript files, enhancing the build process.
  
- **Chores**
	- Updated project configuration to improve resource integration during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->