### PR TITLE
Empty ACL Log

### DIFF
--- a/src/packages/auth/src/decorators/hooks/acl.ts
+++ b/src/packages/auth/src/decorators/hooks/acl.ts
@@ -138,9 +138,10 @@ const assertUserCanPerformRequest = async <G, TContext extends AuthorizationCont
 			const acl = getACL(entityName);
 
 			if (!acl || Object.keys(acl).length === 0) {
-				throw new Error(
+				logger.error(
 					`The entity ${entityName} does not have an ACL defined. Please define an ACL for this entity.`
 				);
+				throw new Error(GENERIC_AUTH_ERROR_MESSAGE);
 			}
 
 			try {

--- a/src/packages/auth/src/decorators/hooks/acl.ts
+++ b/src/packages/auth/src/decorators/hooks/acl.ts
@@ -136,17 +136,17 @@ const assertUserCanPerformRequest = async <G, TContext extends AuthorizationCont
 
 		if (type === RequirePermissionType.ENTITY) {
 			const acl = getACL(entityName);
+
+			if (!acl || Object.keys(acl).length === 0) {
+				throw new Error(
+					`The entity ${entityName} does not have an ACL defined. Please define an ACL for this entity.`
+				);
+			}
+
 			try {
 				await assertUserCanPerformRequestedAction(acl, accessType);
 			} catch (e) {
 				logger.error(`User does not have permission to ${accessType} the ${entityName} entity`, e);
-
-				if (acl && Object.keys(acl).length === 0) {
-					logger.error(
-						`The entity ${entityName} does not have an ACL defined. Please define an ACL for this entity.`
-					);
-				}
-
 				throw e;
 			}
 		} else if (type === RequirePermissionType.FIELD && field) {

--- a/src/packages/auth/src/decorators/hooks/acl.ts
+++ b/src/packages/auth/src/decorators/hooks/acl.ts
@@ -136,7 +136,19 @@ const assertUserCanPerformRequest = async <G, TContext extends AuthorizationCont
 
 		if (type === RequirePermissionType.ENTITY) {
 			const acl = getACL(entityName);
-			await assertUserCanPerformRequestedAction(acl, accessType);
+			try {
+				await assertUserCanPerformRequestedAction(acl, accessType);
+			} catch (e) {
+				logger.error(`User does not have permission to ${accessType} the ${entityName} entity`, e);
+
+				if (acl && Object.keys(acl).length === 0) {
+					logger.error(
+						`The entity ${entityName} does not have an ACL defined. Please define an ACL for this entity.`
+					);
+				}
+
+				throw e;
+			}
 		} else if (type === RequirePermissionType.FIELD && field) {
 			assertUserHasAccessToField({
 				field,


### PR DESCRIPTION
This PR logs when an ACL is empty.

```
{"level":50,"time":1724210382088,"pid":62821,"hostname":"Stephens-MacBook-Pro.local","name":"graphweaver","msg":"The entity Task does not have an ACL defined. Please define an ACL for this entity."}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for permission validation, preventing runtime errors from invalid Access Control Lists (ACLs).
	- Enhanced feedback for permission assertion failures with clear logging for better debugging.

- **Chores**
	- Refined validation logic to ensure ACLs are correctly defined before assertions are made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->