### PR TITLE
Chore / Bump Mikro Overrides

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -50,11 +50,11 @@
 		"overrides": {
 			"d3-color": "3.1.0",
 			"@babel/traverse": "7.23.2",
-			"@mikro-orm/core": "6.3.7",
-			"@mikro-orm/knex": "6.3.7",
-			"@mikro-orm/postgresql": "6.3.7",
-			"@mikro-orm/mysql": "6.3.7",
-			"@mikro-orm/sqlite": "6.3.7"
+			"@mikro-orm/core": "6.3.8",
+			"@mikro-orm/knex": "6.3.8",
+			"@mikro-orm/postgresql": "6.3.8",
+			"@mikro-orm/mysql": "6.3.8",
+			"@mikro-orm/sqlite": "6.3.8"
 		},
 		"peerDependencyRules": {
 			"ignoreMissing": [

--- a/src/packages/mikroorm/package.json
+++ b/src/packages/mikroorm/package.json
@@ -10,6 +10,7 @@
 		"generate:schema": "tsx ./src/utils/generate-db-schema.ts",
 		"package:pack": "pnpm pack",
 		"prettier": "prettier --write src/**/*.ts",
+		"test": "tsx scripts/check-mikro-overrides-match-installed-versions.ts",
 		"test-introspection": "tsx scripts/test-introspection.ts",
 		"version": "npm version --no-git-tag-version"
 	},

--- a/src/packages/mikroorm/scripts/check-mikro-overrides-match-installed-versions.ts
+++ b/src/packages/mikroorm/scripts/check-mikro-overrides-match-installed-versions.ts
@@ -1,3 +1,5 @@
+// We're fine with require() in this file.
+/* eslint-disable @typescript-eslint/no-require-imports */
 const packageVersion = require('../package.json').devDependencies['@mikro-orm/core'];
 const overrideVersion = require('../../../package.json').pnpm.overrides['@mikro-orm/core'];
 

--- a/src/packages/mikroorm/scripts/check-mikro-overrides-match-installed-versions.ts
+++ b/src/packages/mikroorm/scripts/check-mikro-overrides-match-installed-versions.ts
@@ -1,0 +1,12 @@
+const packageVersion = require('../package.json').devDependencies['@mikro-orm/core'];
+const overrideVersion = require('../../../package.json').pnpm.overrides['@mikro-orm/core'];
+
+console.log(
+	`Checking @mikro-orm/core version. Installed: '${packageVersion}', Overridden: '${overrideVersion}'`
+);
+
+if (packageVersion !== overrideVersion) {
+	throw new Error('@mikro-orm/core version mismatch.');
+} else {
+	console.log('Success: versions match.');
+}

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 overrides:
   d3-color: 3.1.0
   '@babel/traverse': 7.23.2
-  '@mikro-orm/core': 6.3.7
-  '@mikro-orm/knex': 6.3.7
-  '@mikro-orm/postgresql': 6.3.7
-  '@mikro-orm/mysql': 6.3.7
-  '@mikro-orm/sqlite': 6.3.7
+  '@mikro-orm/core': 6.3.8
+  '@mikro-orm/knex': 6.3.8
+  '@mikro-orm/postgresql': 6.3.8
+  '@mikro-orm/mysql': 6.3.8
+  '@mikro-orm/sqlite': 6.3.8
 
 importers:
 
@@ -78,14 +78,14 @@ importers:
         specifier: workspace:*
         version: link:../../packages/server
       '@mikro-orm/core':
-        specifier: 6.3.7
-        version: 6.3.7
+        specifier: 6.3.8
+        version: 6.3.8
       '@mikro-orm/knex':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0)(sqlite3@5.1.7)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(mysql2@3.11.0)(pg@8.12.0)
       '@mikro-orm/sqlite':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(pg@8.12.0)
       graphql:
         specifier: 16.9.0
         version: 16.9.0
@@ -173,17 +173,17 @@ importers:
         specifier: workspace:*
         version: link:../../packages/server
       '@mikro-orm/core':
-        specifier: 6.3.7
-        version: 6.3.7
+        specifier: 6.3.8
+        version: 6.3.8
       '@mikro-orm/knex':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)(mysql2@3.11.0)(pg@8.12.0)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(mysql2@3.11.0)(pg@8.12.0)
       '@mikro-orm/mysql':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(pg@8.12.0)
       '@mikro-orm/postgresql':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)(mysql2@3.11.0)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(mysql2@3.11.0)
       class-validator:
         specifier: 0.14.1
         version: 0.14.1
@@ -259,14 +259,14 @@ importers:
         specifier: workspace:*
         version: link:../../packages/server
       '@mikro-orm/core':
-        specifier: 6.3.7
-        version: 6.3.7
+        specifier: 6.3.8
+        version: 6.3.8
       '@mikro-orm/knex':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0)(sqlite3@5.1.7)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(mysql2@3.11.0)(pg@8.12.0)
       '@mikro-orm/mysql':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(pg@8.12.0)
       dotenv:
         specifier: 16.4.5
         version: 16.4.5
@@ -311,11 +311,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/server
       '@mikro-orm/core':
-        specifier: 6.3.7
-        version: 6.3.7
+        specifier: 6.3.8
+        version: 6.3.8
       '@mikro-orm/mysql':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(pg@8.12.0)
       dotenv:
         specifier: 16.4.5
         version: 16.4.5
@@ -378,14 +378,14 @@ importers:
         specifier: workspace:*
         version: link:../../packages/storage-provider
       '@mikro-orm/core':
-        specifier: 6.3.7
-        version: 6.3.7
+        specifier: 6.3.8
+        version: 6.3.8
       '@mikro-orm/knex':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0)(sqlite3@5.1.7)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(mysql2@3.11.0)(pg@8.12.0)
       '@mikro-orm/postgresql':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(mysql2@3.11.0)
       graphql:
         specifier: 16.9.0
         version: 16.9.0
@@ -436,14 +436,14 @@ importers:
         specifier: workspace:*
         version: link:../../packages/server
       '@mikro-orm/core':
-        specifier: 6.3.7
-        version: 6.3.7
+        specifier: 6.3.8
+        version: 6.3.8
       '@mikro-orm/knex':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0)(sqlite3@5.1.7)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(mysql2@3.11.0)(pg@8.12.0)
       '@mikro-orm/sqlite':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(pg@8.12.0)
       graphql:
         specifier: 16.9.0
         version: 16.9.0
@@ -1213,14 +1213,14 @@ importers:
         specifier: workspace:*
         version: link:../storage-provider
       '@mikro-orm/core':
-        specifier: 6.3.7
-        version: 6.3.7
+        specifier: 6.3.8
+        version: 6.3.8
       '@mikro-orm/postgresql':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(mysql2@3.11.0)
       '@mikro-orm/sqlite':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(pg@8.12.0)
       class-validator:
         specifier: 0.14.1
         version: 0.14.1
@@ -1321,11 +1321,11 @@ importers:
   packages/mikro-orm-sqlite-wasm:
     dependencies:
       '@mikro-orm/knex':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0)(sqlite3@5.1.7)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(mysql2@3.11.0)(pg@8.12.0)
       '@mikro-orm/sqlite':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(pg@8.12.0)
       node-sqlite3-wasm:
         specifier: 0.8.20
         version: 0.8.20
@@ -1383,21 +1383,21 @@ importers:
         version: 0.2.2
     optionalDependencies:
       '@mikro-orm/knex':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0)(sqlite3@5.1.7)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(mysql2@3.11.0)(pg@8.12.0)
       '@mikro-orm/mysql':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(pg@8.12.0)
       '@mikro-orm/postgresql':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(mysql2@3.11.0)
       '@mikro-orm/sqlite':
-        specifier: 6.3.7
-        version: 6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0)
+        specifier: 6.3.8
+        version: 6.3.8(@mikro-orm/core@6.3.8)(pg@8.12.0)
     devDependencies:
       '@mikro-orm/core':
-        specifier: 6.3.7
-        version: 6.3.7
+        specifier: 6.3.8
+        version: 6.3.8
       '@types/node':
         specifier: 22.5.3
         version: 22.5.3
@@ -6260,8 +6260,8 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: false
 
-  /@mikro-orm/core@6.3.7:
-    resolution: {integrity: sha512-S8K257sTTUpnWCgtpJ4EI5kurSP6ha4Zwv1Moy9X33p4xH7JIpEHq5EVTTNZEaj/HbyX/nVRIqAm7ssUBcM1tA==}
+  /@mikro-orm/core@6.3.8:
+    resolution: {integrity: sha512-PkCyX+Dtj1RNZFjRzpNd0QYzs2zb3ubK1KjfBTdUQdvar3x6zReOQD1nfybXcWXeI40ZfsvSixUoTY4YuBD9CA==}
     engines: {node: '>= 18.12.0'}
     dependencies:
       dataloader: 2.2.2
@@ -6269,14 +6269,14 @@ packages:
       esprima: 4.0.1
       fs-extra: 11.2.0
       globby: 11.1.0
-      mikro-orm: 6.3.7
+      mikro-orm: 6.3.8
       reflect-metadata: 0.2.2
 
-  /@mikro-orm/knex@6.3.7(@mikro-orm/core@6.3.7)(mysql2@3.11.0)(pg@8.12.0):
-    resolution: {integrity: sha512-V5wRl+3CM3OLlE8eMT9P/r7B5ZGs0Wjqco/zT7DEPx+j3ym3zk+vXYBVzq74xvKxgKy5F09hpTsvHC8/BhnpEQ==}
+  /@mikro-orm/knex@6.3.8(@mikro-orm/core@6.3.8)(mysql2@3.11.0)(pg@8.12.0):
+    resolution: {integrity: sha512-cUaz5hVuyFbSDt5gQMV0sZPozou5KfRC/43xMoJ5+S4GjQgZEbHMON3Xouqti50ARCFlcq5DEC7qQaHC4atHmA==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      '@mikro-orm/core': 6.3.7
+      '@mikro-orm/core': 6.3.8
       better-sqlite3: '*'
       libsql: '*'
       mariadb: '*'
@@ -6288,7 +6288,7 @@ packages:
       mariadb:
         optional: true
     dependencies:
-      '@mikro-orm/core': 6.3.7
+      '@mikro-orm/core': 6.3.8
       fs-extra: 11.2.0
       knex: 3.1.0(mysql2@3.11.0)(pg@8.12.0)
       sqlstring: 2.3.3
@@ -6302,11 +6302,11 @@ packages:
       - tedious
     dev: false
 
-  /@mikro-orm/knex@6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0)(sqlite3@5.1.7):
-    resolution: {integrity: sha512-V5wRl+3CM3OLlE8eMT9P/r7B5ZGs0Wjqco/zT7DEPx+j3ym3zk+vXYBVzq74xvKxgKy5F09hpTsvHC8/BhnpEQ==}
+  /@mikro-orm/knex@6.3.8(@mikro-orm/core@6.3.8)(pg@8.12.0)(sqlite3@5.1.7):
+    resolution: {integrity: sha512-cUaz5hVuyFbSDt5gQMV0sZPozou5KfRC/43xMoJ5+S4GjQgZEbHMON3Xouqti50ARCFlcq5DEC7qQaHC4atHmA==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      '@mikro-orm/core': 6.3.7
+      '@mikro-orm/core': 6.3.8
       better-sqlite3: '*'
       libsql: '*'
       mariadb: '*'
@@ -6318,7 +6318,7 @@ packages:
       mariadb:
         optional: true
     dependencies:
-      '@mikro-orm/core': 6.3.7
+      '@mikro-orm/core': 6.3.8
       fs-extra: 11.2.0
       knex: 3.1.0(pg@8.12.0)(sqlite3@5.1.7)
       sqlstring: 2.3.3
@@ -6332,14 +6332,14 @@ packages:
       - tedious
     dev: false
 
-  /@mikro-orm/mysql@6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0):
-    resolution: {integrity: sha512-s+pq1GEDn1Iquk8NRLNYkUJw/O4ybd1FPq87p4e0taN6LHLY2U2RsREHdng0/HZwoQFZg0iB7EGMXTeOwRCpbw==}
+  /@mikro-orm/mysql@6.3.8(@mikro-orm/core@6.3.8)(pg@8.12.0):
+    resolution: {integrity: sha512-RFzb0LdTgOghxJ/8h57QT2pmJOmNA9hIcicvC11FXIGqKTE9JyR8Ywq65Zvgb9Bmr9SQ1ayewmAiO+lOzB+Auw==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      '@mikro-orm/core': 6.3.7
+      '@mikro-orm/core': 6.3.8
     dependencies:
-      '@mikro-orm/core': 6.3.7
-      '@mikro-orm/knex': 6.3.7(@mikro-orm/core@6.3.7)(mysql2@3.11.0)(pg@8.12.0)
+      '@mikro-orm/core': 6.3.8
+      '@mikro-orm/knex': 6.3.8(@mikro-orm/core@6.3.8)(mysql2@3.11.0)(pg@8.12.0)
       mysql2: 3.11.0
     transitivePeerDependencies:
       - better-sqlite3
@@ -6353,14 +6353,14 @@ packages:
       - tedious
     dev: false
 
-  /@mikro-orm/postgresql@6.3.7(@mikro-orm/core@6.3.7):
-    resolution: {integrity: sha512-9bGzJTMTqiaqTrCtW9DvmTZs01DBu5q4tjRnq5UA+Bf+egGpd0GMOcn6RStSvP0dnSPr1B71rJ+oQz1tqy5Ubg==}
+  /@mikro-orm/postgresql@6.3.8(@mikro-orm/core@6.3.8)(mysql2@3.11.0):
+    resolution: {integrity: sha512-9Ce3ddKQAMBMHkE1ofE++r8Tkq9YB7yK0my6EQlD3BM2wCSWq/Uj/67Ru7x+JTFiwcr9+sGEXwSv2Tsx8Z0fyw==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      '@mikro-orm/core': 6.3.7
+      '@mikro-orm/core': 6.3.8
     dependencies:
-      '@mikro-orm/core': 6.3.7
-      '@mikro-orm/knex': 6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0)(sqlite3@5.1.7)
+      '@mikro-orm/core': 6.3.8
+      '@mikro-orm/knex': 6.3.8(@mikro-orm/core@6.3.8)(mysql2@3.11.0)(pg@8.12.0)
       pg: 8.12.0
       postgres-array: 3.0.2
       postgres-date: 2.1.0
@@ -6377,38 +6377,14 @@ packages:
       - tedious
     dev: false
 
-  /@mikro-orm/postgresql@6.3.7(@mikro-orm/core@6.3.7)(mysql2@3.11.0):
-    resolution: {integrity: sha512-9bGzJTMTqiaqTrCtW9DvmTZs01DBu5q4tjRnq5UA+Bf+egGpd0GMOcn6RStSvP0dnSPr1B71rJ+oQz1tqy5Ubg==}
+  /@mikro-orm/sqlite@6.3.8(@mikro-orm/core@6.3.8)(pg@8.12.0):
+    resolution: {integrity: sha512-AFJxGl1r3UYlCHV7Jdu+bMduALGbxE0L8glYkIJwYQVAXBFWlMykRdzyPdc56NwuhN98518ISH5CtteslrxD4g==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      '@mikro-orm/core': 6.3.7
+      '@mikro-orm/core': 6.3.8
     dependencies:
-      '@mikro-orm/core': 6.3.7
-      '@mikro-orm/knex': 6.3.7(@mikro-orm/core@6.3.7)(mysql2@3.11.0)(pg@8.12.0)
-      pg: 8.12.0
-      postgres-array: 3.0.2
-      postgres-date: 2.1.0
-      postgres-interval: 4.0.2
-    transitivePeerDependencies:
-      - better-sqlite3
-      - libsql
-      - mariadb
-      - mysql
-      - mysql2
-      - pg-native
-      - sqlite3
-      - supports-color
-      - tedious
-    dev: false
-
-  /@mikro-orm/sqlite@6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0):
-    resolution: {integrity: sha512-Ti9ePY9fNQmBtzR0mEReu/+cuofVh39sV0wTOKgyOtYEAaFTwuTR/VmZcfvrW8ruARQUxNZlU2eT1nhcMk/C3Q==}
-    engines: {node: '>= 18.12.0'}
-    peerDependencies:
-      '@mikro-orm/core': 6.3.7
-    dependencies:
-      '@mikro-orm/core': 6.3.7
-      '@mikro-orm/knex': 6.3.7(@mikro-orm/core@6.3.7)(pg@8.12.0)(sqlite3@5.1.7)
+      '@mikro-orm/core': 6.3.8
+      '@mikro-orm/knex': 6.3.8(@mikro-orm/core@6.3.8)(pg@8.12.0)(sqlite3@5.1.7)
       fs-extra: 11.2.0
       sqlite3: 5.1.7
       sqlstring-sqlite: 0.1.1
@@ -14672,8 +14648,8 @@ packages:
       braces: 3.0.3
       picomatch: 2.3.1
 
-  /mikro-orm@6.3.7:
-    resolution: {integrity: sha512-a4cvGnt2r4ViWm/r2VVTZ74X5o6YiSiJqVQXO5CpcPXk+A88hQr1zVX3fpqlv8em4H0rix9zFfeNW1m3LBtsYg==}
+  /mikro-orm@6.3.8:
+    resolution: {integrity: sha512-QlLa/O9nO6gp7gwQ0Jb8STwiprv6Q9xVUZU93PBS6WrjZsPtmfy7hV6Ufy5bH7gnntTCxtGK2BoCgDFB47+n+Q==}
     engines: {node: '>= 18.12.0'}
 
   /mime-db@1.52.0:


### PR DESCRIPTION
- Bump MikroORM overrides to match versions selected by dependabot.
- Add a script to stop builds passing if dependabot tries to bump Mikro without also bumping the overrides in the future.