### PR TITLE
Fix / Better Handling for Nulls from String Id Values in @RelationshipField

### DIFF
--- a/src/packages/core/src/resolvers.ts
+++ b/src/packages/core/src/resolvers.ts
@@ -531,6 +531,9 @@ const _listRelationshipField = async <G, D, R, C extends BaseContext>(
 			Array.isArray(valueOfForeignKey)
 		) {
 			idValue = valueOfForeignKey;
+		} else if (typeof valueOfForeignKey === 'undefined' || valueOfForeignKey === null) {
+			// If the value is null, we'll use it as the id value.
+			idValue = undefined;
 		} else {
 			// The ID value must be a string or a number otherwise we'll throw an error.
 			throw new Error(
@@ -539,7 +542,11 @@ const _listRelationshipField = async <G, D, R, C extends BaseContext>(
 		}
 	}
 
-	if (typeof existingData === 'undefined' && !idValue && !field.relationshipInfo?.relatedField) {
+	if (
+		typeof existingData === 'undefined' &&
+		(typeof idValue === 'undefined' || idValue === null) &&
+		!field.relationshipInfo?.relatedField
+	) {
 		// id is null and we are loading a single instance so let's return null
 		return null;
 	}


### PR DESCRIPTION
There were two issues here:

1. If the foreign key was 0, this is falsey, so we'd think we didn't get a value when we did.
2. If a string value was used as the configuration for `id` and this returned null or undefined, there wasn't a code path to let that result just return null for the relationship.