### PR TITLE
Feature / Allow hook-generated primary keys for all entities

### DIFF
--- a/src/packages/core/src/utils/create-or-update-entities.ts
+++ b/src/packages/core/src/utils/create-or-update-entities.ts
@@ -180,17 +180,13 @@ export const createOrUpdateEntities = async <G = unknown, D = unknown>(
 			return fromBackendEntity(meta, node as D);
 		} else {
 			// Is it a create or an update?
-			let operation: 'create' | 'update';
-			// If client side ID generation is disabled, we can be sure it follows our old rules.
-			if (!meta.apiOptions?.clientGeneratedPrimaryKeys) {
-				operation =
-					primaryKeyField in node && node[primaryKeyField] && Object.keys(node).length > 1
-						? 'update'
-						: 'create';
-			} else {
-				// Ok, this is a client generated primary key entity. That means we don't know which it is until we check
-				// whether the entity exists in the first place.
-				// If there's no primary key at this point, that's an error.
+			let operation: 'create' | 'update' = 'create';
+
+			// If there's an ID, we can't be certain whether it's an update or a create. It could be
+			// a client-side primary key entity, or it could be a server side primary key entity where the
+			// ID is coming from a hook. So if there's an ID, there's only one way to be sure
+			// what the operation is, which is to check if it already exists or not.
+			if (primaryKeyField in node && node[primaryKeyField] && Object.keys(node).length > 1) {
 				const primaryKey = node[primaryKeyField];
 				if (!primaryKey)
 					throw new Error(

--- a/src/packages/end-to-end/src/__tests__/api/auth/acl/create-or-update.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/auth/acl/create-or-update.test.ts
@@ -3,7 +3,7 @@ process.env.PASSWORD_AUTH_REDIRECT_URI = '*';
 import gql from 'graphql-tag';
 import assert from 'assert';
 import Graphweaver from '@exogee/graphweaver-server';
-import { Field, ID, BaseDataProvider, Entity } from '@exogee/graphweaver';
+import { Field, ID, BaseDataProvider, Entity, Filter } from '@exogee/graphweaver';
 import {
 	CredentialStorage,
 	UserProfile,
@@ -14,13 +14,19 @@ import {
 	setAddUserToContext,
 } from '@exogee/graphweaver-auth';
 
-const user = new UserProfile({
-	id: '1',
-	roles: ['admin'],
-	displayName: 'Test User',
-});
+class AlbumDataProvider extends BaseDataProvider<Album> {
+	async findOne(filter: Filter<Album>) {
+		if (filter.id === 1) {
+			return {
+				id: 1,
+				description: 'dummy album',
+			};
+		}
 
-const albumDataProvider = new BaseDataProvider<any>('album');
+		return null;
+	}
+}
+const albumDataProvider = new AlbumDataProvider('album');
 
 @Entity('Album', {
 	provider: albumDataProvider,
@@ -32,6 +38,12 @@ export class Album {
 	@Field(() => String)
 	description!: string;
 }
+
+const user = new UserProfile({
+	id: '1',
+	roles: ['admin'],
+	displayName: 'Test User',
+});
 
 const cred: CredentialStorage = {
 	id: '1',

--- a/src/packages/end-to-end/src/__tests__/api/auth/acl/create-or-update.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/auth/acl/create-or-update.test.ts
@@ -16,7 +16,7 @@ import {
 
 class AlbumDataProvider extends BaseDataProvider<Album> {
 	async findOne(filter: Filter<Album>) {
-		if (filter.id === 1) {
+		if (String(filter.id) === '1') {
 			return {
 				id: 1,
 				description: 'dummy album',


### PR DESCRIPTION
Previously if you had not enabled client side primary key generation, it was impossible to supply the primary key value with a hook. With this PR, you can do the following:

1. If client generated primary keys is off for the entity, the primary key field will not be in the GraphQL input type for the entity, so clients cannot send it. If a hook puts it in there though, then the resolvers will respect this value and create the entity with that ID.
2. If client generated primary keys is on for the entity, the primary key field will be required in the GraphQL input type for the entity, so clients must send it. A hook is able to edit it on the way through. Resolvers will respect this value either way and create the entity with that ID.
3. If you do not enable client generated primary keys for an entity, and a hook does not specify the primary key, then existing behaviour is preserved. The underlying datasource is expected to generate the ID for the entity.