### PR TITLE
Chore / Realign license in readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ You're done!
 
 ## License
 
-Distributed under the MIT License. See LICENSE for more information.
+Distributed under the Apache 2.0 License. See LICENSE for more information.
 
 <!-- FOOTER -->
 <p align="center">


### PR DESCRIPTION
The license reference in our readme got missed on the way over to Apache 2.0.