### PR TITLE
Fix Auth CLI

### DIFF
--- a/src/packages/builder/package.json
+++ b/src/packages/builder/package.json
@@ -16,9 +16,9 @@
 	"main": "lib/index.js",
 	"source": "src/index.ts",
 	"dependencies": {
+		"@exogee/graphweaver-admin-ui": "workspace:*",
 		"@exogee/graphweaver-config": "workspace:*",
 		"@exogee/graphweaver-mikroorm": "workspace:*",
-		"@exogee/graphweaver-admin-ui": "workspace:*",
 		"@graphql-codegen/add": "5.0.3",
 		"@graphql-codegen/cli": "5.0.2",
 		"@graphql-codegen/near-operation-file-preset": "3.0.0",
@@ -32,9 +32,9 @@
 		"esbuild": "0.23.0",
 		"esbuild-css-modules-plugin": "3.1.2",
 		"glob": "10.4.3",
-		"hash-wasm": "4.11.0",
 		"graphql": "16.9.0",
 		"graphql-tag": "2.12.6",
+		"hash-wasm": "4.11.0",
 		"log-node": "8.0.3",
 		"omgopass": "3.2.1",
 		"rimraf": "5.0.8",
@@ -44,8 +44,10 @@
 		"vite-plugin-graphweaver": "workspace:*"
 	},
 	"devDependencies": {
-		"@types/omgopass": "3.2.3",
+		"@types/jsonwebtoken": "9.0.6",
 		"@types/node": "22.2.0",
+		"@types/omgopass": "3.2.3",
+		"jsonwebtoken": "9.0.2",
 		"prettier": "3.3.3",
 		"typescript": "5.5.4",
 		"vitest": "2.0.5"

--- a/src/packages/builder/src/auth/env.test.ts
+++ b/src/packages/builder/src/auth/env.test.ts
@@ -1,12 +1,31 @@
 import { describe, it, expect } from 'vitest';
-import { generateAuthEnv } from './env';
+import jwt from 'jsonwebtoken';
 
-describe('generateKeyPair', () => {
+import { generateAuthEnv, generateKeyPair } from './env';
+
+describe('generateAuthEnv', () => {
 	it('should return a env file with each string key', async () => {
 		const env = await generateAuthEnv();
 		expect(env).toEqual(expect.stringContaining('AUTH_PUBLIC_KEY_PEM_BASE64='));
 		expect(env).toEqual(expect.stringContaining('AUTH_PRIVATE_KEY_PEM_BASE64='));
 		expect(env).toEqual(expect.stringContaining('AUTH_BASE_URI="http://localhost:9000"'));
 		expect(env).toEqual(expect.stringContaining('AUTH_WHITELIST_DOMAINS="localhost"'));
+	});
+});
+
+describe('generateKeyPair', () => {
+	it('should be able to sign a JWT using the privateKey', async () => {
+		const { privateKey, publicKey } = await generateKeyPair();
+		const decodedPrivateKey = Buffer.from(privateKey, 'base64').toString('ascii');
+		const decodedPublicKey = Buffer.from(publicKey, 'base64').toString('ascii');
+		const authToken = jwt.sign({}, decodedPrivateKey, {
+			algorithm: 'ES256',
+			expiresIn: '8h',
+		});
+		expect(authToken).toBeDefined();
+
+		// verify the token
+		const decoded = jwt.verify(authToken, decodedPublicKey);
+		expect(decoded).toBeDefined();
 	});
 });

--- a/src/packages/builder/src/auth/env.ts
+++ b/src/packages/builder/src/auth/env.ts
@@ -10,7 +10,6 @@ export const generateKeyPair = async () => {
 	// Export the private key
 	const privateKeyDer = privateKey.export({ type: 'sec1', format: 'der' }).toString('base64');
 	const formattedPrivateKey = privateKeyDer.replace(regex, '$&\n');
-
 	const privatePem = `-----BEGIN EC PRIVATE KEY-----\n${formattedPrivateKey}\n-----END EC PRIVATE KEY-----\n`;
 	const base64EncodedPrivatePem = Buffer.from(privatePem).toString('base64');
 

--- a/src/packages/builder/src/auth/env.ts
+++ b/src/packages/builder/src/auth/env.ts
@@ -1,19 +1,26 @@
 import crypto from 'crypto';
 
-const generateKeyPair = async () => {
+export const generateKeyPair = async () => {
 	const { privateKey, publicKey } = crypto.generateKeyPairSync('ec', {
 		namedCurve: 'prime256v1',
-		privateKeyEncoding: {
-			type: 'pkcs8',
-			format: 'der',
-		},
-		publicKeyEncoding: {
-			type: 'spki',
-			format: 'der',
-		},
 	});
 
-	return { privateKey: privateKey.toString('base64'), publicKey: publicKey.toString('base64') };
+	const regex = /.{64}/g;
+
+	// Export the private key
+	const privateKeyDer = privateKey.export({ type: 'sec1', format: 'der' }).toString('base64');
+	const formattedPrivateKey = privateKeyDer.replace(regex, '$&\n');
+
+	const privatePem = `-----BEGIN EC PRIVATE KEY-----\n${formattedPrivateKey}\n-----END EC PRIVATE KEY-----\n`;
+	const base64EncodedPrivatePem = Buffer.from(privatePem).toString('base64');
+
+	// Export the public key
+	const publicKeyDer = publicKey.export({ type: 'spki', format: 'der' }).toString('base64');
+	const formattedPublicKey = publicKeyDer.replace(regex, '$&\n');
+	const publicPem = `-----BEGIN PUBLIC KEY-----\n${formattedPublicKey}\n-----END PUBLIC KEY-----\n`;
+	const base64EncodedPublicPem = Buffer.from(publicPem).toString('base64');
+
+	return { privateKey: base64EncodedPrivatePem, publicKey: base64EncodedPublicPem };
 };
 
 export const generateAuthEnv = async () => {

--- a/src/packages/builder/src/auth/password.ts
+++ b/src/packages/builder/src/auth/password.ts
@@ -7,13 +7,13 @@ import generatePassword from 'omgopass';
 
 import { DatabaseOptions } from './index';
 
-const generateSalt = (): Uint8Array => {
+export const generateSalt = (): Uint8Array => {
 	const salt = new Uint8Array(16);
 	// Fill the salt array with cryptographically secure random numbers.
 	return crypto.getRandomValues(salt);
 };
 
-const argon2IdOptions = {
+export const argon2IdOptions = {
 	salt: generateSalt(),
 	parallelism: 4,
 	iterations: 3,

--- a/src/packages/builder/src/auth/password.ts
+++ b/src/packages/builder/src/auth/password.ts
@@ -7,13 +7,13 @@ import generatePassword from 'omgopass';
 
 import { DatabaseOptions } from './index';
 
-export const generateSalt = (): Uint8Array => {
+const generateSalt = (): Uint8Array => {
 	const salt = new Uint8Array(16);
 	// Fill the salt array with cryptographically secure random numbers.
 	return crypto.getRandomValues(salt);
 };
 
-export const argon2IdOptions = {
+const argon2IdOptions = {
 	salt: generateSalt(),
 	parallelism: 4,
 	iterations: 3,

--- a/src/packages/builder/src/auth/password.ts
+++ b/src/packages/builder/src/auth/password.ts
@@ -66,7 +66,7 @@ export const generateAdminPassword = async (options: GenerateAdminPasswordOption
 		);
 
 	const pwd = generatePassword();
-	const hash = argon2id({
+	const hash = await argon2id({
 		password: pwd,
 		...argon2IdOptions,
 	});

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -960,12 +960,18 @@ importers:
         specifier: workspace:*
         version: link:../vite-plugin-graphweaver
     devDependencies:
+      '@types/jsonwebtoken':
+        specifier: 9.0.6
+        version: 9.0.6
       '@types/node':
         specifier: 22.2.0
         version: 22.2.0
       '@types/omgopass':
         specifier: 3.2.3
         version: 3.2.3
+      jsonwebtoken:
+        specifier: 9.0.2
+        version: 9.0.2
       prettier:
         specifier: 3.3.3
         version: 3.3.3
@@ -9642,7 +9648,6 @@ packages:
 
   /buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
-    dev: false
 
   /buffer-fill@1.0.0:
     resolution: {integrity: sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==}
@@ -10825,7 +10830,6 @@ packages:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
     dependencies:
       safe-buffer: 5.2.1
-    dev: false
 
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -13578,7 +13582,6 @@ packages:
       lodash.once: 4.1.1
       ms: 2.1.3
       semver: 7.6.3
-    dev: false
 
   /jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
@@ -13595,7 +13598,6 @@ packages:
       buffer-equal-constant-time: 1.0.1
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
-    dev: false
 
   /jwks-rsa@3.1.0:
     resolution: {integrity: sha512-v7nqlfezb9YfHHzYII3ef2a2j1XnGeSE/bK3WfumaYCqONAIstJbrEGapz4kadScZzEt7zYCN7bucj8C0Mv/Rg==}
@@ -13616,7 +13618,6 @@ packages:
     dependencies:
       jwa: 1.4.1
       safe-buffer: 5.2.1
-    dev: false
 
   /jwt-decode@3.1.2:
     resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
@@ -13965,11 +13966,9 @@ packages:
 
   /lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
-    dev: false
 
   /lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
-    dev: false
 
   /lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
@@ -13977,19 +13976,15 @@ packages:
 
   /lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
-    dev: false
 
   /lodash.isnumber@3.0.3:
     resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
-    dev: false
 
   /lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
-    dev: false
 
   /lodash.isstring@4.0.1:
     resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
-    dev: false
 
   /lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
@@ -14000,7 +13995,6 @@ packages:
 
   /lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
-    dev: false
 
   /lodash.pickby@4.6.0:
     resolution: {integrity: sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==}
@@ -16122,7 +16116,6 @@ packages:
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-    dev: false
 
   /safe-regex2@3.1.0:
     resolution: {integrity: sha512-RAAZAGbap2kBfbVhvmnTFv73NWLMvDGOITFYTZBAaY8eR+Ir4ef7Up/e7amo+y1+AH+3PtLkrt9mvcTsG9LXug==}


### PR DESCRIPTION
The new `init-auth` CLI option was correctly generating the required key pair however, this failed when validating a token.

This PR addresses the issue and also creates a test to catch that error in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new JSON Web Token handling capabilities with the addition of `jsonwebtoken` and its type definitions.
	- Enhanced key generation function to export keys in structured PEM format for better interoperability.

- **Bug Fixes**
	- Improved asynchronous handling in password generation to ensure robustness during hashing operations.

- **Tests**
	- Enhanced test coverage for authentication functionalities, including JWT signing and verification to ensure correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->