### PR TITLE
Feature / Client Side ID Generation

### DIFF
--- a/src/examples/auth-zero/src/frontend/types.generated.ts
+++ b/src/examples/auth-zero/src/frontend/types.generated.ts
@@ -24,6 +24,7 @@ export type Scalars = {
 
 export type AdminUiEntityAttributeMetadata = {
   __typename?: 'AdminUiEntityAttributeMetadata';
+  clientGeneratedPrimaryKeys?: Maybe<Scalars['Boolean']['output']>;
   exportPageSize?: Maybe<Scalars['Float']['output']>;
   isReadOnly?: Maybe<Scalars['Boolean']['output']>;
 };

--- a/src/examples/auth-zero/src/types.generated.ts
+++ b/src/examples/auth-zero/src/types.generated.ts
@@ -24,6 +24,7 @@ export type Scalars = {
 
 export type AdminUiEntityAttributeMetadata = {
   __typename?: 'AdminUiEntityAttributeMetadata';
+  clientGeneratedPrimaryKeys?: Maybe<Scalars['Boolean']['output']>;
   exportPageSize?: Maybe<Scalars['Float']['output']>;
   isReadOnly?: Maybe<Scalars['Boolean']['output']>;
 };

--- a/src/examples/aws-cognito/src/frontend/types.generated.ts
+++ b/src/examples/aws-cognito/src/frontend/types.generated.ts
@@ -22,6 +22,7 @@ export type Scalars = {
 
 export type AdminUiEntityAttributeMetadata = {
   __typename?: 'AdminUiEntityAttributeMetadata';
+  clientGeneratedPrimaryKeys?: Maybe<Scalars['Boolean']['output']>;
   exportPageSize?: Maybe<Scalars['Float']['output']>;
   isReadOnly?: Maybe<Scalars['Boolean']['output']>;
 };

--- a/src/examples/aws-cognito/src/types.generated.ts
+++ b/src/examples/aws-cognito/src/types.generated.ts
@@ -22,6 +22,7 @@ export type Scalars = {
 
 export type AdminUiEntityAttributeMetadata = {
   __typename?: 'AdminUiEntityAttributeMetadata';
+  clientGeneratedPrimaryKeys?: Maybe<Scalars['Boolean']['output']>;
   exportPageSize?: Maybe<Scalars['Float']['output']>;
   isReadOnly?: Maybe<Scalars['Boolean']['output']>;
 };

--- a/src/examples/federation/src/frontend/types.generated.ts
+++ b/src/examples/federation/src/frontend/types.generated.ts
@@ -25,6 +25,7 @@ export type Scalars = {
 
 export type AdminUiEntityAttributeMetadata = {
   __typename?: 'AdminUiEntityAttributeMetadata';
+  clientGeneratedPrimaryKeys?: Maybe<Scalars['Boolean']['output']>;
   exportPageSize?: Maybe<Scalars['Float']['output']>;
   isReadOnly?: Maybe<Scalars['Boolean']['output']>;
 };

--- a/src/examples/federation/src/types.generated.ts
+++ b/src/examples/federation/src/types.generated.ts
@@ -25,6 +25,7 @@ export type Scalars = {
 
 export type AdminUiEntityAttributeMetadata = {
   __typename?: 'AdminUiEntityAttributeMetadata';
+  clientGeneratedPrimaryKeys?: Maybe<Scalars['Boolean']['output']>;
   exportPageSize?: Maybe<Scalars['Float']['output']>;
   isReadOnly?: Maybe<Scalars['Boolean']['output']>;
 };

--- a/src/examples/rest-with-auth/src/frontend/types.generated.ts
+++ b/src/examples/rest-with-auth/src/frontend/types.generated.ts
@@ -26,6 +26,7 @@ export type Scalars = {
 
 export type AdminUiEntityAttributeMetadata = {
   __typename?: 'AdminUiEntityAttributeMetadata';
+  clientGeneratedPrimaryKeys?: Maybe<Scalars['Boolean']['output']>;
   exportPageSize?: Maybe<Scalars['Float']['output']>;
   isReadOnly?: Maybe<Scalars['Boolean']['output']>;
 };

--- a/src/examples/rest-with-auth/src/types.generated.ts
+++ b/src/examples/rest-with-auth/src/types.generated.ts
@@ -26,6 +26,7 @@ export type Scalars = {
 
 export type AdminUiEntityAttributeMetadata = {
   __typename?: 'AdminUiEntityAttributeMetadata';
+  clientGeneratedPrimaryKeys?: Maybe<Scalars['Boolean']['output']>;
   exportPageSize?: Maybe<Scalars['Float']['output']>;
   isReadOnly?: Maybe<Scalars['Boolean']['output']>;
 };

--- a/src/examples/rest-with-auth/types.generated.ts
+++ b/src/examples/rest-with-auth/types.generated.ts
@@ -26,6 +26,7 @@ export type Scalars = {
 
 export type AdminUiEntityAttributeMetadata = {
   __typename?: 'AdminUiEntityAttributeMetadata';
+  clientGeneratedPrimaryKeys?: Maybe<Scalars['Boolean']['output']>;
   exportPageSize?: Maybe<Scalars['Float']['output']>;
   isReadOnly?: Maybe<Scalars['Boolean']['output']>;
 };

--- a/src/examples/rest/src/frontend/types.generated.ts
+++ b/src/examples/rest/src/frontend/types.generated.ts
@@ -22,6 +22,7 @@ export type Scalars = {
 
 export type AdminUiEntityAttributeMetadata = {
   __typename?: 'AdminUiEntityAttributeMetadata';
+  clientGeneratedPrimaryKeys?: Maybe<Scalars['Boolean']['output']>;
   exportPageSize?: Maybe<Scalars['Float']['output']>;
   isReadOnly?: Maybe<Scalars['Boolean']['output']>;
 };

--- a/src/examples/rest/src/types.generated.ts
+++ b/src/examples/rest/src/types.generated.ts
@@ -22,6 +22,7 @@ export type Scalars = {
 
 export type AdminUiEntityAttributeMetadata = {
   __typename?: 'AdminUiEntityAttributeMetadata';
+  clientGeneratedPrimaryKeys?: Maybe<Scalars['Boolean']['output']>;
   exportPageSize?: Maybe<Scalars['Float']['output']>;
   isReadOnly?: Maybe<Scalars['Boolean']['output']>;
 };

--- a/src/examples/s3-storage/src/frontend/types.generated.ts
+++ b/src/examples/s3-storage/src/frontend/types.generated.ts
@@ -22,6 +22,7 @@ export type Scalars = {
 
 export type AdminUiEntityAttributeMetadata = {
   __typename?: 'AdminUiEntityAttributeMetadata';
+  clientGeneratedPrimaryKeys?: Maybe<Scalars['Boolean']['output']>;
   exportPageSize?: Maybe<Scalars['Float']['output']>;
   isReadOnly?: Maybe<Scalars['Boolean']['output']>;
 };

--- a/src/examples/s3-storage/src/types.generated.ts
+++ b/src/examples/s3-storage/src/types.generated.ts
@@ -22,6 +22,7 @@ export type Scalars = {
 
 export type AdminUiEntityAttributeMetadata = {
   __typename?: 'AdminUiEntityAttributeMetadata';
+  clientGeneratedPrimaryKeys?: Maybe<Scalars['Boolean']['output']>;
   exportPageSize?: Maybe<Scalars['Float']['output']>;
   isReadOnly?: Maybe<Scalars['Boolean']['output']>;
 };

--- a/src/examples/sqlite/src/backend/schema/genre.ts
+++ b/src/examples/sqlite/src/backend/schema/genre.ts
@@ -6,6 +6,7 @@ import { connection } from '../database';
 
 @Entity('Genre', {
 	provider: new MikroBackendProvider(OrmGenre, connection),
+	apiOptions: { clientGeneratedPrimaryKeys: true },
 })
 export class Genre {
 	@Field(() => ID, { primaryKeyField: true })

--- a/src/examples/sqlite/src/frontend/types.generated.ts
+++ b/src/examples/sqlite/src/frontend/types.generated.ts
@@ -28,6 +28,7 @@ export type Scalars = {
 
 export type AdminUiEntityAttributeMetadata = {
   __typename?: 'AdminUiEntityAttributeMetadata';
+  clientGeneratedPrimaryKeys?: Maybe<Scalars['Boolean']['output']>;
   exportPageSize?: Maybe<Scalars['Float']['output']>;
   isReadOnly?: Maybe<Scalars['Boolean']['output']>;
 };
@@ -879,13 +880,14 @@ export type GenreTracks_AggregateArgs = {
 
 /** Data needed to create or update Genres. If an ID is passed, this is an update, otherwise it's an insert. */
 export type GenreCreateOrUpdateInput = {
-  genreId?: InputMaybe<Scalars['ID']['input']>;
+  genreId: Scalars['ID']['input'];
   name?: InputMaybe<Scalars['String']['input']>;
   tracks?: InputMaybe<Array<TrackCreateOrUpdateInput>>;
 };
 
 /** Data needed to create Genres. */
 export type GenreInsertInput = {
+  genreId: Scalars['ID']['input'];
   name?: InputMaybe<Scalars['String']['input']>;
   tracks?: InputMaybe<Array<TrackCreateOrUpdateInput>>;
 };

--- a/src/examples/sqlite/src/types.generated.ts
+++ b/src/examples/sqlite/src/types.generated.ts
@@ -28,6 +28,7 @@ export type Scalars = {
 
 export type AdminUiEntityAttributeMetadata = {
   __typename?: 'AdminUiEntityAttributeMetadata';
+  clientGeneratedPrimaryKeys?: Maybe<Scalars['Boolean']['output']>;
   exportPageSize?: Maybe<Scalars['Float']['output']>;
   isReadOnly?: Maybe<Scalars['Boolean']['output']>;
 };
@@ -879,13 +880,14 @@ export type GenreTracks_AggregateArgs = {
 
 /** Data needed to create or update Genres. If an ID is passed, this is an update, otherwise it's an insert. */
 export type GenreCreateOrUpdateInput = {
-  genreId?: InputMaybe<Scalars['ID']['input']>;
+  genreId: Scalars['ID']['input'];
   name?: InputMaybe<Scalars['String']['input']>;
   tracks?: InputMaybe<Array<TrackCreateOrUpdateInput>>;
 };
 
 /** Data needed to create Genres. */
 export type GenreInsertInput = {
+  genreId: Scalars['ID']['input'];
   name?: InputMaybe<Scalars['String']['input']>;
   tracks?: InputMaybe<Array<TrackCreateOrUpdateInput>>;
 };

--- a/src/examples/xero/src/admin-ui/custom-pages/dashboards/all-companies/component.generated.ts
+++ b/src/examples/xero/src/admin-ui/custom-pages/dashboards/all-companies/component.generated.ts
@@ -52,8 +52,8 @@ export function useAllCompaniesProfitAndLossRowsLazyQuery(baseOptions?: Apollo.L
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<AllCompaniesProfitAndLossRowsQuery, AllCompaniesProfitAndLossRowsQueryVariables>(AllCompaniesProfitAndLossRowsDocument, options);
         }
-export function useAllCompaniesProfitAndLossRowsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<AllCompaniesProfitAndLossRowsQuery, AllCompaniesProfitAndLossRowsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useAllCompaniesProfitAndLossRowsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<AllCompaniesProfitAndLossRowsQuery, AllCompaniesProfitAndLossRowsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<AllCompaniesProfitAndLossRowsQuery, AllCompaniesProfitAndLossRowsQueryVariables>(AllCompaniesProfitAndLossRowsDocument, options);
         }
 export type AllCompaniesProfitAndLossRowsQueryHookResult = ReturnType<typeof useAllCompaniesProfitAndLossRowsQuery>;

--- a/src/examples/xero/src/admin-ui/custom-pages/dashboards/single-company/component.generated.ts
+++ b/src/examples/xero/src/admin-ui/custom-pages/dashboards/single-company/component.generated.ts
@@ -53,8 +53,8 @@ export function useSingleCompanyProfitAndLossRowsLazyQuery(baseOptions?: Apollo.
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<SingleCompanyProfitAndLossRowsQuery, SingleCompanyProfitAndLossRowsQueryVariables>(SingleCompanyProfitAndLossRowsDocument, options);
         }
-export function useSingleCompanyProfitAndLossRowsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<SingleCompanyProfitAndLossRowsQuery, SingleCompanyProfitAndLossRowsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useSingleCompanyProfitAndLossRowsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<SingleCompanyProfitAndLossRowsQuery, SingleCompanyProfitAndLossRowsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<SingleCompanyProfitAndLossRowsQuery, SingleCompanyProfitAndLossRowsQueryVariables>(SingleCompanyProfitAndLossRowsDocument, options);
         }
 export type SingleCompanyProfitAndLossRowsQueryHookResult = ReturnType<typeof useSingleCompanyProfitAndLossRowsQuery>;

--- a/src/examples/xero/src/admin-ui/custom-pages/index.generated.ts
+++ b/src/examples/xero/src/admin-ui/custom-pages/index.generated.ts
@@ -45,8 +45,8 @@ export function useTenantsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Te
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<TenantsQuery, TenantsQueryVariables>(TenantsDocument, options);
         }
-export function useTenantsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<TenantsQuery, TenantsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useTenantsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<TenantsQuery, TenantsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<TenantsQuery, TenantsQueryVariables>(TenantsDocument, options);
         }
 export type TenantsQueryHookResult = ReturnType<typeof useTenantsQuery>;

--- a/src/examples/xero/src/frontend/types.generated.ts
+++ b/src/examples/xero/src/frontend/types.generated.ts
@@ -152,6 +152,7 @@ export type AccountsPaginationInput = {
 
 export type AdminUiEntityAttributeMetadata = {
   __typename?: 'AdminUiEntityAttributeMetadata';
+  clientGeneratedPrimaryKeys?: Maybe<Scalars['Boolean']['output']>;
   exportPageSize?: Maybe<Scalars['Float']['output']>;
   isReadOnly?: Maybe<Scalars['Boolean']['output']>;
 };

--- a/src/examples/xero/src/types.generated.ts
+++ b/src/examples/xero/src/types.generated.ts
@@ -152,6 +152,7 @@ export type AccountsPaginationInput = {
 
 export type AdminUiEntityAttributeMetadata = {
   __typename?: 'AdminUiEntityAttributeMetadata';
+  clientGeneratedPrimaryKeys?: Maybe<Scalars['Boolean']['output']>;
   exportPageSize?: Maybe<Scalars['Float']['output']>;
   isReadOnly?: Maybe<Scalars['Boolean']['output']>;
 };

--- a/src/packages/admin-ui-components/src/assets/request.tsx
+++ b/src/packages/admin-ui-components/src/assets/request.tsx
@@ -2,22 +2,22 @@ import { SVGProps } from 'react';
 
 export const RequestIcon = (props: SVGProps<SVGSVGElement>) => (
 	<svg width="64" height="64" viewBox="0 0 16 16" {...props}>
-		<g clip-path="url(#clip0_238_1190)">
+		<g clipPath="url(#clip0_238_1190)">
 			<path
 				d="M4.91406 11.3787L14.3283 11.3788M14.3283 11.3788L11.0354 14.6717M14.3283 11.3788L11.0354 8.08594"
 				stroke="#958CAA"
-				stroke-opacity="0.7"
-				stroke-width="2"
-				stroke-linecap="round"
-				stroke-linejoin="round"
+				strokeOpacity="0.7"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
 			/>
 			<path
 				d="M11.0859 4.62102L1.67173 4.62102M1.67173 4.62102L4.96462 7.91391M1.67173 4.62102L4.96462 1.32813"
 				stroke="#958CAA"
-				stroke-opacity="0.7"
-				stroke-width="2"
-				stroke-linecap="round"
-				stroke-linejoin="round"
+				strokeOpacity="0.7"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
 			/>
 		</g>
 		<defs>

--- a/src/packages/admin-ui-components/src/combo-box/component.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/component.tsx
@@ -26,6 +26,7 @@ interface SelectProps {
 	placeholder?: string;
 	loading?: boolean;
 	autoFocus?: boolean;
+	disabled?: boolean;
 	['data-testid']?: string;
 }
 
@@ -44,6 +45,7 @@ export const ComboBox = ({
 	placeholder = 'Select',
 	loading = false,
 	autoFocus = false,
+	disabled = false,
 	['data-testid']: testId,
 }: SelectProps) => {
 	const valueArray = arrayify(value);
@@ -52,6 +54,7 @@ export const ComboBox = ({
 	const { isOpen, getMenuProps, getInputProps, highlightedIndex, getItemProps } = useCombobox({
 		items: options,
 		itemToString: (item) => item?.label ?? '',
+		isItemDisabled: () => disabled,
 		onSelectedItemChange: (change) => {
 			if (mode === SelectMode.MULTI) {
 				onChange([...valueArray, change.selectedItem]);

--- a/src/packages/admin-ui-components/src/detail-panel/component.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/component.tsx
@@ -233,7 +233,7 @@ const DetailForm = ({
 				.join('\n');
 
 			// TODO EXOGW-150: instead of using toast, we should use a formik error message on the form itself
-			toast.error(message, { duration: 5000 });
+			if (message) toast.error(message, { duration: 5000 });
 
 			return errors;
 		},
@@ -433,29 +433,32 @@ export const DetailPanel = () => {
 
 	const handleOnSubmit = async (values: any, actions: FormikHelpers<any>) => {
 		try {
-			let result: FetchResult;
+			let result: FetchResult | undefined = undefined;
 
-			if (panelMode === PanelMode.EDIT) {
-				// Update an existing entity
-				result = await updateEntity({
-					variables: {
-						input: values,
-					},
-				});
-			} else {
-				// Create a new entity
-				result = await createEntity({
-					variables: {
-						input: values,
-					},
-					refetchQueries: [`${selectedEntity.plural}List`],
-				});
+			try {
+				if (panelMode === PanelMode.EDIT) {
+					// Update an existing entity
+					result = await updateEntity({
+						variables: {
+							input: values,
+						},
+					});
+				} else {
+					// Create a new entity
+					result = await createEntity({
+						variables: {
+							input: values,
+						},
+						refetchQueries: [`${selectedEntity.plural}List`],
+					});
+				}
+			} catch (error: any) {
+				console.error(error);
+				return toast.error(`Error from server: ${error.message}`, { duration: 5000 });
 			}
 
-			if (!result.data) {
-				return toast.error('No data received in response', {
-					duration: 5000,
-				});
+			if (!result?.data) {
+				return toast.error('No data received in response', { duration: 5000 });
 			}
 
 			clearSessionState();

--- a/src/packages/admin-ui-components/src/detail-panel/component.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/component.tsx
@@ -12,6 +12,7 @@ import { Modal } from '../modal';
 import {
 	CustomField,
 	decodeSearchParams,
+	Entity,
 	EntityField,
 	queryForEntity,
 	routeFor,
@@ -46,27 +47,50 @@ export enum PanelMode {
 	EDIT = 'EDIT',
 }
 
-const isFieldReadonly = (field: EntityField | CustomField<unknown>) =>
-	field.type === 'ID' || field.type === 'ID!' || field.attributes?.isReadOnly;
+const isFieldReadonly = (
+	panelMode: PanelMode,
+	entity: Entity,
+	field: EntityField | CustomField<unknown>
+) => {
+	// Regardless of if we're creating or editing, IDs should always be read only
+	// unless the entity has client generated primary keys.
+	if (
+		(field.type === 'ID' || field.type === 'ID!') &&
+		!entity.attributes.clientGeneratedPrimaryKeys
+	) {
+		return true;
+	}
+
+	// If the entity as a whole is read only, then all fields should be read only.
+	if (entity.attributes.isReadOnly) return true;
+
+	// If we're editing and a field is read only, it should be shown as read only.
+	// However if we're creating, we may need to write the value for the initial creation.
+	if (panelMode !== PanelMode.CREATE && field.attributes?.isReadOnly) return true;
+
+	return false;
+};
 
 const getField = ({
+	entity,
 	field,
 	autoFocus,
 	panelMode,
 }: {
+	entity: Entity;
 	field: EntityField;
 	autoFocus: boolean;
 	panelMode: PanelMode;
 }) => {
-	// In Create mode, all readonly fields should be writeable.
-	const isReadonly = panelMode !== PanelMode.CREATE && isFieldReadonly(field);
+	// In Create mode, all readonly fields should be writeable except ID fields
+	const isReadonly = isFieldReadonly(panelMode, entity, field);
 
 	if (field.type === 'JSON') {
 		return <JSONField name={field.name} autoFocus={autoFocus} disabled={isReadonly} />;
 	}
 
 	if (field.type === 'Boolean') {
-		return <BooleanField name={field.name} autoFocus={autoFocus} />;
+		return <BooleanField name={field.name} autoFocus={autoFocus} disabled={isReadonly} />;
 	}
 
 	if (field.type === 'GraphweaverMedia') {
@@ -77,8 +101,9 @@ const getField = ({
 		// If the field is readonly and a relationship, show a link to the entity/entities
 		if (isReadonly) {
 			return <LinkField name={field.name} field={field} />;
+		} else {
+			return <RelationshipField name={field.name} field={field} autoFocus={autoFocus} />;
 		}
-		return <RelationshipField name={field.name} field={field} autoFocus={autoFocus} />;
 	}
 
 	const { enumByName } = useSchema();
@@ -90,6 +115,7 @@ const getField = ({
 				typeEnum={enumObject}
 				multiple={field.isArray}
 				autoFocus={autoFocus}
+				disabled={isReadonly}
 			/>
 		);
 	}
@@ -102,10 +128,12 @@ const getField = ({
 };
 
 const DetailField = ({
+	entity,
 	field,
 	autoFocus,
 	panelMode,
 }: {
+	entity: Entity;
 	field: EntityField;
 	autoFocus: boolean;
 	panelMode: PanelMode;
@@ -115,7 +143,7 @@ const DetailField = ({
 		<div className={styles.detailField} data-testid={`detail-panel-field-${field.name}`}>
 			<DetailPanelFieldLabel fieldName={field.name} required={isRequired} />
 
-			{getField({ field, autoFocus, panelMode })}
+			{getField({ entity, field, autoFocus, panelMode })}
 		</div>
 	);
 };
@@ -153,6 +181,7 @@ const PersistForm = ({ name }: { name: string }) => {
 
 const DetailForm = ({
 	initialValues,
+	entity,
 	detailFields,
 	onCancel,
 	onSubmit,
@@ -161,6 +190,7 @@ const DetailForm = ({
 	panelMode,
 }: {
 	initialValues: Record<string, any>;
+	entity: Entity;
 	detailFields: (EntityField | CustomField)[];
 	onSubmit: (values: any, actions: FormikHelpers<any>) => void;
 	onCancel: () => void;
@@ -233,7 +263,9 @@ const DetailForm = ({
 		[dataTransforms]
 	);
 
-	const firstEditableField = detailFields.find((field) => !isFieldReadonly(field));
+	const firstEditableField = detailFields.find(
+		(field) => !isFieldReadonly(panelMode, entity, field)
+	);
 
 	return (
 		<Formik
@@ -263,6 +295,7 @@ const DetailForm = ({
 								return (
 									<DetailField
 										key={field.name}
+										entity={entity}
 										field={field}
 										autoFocus={field === firstEditableField}
 										panelMode={panelMode}
@@ -496,6 +529,7 @@ export const DetailPanel = () => {
 							<DetailForm
 								initialValues={initialValues}
 								detailFields={formFields}
+								entity={selectedEntity}
 								onCancel={closeModal}
 								onSubmit={handleOnSubmit}
 								persistName={persistName}

--- a/src/packages/admin-ui-components/src/detail-panel/fields/boolean-field.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/fields/boolean-field.tsx
@@ -2,7 +2,15 @@ import { useField } from 'formik';
 import { useEffect } from 'react';
 import { SelectOption, ComboBox, SelectMode } from '../../combo-box';
 
-export const BooleanField = ({ name, autoFocus }: { name: string; autoFocus: boolean }) => {
+export const BooleanField = ({
+	name,
+	autoFocus,
+	disabled = false,
+}: {
+	name: string;
+	autoFocus: boolean;
+	disabled?: boolean;
+}) => {
 	const [_, meta, helpers] = useField({ name, multiple: false });
 	const { initialValue } = meta;
 
@@ -28,6 +36,7 @@ export const BooleanField = ({ name, autoFocus }: { name: string; autoFocus: boo
 			value={initialValue === undefined ? [] : [{ value: initialValue, label: `${initialValue}` }]}
 			onChange={handleOnChange}
 			mode={SelectMode.SINGLE}
+			disabled={disabled}
 			autoFocus={autoFocus}
 		/>
 	);

--- a/src/packages/admin-ui-components/src/detail-panel/fields/enum-field.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/fields/enum-field.tsx
@@ -7,11 +7,13 @@ export const EnumField = ({
 	typeEnum,
 	multiple,
 	autoFocus = false,
+	disabled = false,
 }: {
 	name: string;
 	typeEnum: Enum;
 	multiple?: boolean;
 	autoFocus?: boolean;
+	disabled?: boolean;
 }) => {
 	const [{ value }, _, helpers] = useField({ name, multiple });
 
@@ -53,6 +55,7 @@ export const EnumField = ({
 			onChange={handleOnChange}
 			mode={multiple ? SelectMode.MULTI : SelectMode.SINGLE}
 			autoFocus={autoFocus}
+			disabled={disabled}
 		/>
 	);
 };

--- a/src/packages/admin-ui-components/src/hooks/use-auto-focus.ts
+++ b/src/packages/admin-ui-components/src/hooks/use-auto-focus.ts
@@ -3,12 +3,9 @@ import { autoFocusDelay } from '../config';
 
 export const useAutoFocus = <T extends HTMLElement>(autoFocus?: boolean) => {
 	const ref = useRef<T>(null);
+
 	useEffect(() => {
-		if (autoFocus) {
-			setTimeout(() => {
-				ref.current?.focus();
-			}, autoFocusDelay);
-		}
+		if (autoFocus) setTimeout(() => ref.current?.focus(), autoFocusDelay);
 	}, [autoFocus]);
 
 	return ref;

--- a/src/packages/admin-ui-components/src/utils/graphql.ts
+++ b/src/packages/admin-ui-components/src/utils/graphql.ts
@@ -40,6 +40,7 @@ export const SCHEMA_QUERY = gql`
 				attributes {
 					isReadOnly
 					exportPageSize
+					clientGeneratedPrimaryKeys
 				}
 			}
 			enums {

--- a/src/packages/admin-ui-components/src/utils/use-schema.ts
+++ b/src/packages/admin-ui-components/src/utils/use-schema.ts
@@ -97,6 +97,7 @@ export interface EntityFieldAttributes {
 export interface EntityAttributes {
 	isReadOnly?: boolean;
 	exportPageSize?: number;
+	clientGeneratedPrimaryKeys?: boolean;
 }
 
 export interface CustomFieldArgs<T = unknown> {

--- a/src/packages/core/src/metadata-service/entity-attribute.ts
+++ b/src/packages/core/src/metadata-service/entity-attribute.ts
@@ -9,4 +9,7 @@ export class AdminUiEntityAttributeMetadata {
 
 	@Field(() => Number, { nullable: true })
 	exportPageSize?: number;
+
+	@Field(() => Boolean, { nullable: true })
+	clientGeneratedPrimaryKeys?: boolean;
 }

--- a/src/packages/core/src/metadata-service/resolver.ts
+++ b/src/packages/core/src/metadata-service/resolver.ts
@@ -73,6 +73,7 @@ export const resolveAdminUiMetadata = (hooks?: Hooks) => {
 
 			const attributes = new AdminUiEntityAttributeMetadata();
 			attributes.exportPageSize = entity.adminUIOptions?.exportPageSize;
+			attributes.clientGeneratedPrimaryKeys = entity.apiOptions?.clientGeneratedPrimaryKeys;
 			attributes.isReadOnly =
 				entity.adminUIOptions?.readonly ??
 				entity.apiOptions?.excludeFromBuiltInOperations ??

--- a/src/packages/core/src/metadata.ts
+++ b/src/packages/core/src/metadata.ts
@@ -19,6 +19,16 @@ export interface EntityMetadata<G = unknown, D = unknown> {
 	primaryKeyField?: keyof G;
 
 	apiOptions?: {
+		// By default we expect the underlying data provider to generate the primary keys for entities, e.g. an
+		// identity field in a database. This allows consistency and centralised control. It is, however, sometimes
+		// nice to allow for client side ID creation, particularly with uuid IDs, or in situations like chat programs
+		// where you want the client to know the ID before it even does the initial mutation to create the entity.
+		// In these cases, you'll want to set this to true. The schema will then emit the primary key field as a
+		// required field in calls to create the entity. If you call createOrUpdate with these entities, it will
+		// be less efficient because we have to go to the underlying datasource to see if the entity exists before
+		// we can decide if it was a create or if it was an update that you meant.
+		clientGeneratedPrimaryKeys?: boolean;
+
 		// This means that the entity should not be given the default list, find one, create, update, and delete
 		// operations. This is useful for entities that you're defining the API for yourself. Setting this to true
 		// enables excludeFromFiltering as well.

--- a/src/packages/core/src/schema-builder.ts
+++ b/src/packages/core/src/schema-builder.ts
@@ -72,7 +72,15 @@ export type GraphweaverSchemaInfoExtensionWithSourceEntity = {
 		| 'createOrUpdateInput'
 		| 'updateInput'
 		| 'createInput'
-		| 'filterInput';
+		| 'filterInput'
+		| 'createOne'
+		| 'createMany'
+		| 'updateOne'
+		| 'updateMany'
+		| 'createOrUpdateMany'
+		| 'deleteOne'
+		| 'deleteMany';
+
 	sourceEntity: EntityMetadata<any, any>;
 };
 
@@ -620,8 +628,17 @@ const generateGraphQLInputFieldsForEntity =
 			// The ID field is a special case based on the input type.
 			if (field.name === (entity.primaryKeyField ?? 'id')) {
 				switch (input) {
+					case 'insert':
+						if (entity.apiOptions?.clientGeneratedPrimaryKeys) {
+							fields[field.name] = { type: new GraphQLNonNull(ID) };
+						}
+						break;
 					case 'createOrUpdate':
-						fields[field.name] = { type: ID };
+						if (entity.apiOptions?.clientGeneratedPrimaryKeys) {
+							fields[field.name] = { type: new GraphQLNonNull(ID) };
+						} else {
+							fields[field.name] = { type: ID };
+						}
 						break;
 					case 'update':
 						fields[field.name] = { type: new GraphQLNonNull(ID) };


### PR DESCRIPTION
Before this PR, it was expected by Graphweaver that IDs would be created by the underlying data provider. The primary key field was omitted from the create input arg type entirely.

With this PR, you can optionally set `apiOptions.clientGeneratedPrimaryKeys: true` in the `@Entity` options, which will then require you to supply the primary key for this entity when creating it.