### PR TITLE
Fix Auth0 Sign Out Button

### DIFF
--- a/src/examples/auth-zero/package.json
+++ b/src/examples/auth-zero/package.json
@@ -25,12 +25,12 @@
 		"@mikro-orm/knex": "6.3.4",
 		"@mikro-orm/sqlite": "6.3.4",
 		"graphql": "16.9.0",
+		"graphweaver": "workspace:*",
 		"mikro-orm-sqlite-wasm": "workspace:*",
 		"react": "18.3.1"
 	},
 	"devDependencies": {
 		"@types/node": "22.1.0",
-		"graphweaver": "workspace:*",
 		"typescript": "5.5.4"
 	}
 }

--- a/src/packages/end-to-end/package.json
+++ b/src/packages/end-to-end/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"build:types": "tsc --noEmit",
 		"import-auth": "pnpm unpack && tsx ./scripts/import-auth.ts",
+		"import-auth0": "pnpm unpack && tsx ./scripts/import-auth0.ts",
 		"import-storage-provider": "pnpm unpack && tsx ./scripts/import-storage-provider.ts",
 		"import-database-sqlite": "pnpm unpack && tsx ./scripts/import-sqlite.ts",
 		"import-database-postgres": "pnpm unpack && . ./scripts/import-postgres.sh",

--- a/src/packages/end-to-end/scripts/import-auth0.ts
+++ b/src/packages/end-to-end/scripts/import-auth0.ts
@@ -1,0 +1,61 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { exec } from 'promisify-child-process';
+
+async function removeDirectory(directoryPath: string) {
+	if (fs.existsSync(directoryPath)) {
+		await fs.promises.rm(directoryPath, { recursive: true });
+	}
+}
+
+async function execAsync(command: string) {
+	const child = exec(command);
+	child.stdout?.on('data', (data) => {
+		console.log(data);
+	});
+	child.stderr?.on('data', (data) => {
+		console.error(data);
+	});
+	return child;
+}
+
+async function main() {
+	try {
+		await execAsync('pwd');
+		await removeDirectory('./app');
+
+		// Copy the auth example over for testing
+		await execAsync('cp -r ../../examples/auth-zero ./app');
+
+		// Update to use the local dependencies
+		process.chdir('./app');
+		const packageJsonPath = path.join(`package.json`);
+		const packageJson = JSON.parse(await fs.promises.readFile(packageJsonPath, 'utf-8'));
+
+		for (const key of Object.keys(packageJson.dependencies ?? {})) {
+			if (key.startsWith('@exogee')) {
+				packageJson.dependencies[key] = `file:../local_modules/${key}`;
+			} else if (key === 'graphweaver') {
+				packageJson.dependencies[key] = `file:../local_modules/graphweaver`;
+			} else if (key === 'vite-plugin-graphweaver') {
+				packageJson.dependencies[key] = `file:../local_modules/vite-plugin-graphweaver`;
+			} else if (key === 'mikro-orm-sqlite-wasm') {
+				packageJson.dependencies[key] = `file:../local_modules/mikro-orm-sqlite-wasm`;
+			}
+		}
+
+		await fs.promises.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
+
+		await execAsync('pwd');
+		await execAsync('pnpm i --ignore-workspace --no-lockfile');
+
+		const tsJson = JSON.parse(await fs.promises.readFile('tsconfig.json', 'utf-8'));
+		delete tsJson.references;
+		await fs.promises.writeFile('tsconfig.json', JSON.stringify(tsJson, null, 2));
+	} catch (error) {
+		console.error('Error:', error);
+		throw error;
+	}
+}
+
+main();

--- a/src/packages/vite-plugin-graphweaver/src/loaders/custom-pages.ts
+++ b/src/packages/vite-plugin-graphweaver/src/loaders/custom-pages.ts
@@ -15,7 +15,7 @@ export const loadCustomPages = async (projectRoot: string) => {
 		return `export const customPages = {
 		routes: () => [],
 		navLinks: () => [],
-		sidebarFooter: () => null,
+		sidebarFooter: undefined,
 	};`;
 	}
 };

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       graphql:
         specifier: 16.9.0
         version: 16.9.0
+      graphweaver:
+        specifier: workspace:*
+        version: link:../../packages/cli
       mikro-orm-sqlite-wasm:
         specifier: workspace:*
         version: link:../../packages/mikro-orm-sqlite-wasm
@@ -94,9 +97,6 @@ importers:
       '@types/node':
         specifier: 22.1.0
         version: 22.1.0
-      graphweaver:
-        specifier: workspace:*
-        version: link:../../packages/cli
       typescript:
         specifier: 5.5.4
         version: 5.5.4


### PR DESCRIPTION
The default sign-out button was not showing in the adminUI because a conditional check for undefined would always be truthy. This PR adds:

* Set the `sidebarFooter` to undefined by default
* Adds a script to `end-to-end` to check the packed version of the auth0 example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new script for importing authentication through Auth0, enhancing operational capabilities.
	- Shifted the `graphweaver` package to a runtime dependency, reflecting its essential role in application functionality.
  
- **Bug Fixes**
	- Updated the handling of the `sidebarFooter` to improve its representation, refining how it is consumed in the application. 

- **Chores**
	- Automated application environment setup with a new script, improving workflow efficiency for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->