### PR TITLE
Feature / Allow auth context creation from token claims

### DIFF
--- a/src/packages/auth/src/authentication/apollo/plugin.ts
+++ b/src/packages/auth/src/authentication/apollo/plugin.ts
@@ -2,7 +2,12 @@ import { ApolloServerPlugin } from '@apollo/server';
 import { logger } from '@exogee/logger';
 import { AuthenticationError } from 'apollo-server-errors';
 
-import { AccessControlList, AuthenticationMethod, AuthorizationContext } from '../../types';
+import {
+	AccessControlList,
+	AuthenticationMethod,
+	AuthorizationContext,
+	JwtPayload,
+} from '../../types';
 import { AuthTokenProvider, isExpired } from '../token';
 import { AclMap, requireEnvironmentVariable } from '../../helper-functions';
 import { UserProfile, UserProfileType } from '../../user-profile';
@@ -90,7 +95,7 @@ type AuthApolloPluginOptions<R> = {
 };
 
 export const authApolloPlugin = <R>(
-	addUserToContext?: (userId: string) => Promise<UserProfile<R>>,
+	addUserToContext?: (userId: string, token: JwtPayload) => Promise<UserProfile<R>>,
 	options?: AuthApolloPluginOptions<R>
 ): ApolloServerPlugin<AuthorizationContext> => {
 	return {
@@ -206,7 +211,7 @@ export const authApolloPlugin = <R>(
 							'No addUserToContext provider please set one using the setAddUserToContext function.'
 						);
 
-					const userProfile = await addUserToContextCallback(userId);
+					const userProfile = await addUserToContextCallback(userId, decoded);
 
 					contextValue.token = decoded;
 					contextValue.user = userProfile;

--- a/src/packages/auth/src/types.ts
+++ b/src/packages/auth/src/types.ts
@@ -9,7 +9,7 @@ export enum AuthenticationMethod {
 	PASSKEY = 'pky',
 }
 
-export interface JwtPayload {
+export interface JwtPayload extends Record<string, unknown> {
 	sub?: string;
 	iat?: number;
 	exp?: number;

--- a/src/packages/auth/src/user-context.ts
+++ b/src/packages/auth/src/user-context.ts
@@ -1,6 +1,7 @@
+import { JwtPayload } from './types';
 import { UserProfile } from './user-profile';
 
-type AddUserToContext<R> = (userId: string) => Promise<UserProfile<R>>;
+type AddUserToContext<R> = (userId: string, token: JwtPayload) => Promise<UserProfile<R>>;
 
 class AuthContextManager<R> {
 	private _addUserToContext?: AddUserToContext<R>;


### PR DESCRIPTION
- Pass token to `addUserToContext()` as second argument so that users can use the claims to determine groups.
- Make the type for `JwtPayload` more flexible, as users can have custom claims, and we don't want the type to restrict that unnecessarily.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user context management by allowing authentication tokens to be received alongside user IDs.
	- Expanded the structure of JWT payloads to accommodate additional properties for greater flexibility in user authentication.

- **Bug Fixes**
	- Improved handling of user profiles by integrating decoded JWT tokens into the context management process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->