### PR TITLE
Feature / Async Local Storage Alternative

### DIFF
--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -31,6 +31,7 @@
 		"@opentelemetry/resources": "1.25.1",
 		"@opentelemetry/sdk-node": "0.52.1",
 		"@opentelemetry/sdk-trace-base": "1.25.1",
+		"async-mutex": "0.5.0",
 		"class-validator": "0.14.1",
 		"dataloader": "2.2.2",
 		"graphql": "16.9.0",

--- a/src/packages/core/src/request-context.ts
+++ b/src/packages/core/src/request-context.ts
@@ -1,6 +1,8 @@
-import { AsyncLocalStorage } from 'async_hooks';
-import { BaseLoader } from './base-loader';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { logger } from '@exogee/logger';
+import { Mutex } from 'async-mutex';
+
+import { BaseLoader } from './base-loader';
 
 type Context = {
 	BaseLoaders: BaseLoader;
@@ -9,6 +11,10 @@ type Context = {
 export class RequestContext {
 	private static storage = new AsyncLocalStorage<RequestContext>();
 	private static counter = 1;
+
+	// Workaround for environments that don't support AsyncLocalStorage
+	private static workaroundStorage: RequestContext | undefined;
+	private static mutex = new Mutex();
 
 	readonly id = RequestContext.counter++;
 
@@ -27,11 +33,32 @@ export class RequestContext {
 	static async create<T>(next: (...args: any[]) => T): Promise<T> {
 		const ctx = RequestContext.createContext();
 		logger.trace(`Creating RequestContext with ID: ${ctx.id}`);
-		return RequestContext.storage.run(ctx, next);
+
+		// WebContainers don't support AsyncLocalStorage:
+		// https://github.com/stackblitz/webcontainer-core/issues/1169
+		//
+		// To support use cases like this, if you want us to, we'll just use a singleton
+		// scratch pad that we mutex access to, which will enforce that only one request
+		// can happen at a time, but will not rely on the AsyncLocalStorage API.
+		//
+		// In standard Node this is not an issue, but if you need to turn off support for
+		// isolated async contexts, you can do so with this environment variable.
+		if (process.env.GRAPHWEAVER_DISABLE_ASYNC_LOCAL_STORAGE === 'true') {
+			logger.trace('AsyncLocalStorage is disabled, using workaround storage, creating context.');
+			this.workaroundStorage = ctx;
+			return await this.mutex.runExclusive(next);
+		} else {
+			logger.trace('Creating new AsyncLocalStorage context.');
+			return RequestContext.storage.run(ctx, next);
+		}
 	}
 
 	static currentRequestContext(): RequestContext | undefined {
-		return RequestContext.storage.getStore();
+		if (process.env.GRAPHWEAVER_DISABLE_ASYNC_LOCAL_STORAGE === 'true') {
+			return this.workaroundStorage;
+		} else {
+			return RequestContext.storage.getStore();
+		}
 	}
 
 	private static createContext(): RequestContext {

--- a/src/packages/core/src/request-context.ts
+++ b/src/packages/core/src/request-context.ts
@@ -45,8 +45,8 @@ export class RequestContext {
 		// isolated async contexts, you can do so with this environment variable.
 		if (process.env.GRAPHWEAVER_DISABLE_ASYNC_LOCAL_STORAGE === 'true') {
 			logger.trace('AsyncLocalStorage is disabled, using workaround storage, creating context.');
-			this.workaroundStorage = ctx;
-			return await this.mutex.runExclusive(next);
+			RequestContext.workaroundStorage = ctx;
+			return await RequestContext.mutex.runExclusive(next);
 		} else {
 			logger.trace('Creating new AsyncLocalStorage context.');
 			return RequestContext.storage.run(ctx, next);
@@ -55,7 +55,7 @@ export class RequestContext {
 
 	static currentRequestContext(): RequestContext | undefined {
 		if (process.env.GRAPHWEAVER_DISABLE_ASYNC_LOCAL_STORAGE === 'true') {
-			return this.workaroundStorage;
+			return RequestContext.workaroundStorage;
 		} else {
 			return RequestContext.storage.getStore();
 		}

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -1117,6 +1117,9 @@ importers:
       '@opentelemetry/sdk-trace-base':
         specifier: 1.25.1
         version: 1.25.1(@opentelemetry/api@1.9.0)
+      async-mutex:
+        specifier: 0.5.0
+        version: 0.5.0
       class-validator:
         specifier: 0.14.1
         version: 0.14.1


### PR DESCRIPTION
Creates an alternative approach to context isolation for runtime environments where AsyncLocalStorage isn't supported, e.g. https://github.com/stackblitz/webcontainer-core/issues/1169

We use webcontainers to run https://demo.graphweaver.com, so this is primarily to support that environment, but can be used at will from any environment this way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for environments without `AsyncLocalStorage` using a new workaround mechanism.
	- Introduced a mutex to manage access to the workaround storage, ensuring single request processing in restricted environments.

- **Chores**
	- Updated dependency list to include `async-mutex`, enhancing concurrency management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->