### PR TITLE
Feature / Added ability to pass options to Fastify.

### DIFF
--- a/src/examples/databases/src/frontend/types.generated.ts
+++ b/src/examples/databases/src/frontend/types.generated.ts
@@ -22,6 +22,7 @@ export type Scalars = {
 
 export type AdminUiEntityAttributeMetadata = {
   __typename?: 'AdminUiEntityAttributeMetadata';
+  clientGeneratedPrimaryKeys?: Maybe<Scalars['Boolean']['output']>;
   exportPageSize?: Maybe<Scalars['Float']['output']>;
   isReadOnly?: Maybe<Scalars['Boolean']['output']>;
 };

--- a/src/examples/databases/src/types.generated.ts
+++ b/src/examples/databases/src/types.generated.ts
@@ -22,6 +22,7 @@ export type Scalars = {
 
 export type AdminUiEntityAttributeMetadata = {
   __typename?: 'AdminUiEntityAttributeMetadata';
+  clientGeneratedPrimaryKeys?: Maybe<Scalars['Boolean']['output']>;
   exportPageSize?: Maybe<Scalars['Float']['output']>;
   isReadOnly?: Maybe<Scalars['Boolean']['output']>;
 };

--- a/src/packages/server/src/config.ts
+++ b/src/packages/server/src/config.ts
@@ -3,6 +3,12 @@ import { GraphQLArmorConfig } from '@escape.tech/graphql-armor-types';
 import { BackendProvider, GraphweaverPlugin, Instrumentation } from '@exogee/graphweaver';
 
 import { CorsPluginOptions } from './apollo-plugins';
+import type {
+	FastifyHttp2Options,
+	FastifyHttp2SecureOptions,
+	FastifyHttpOptions,
+	FastifyHttpsOptions,
+} from 'fastify';
 
 export type MetadataHookParams<C> = {
 	context: C;
@@ -28,6 +34,11 @@ export interface GraphweaverConfig {
 	adminMetadata?: AdminMetadata;
 	// We omit schema here because we will build it from your entities + schema extensions.
 	apolloServerOptions?: Omit<ApolloServerOptionsWithStaticSchema<any>, 'schema'>;
+	fastifyOptions?:
+		| FastifyHttp2SecureOptions<any>
+		| FastifyHttp2Options<any>
+		| FastifyHttpsOptions<any>
+		| FastifyHttpOptions<any>;
 	federationSubgraphName?: string;
 	enableFederationTracing?: boolean;
 	graphQLArmorOptions?: GraphQLArmorConfig;

--- a/src/packages/server/src/integrations/fastify.ts
+++ b/src/packages/server/src/integrations/fastify.ts
@@ -1,26 +1,36 @@
 import Fastify, { FastifyInstance, FastifyRegisterOptions } from 'fastify';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { Http2ServerRequest, Http2ServerResponse } from 'node:http2';
 import { ApolloServer, BaseContext } from '@apollo/server';
 import cors from '@fastify/cors';
 import fastifyApollo, { fastifyApolloDrainPlugin } from '@as-integrations/fastify';
 import { GraphweaverPlugin } from '@exogee/graphweaver';
 import { logger } from '@exogee/logger';
 import { onRequestWrapper } from './utils';
+import { GraphweaverConfig } from '../config';
 
 export type StartServerOptions = {
 	path: string;
 	port: number;
 	host?: string;
-	configureFastify?: (fastify: FastifyInstance) => Promise<void> | void;
+	configureFastify?: (
+		fastify: FastifyInstance<
+			any,
+			IncomingMessage | Http2ServerRequest,
+			ServerResponse<IncomingMessage> | Http2ServerResponse
+		>
+	) => Promise<void> | void;
 };
 
 export const startStandaloneServer = async <TContext extends BaseContext>(
 	{ port, host, path, configureFastify }: StartServerOptions,
+	{ fastifyOptions }: GraphweaverConfig,
 	apollo: ApolloServer<TContext>,
 	plugins: Set<GraphweaverPlugin<void>>
 ) => {
 	logger.info(`Starting standalone server on ${host ?? '::'}:${port}`);
 
-	const fastify = Fastify();
+	const fastify = Fastify(fastifyOptions);
 
 	await configureFastify?.(fastify);
 

--- a/src/packages/server/src/server.ts
+++ b/src/packages/server/src/server.ts
@@ -134,6 +134,12 @@ export default class Graphweaver<TContext extends BaseContext> {
 	public handler(): AWSLambda.APIGatewayProxyHandler {
 		logger.info(`Graphweaver handler called`);
 
+		if (this.config.fastifyOptions) {
+			logger.warn(
+				"Fastify options have been configured, but we're running in lambda mode, so they will be ignored."
+			);
+		}
+
 		return startServerless({
 			server: this.server,
 			graphweaverPlugins: this.graphweaverPlugins as Set<
@@ -147,6 +153,7 @@ export default class Graphweaver<TContext extends BaseContext> {
 
 		await startStandaloneServer(
 			options,
+			this.config,
 			this.server,
 			this.graphweaverPlugins as Set<GraphweaverPlugin<void>>
 		);


### PR DESCRIPTION
Adds the ability to pass options to Fastify via the Graphweaver constructor. Example:

```typescript
import Graphweaver from '@exogee/graphweaver-server';

import './schema';

export const graphweaver = new Graphweaver({
	fastifyOptions: {
		https: {
			cert: fs.readFileSync('cert.pem'),
			key: fs.readFileSync('key.pem'),
		},
	},
});
```

Note: Ensure there's no `handler` export in the backend index file or you're running in Lambda mode and this will not work.

Resolves #1203.