### PR TITLE
Generate API Key from CLI

### DIFF
--- a/src/packages/builder/src/auth/env.test.ts
+++ b/src/packages/builder/src/auth/env.test.ts
@@ -5,11 +5,17 @@ import { generateAuthEnv, generateKeyPair } from './env';
 
 describe('generateAuthEnv', () => {
 	it('should return a env file with each string key', async () => {
-		const env = await generateAuthEnv();
+		const env = await generateAuthEnv('password');
 		expect(env).toEqual(expect.stringContaining('AUTH_PUBLIC_KEY_PEM_BASE64='));
 		expect(env).toEqual(expect.stringContaining('AUTH_PRIVATE_KEY_PEM_BASE64='));
 		expect(env).toEqual(expect.stringContaining('AUTH_BASE_URI="http://localhost:9000"'));
 		expect(env).toEqual(expect.stringContaining('AUTH_WHITELIST_DOMAINS="localhost"'));
+
+		const apiKeyEnv = await generateAuthEnv('api-key');
+		expect(apiKeyEnv).toEqual(expect.not.stringContaining('AUTH_PUBLIC_KEY_PEM_BASE64='));
+		expect(apiKeyEnv).toEqual(expect.not.stringContaining('AUTH_PRIVATE_KEY_PEM_BASE64='));
+		expect(apiKeyEnv).toEqual(expect.stringContaining('AUTH_BASE_URI="http://localhost:9000"'));
+		expect(apiKeyEnv).toEqual(expect.stringContaining('AUTH_WHITELIST_DOMAINS="localhost"'));
 	});
 });
 

--- a/src/packages/builder/src/auth/env.test.ts
+++ b/src/packages/builder/src/auth/env.test.ts
@@ -4,6 +4,10 @@ import jwt from 'jsonwebtoken';
 import { generateAuthEnv, generateKeyPair } from './env';
 
 describe('generateAuthEnv', () => {
+	it('should throw an error for an invalid method', async () => {
+		await expect(generateAuthEnv('invalid-method' as any)).rejects.toThrow('Invalid method');
+	});
+
 	it('should return a env file with each string key', async () => {
 		const env = await generateAuthEnv('password');
 		expect(env).toEqual(expect.stringContaining('AUTH_PUBLIC_KEY_PEM_BASE64='));

--- a/src/packages/builder/src/auth/env.ts
+++ b/src/packages/builder/src/auth/env.ts
@@ -22,16 +22,18 @@ export const generateKeyPair = async () => {
 	return { privateKey: base64EncodedPrivatePem, publicKey: base64EncodedPublicPem };
 };
 
-export const generateAuthEnv = async () => {
+export const generateAuthEnv = async (method: 'password' | 'api-key') => {
 	console.log('Generating Auth Environment...');
 
 	const { privateKey, publicKey } = await generateKeyPair();
 
+	const keys = `AUTH_PUBLIC_KEY_PEM_BASE64='${publicKey}'
+AUTH_PRIVATE_KEY_PEM_BASE64='${privateKey}'`;
+
 	const env = `
 # Generated Auth Environment Variables
-# This file contains the environment variables required for password authentication.
-AUTH_PUBLIC_KEY_PEM_BASE64='${publicKey}'
-AUTH_PRIVATE_KEY_PEM_BASE64='${privateKey}'
+# This file contains the environment variables required for authentication.
+${method === 'password' ? keys : ''}
 AUTH_BASE_URI="http://localhost:9000"
 AUTH_WHITELIST_DOMAINS="localhost"
 `;

--- a/src/packages/builder/src/auth/env.ts
+++ b/src/packages/builder/src/auth/env.ts
@@ -24,6 +24,9 @@ export const generateKeyPair = async () => {
 
 export const generateAuthEnv = async (method: 'password' | 'api-key') => {
 	console.log('Generating Auth Environment...');
+	if (method !== 'password' && method !== 'api-key') {
+		throw new Error(`Invalid method: ${method}. Expected 'password' or 'api-key'.`);
+	}
 
 	const { privateKey, publicKey } = await generateKeyPair();
 

--- a/src/packages/builder/src/auth/index.ts
+++ b/src/packages/builder/src/auth/index.ts
@@ -3,6 +3,7 @@ import { writeFile } from 'fs/promises';
 import { generateConfig } from './config';
 import { generateAuthEnv } from './env';
 import { generateAdminPassword } from './password';
+import { generateApiKey } from './api-key';
 
 export type Source = 'mysql' | 'postgresql' | 'sqlite';
 
@@ -16,7 +17,7 @@ export interface DatabaseOptions {
 }
 
 interface InitialiseAuthOptions extends DatabaseOptions {
-	method: 'password';
+	method: 'password' | 'api-key';
 	tableName: string;
 }
 
@@ -25,6 +26,13 @@ export const initialiseAuth = async ({ method, ...databaseOptions }: InitialiseA
 	const envFile = await generateAuthEnv();
 	await writeFile('.env', envFile);
 	const configFile = await generateConfig();
-	await writeFile('graphweaver-config.js', configFile);
-	await generateAdminPassword(databaseOptions);
+
+	if (method === 'password') {
+		await writeFile('graphweaver-config.js', configFile);
+		await generateAdminPassword(databaseOptions);
+	}
+
+	if (method === 'api-key') {
+		await generateApiKey(databaseOptions);
+	}
 };

--- a/src/packages/builder/src/auth/index.ts
+++ b/src/packages/builder/src/auth/index.ts
@@ -23,11 +23,11 @@ interface InitialiseAuthOptions extends DatabaseOptions {
 
 export const initialiseAuth = async ({ method, ...databaseOptions }: InitialiseAuthOptions) => {
 	console.log(`Initialising Auth with ${method}...`);
-	const envFile = await generateAuthEnv();
+	const envFile = await generateAuthEnv(method);
 	await writeFile('.env', envFile);
-	const configFile = await generateConfig();
 
 	if (method === 'password') {
+		const configFile = await generateConfig();
 		await writeFile('graphweaver-config.js', configFile);
 		await generateAdminPassword(databaseOptions);
 	}

--- a/src/packages/builder/src/auth/utils.ts
+++ b/src/packages/builder/src/auth/utils.ts
@@ -1,0 +1,39 @@
+import crypto from 'crypto';
+import { ConnectionManager, DatabaseType, ConnectionOptions } from '@exogee/graphweaver-mikroorm';
+
+export const generateSalt = (): Uint8Array => {
+	const salt = new Uint8Array(16);
+	// Fill the salt array with cryptographically secure random numbers.
+	return crypto.getRandomValues(salt);
+};
+
+export const argon2IdOptions = {
+	salt: generateSalt(),
+	parallelism: 4,
+	iterations: 3,
+	memorySize: 65536,
+	hashLength: 32,
+	outputType: 'encoded',
+};
+
+export const openConnection = async (type: DatabaseType, options: ConnectionOptions) => {
+	// eslint-disable-next-line @typescript-eslint/no-var-requires
+	const module = require(`@mikro-orm/${type}`);
+	const PLATFORMS = {
+		mysql: 'MySqlDriver',
+		postgresql: 'PostgreSqlDriver',
+		sqlite: 'SqliteDriver',
+	};
+	await ConnectionManager.connect('default', {
+		mikroOrmConfig: {
+			driver: module[PLATFORMS[type]],
+			...options.mikroOrmConfig,
+		},
+	});
+};
+
+export const closeConnection = async () => {
+	console.log('Closing database connection...');
+	await ConnectionManager.close('default');
+	console.log('Database connection closed.');
+};

--- a/src/packages/cli/src/auth/index.ts
+++ b/src/packages/cli/src/auth/index.ts
@@ -1,8 +1,10 @@
 import { DatabaseOptions, initialiseAuth } from '@exogee/graphweaver-builder';
 import { promptForDatabaseOptions } from '../database';
 
+export type AuthMethod = 'password' | 'api-key';
+
 interface InitAuthOptions extends Partial<DatabaseOptions> {
-	method: 'password';
+	method: AuthMethod;
 }
 
 export const initAuth = async ({
@@ -32,7 +34,8 @@ export const initAuth = async ({
 		{
 			type: 'input',
 			name: 'tableName',
-			message: `Please specify the exact name of the table where you would like the credentials to be stored:`,
+			default: method === 'password' ? 'Credentials' : 'ApiKey',
+			message: `Please specify the exact name of the table where you would like the data to be stored:`,
 		},
 	]);
 

--- a/src/packages/cli/src/index.ts
+++ b/src/packages/cli/src/index.ts
@@ -11,7 +11,7 @@ import {
 	startFrontend,
 } from '@exogee/graphweaver-builder';
 import { Backend, init } from './init';
-import { initAuth } from './auth';
+import { initAuth, AuthMethod } from './auth';
 import { importDataSource } from './import';
 import { version } from '../package.json';
 import { generateTypes, printSchema } from './tasks';
@@ -321,7 +321,7 @@ yargs
 			yargs
 				.positional('method', {
 					type: 'string',
-					choices: ['password'],
+					choices: ['password', 'api-key'],
 					default: 'password',
 					describe: 'The primary authentication method to use.',
 				})
@@ -351,15 +351,23 @@ yargs
 					describe: 'Specify the database server user.',
 				}),
 		handler: async ({ method, source, database, host, port, password, user }) => {
-			if (method !== 'password') {
-				throw new Error(`Unsupported method: ${method}`);
+			if (!['password', 'api-key'].includes(method)) {
+				throw new Error(`Unsupported method: ${method}, please use 'password' or 'api-key'`);
 			}
 
 			if (source && !['mysql', 'postgresql', 'sqlite'].includes(source)) {
 				throw new Error(`Invalid source: ${source}`);
 			}
 
-			await initAuth({ method, source: source as Source, database, host, port, password, user });
+			await initAuth({
+				method: method as AuthMethod,
+				source: source as Source,
+				database,
+				host,
+				port,
+				password,
+				user,
+			});
 		},
 	})
 	.version(version)


### PR DESCRIPTION
This PR adds an option to the CLI to create and save an API key used for authentication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced functionality for generating and securely managing API keys and secrets.
	- Enhanced authentication environment generation to support multiple methods ('password' and 'api-key').
	- Updated CLI to allow users to select between 'password' and 'api-key' for authentication.

- **Bug Fixes**
	- Improved error messaging for unsupported authentication methods in the CLI.

- **Documentation**
	- Updated comments and prompts to reflect new authentication options. 

- **Refactor**
	- Restructured utility functions for better modularity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->