### PR TITLE
Fix / Common Tenant Usage with Entra

### DIFF
--- a/src/examples/microsoft-entra/.env.example
+++ b/src/examples/microsoft-entra/.env.example
@@ -2,11 +2,13 @@ AUTH_BASE_URI="http://localhost:9000"
 AUTH_WHITELIST_DOMAINS="localhost" 
 AUTH_JWT_ALGORITHM="RS256" 
 
-# If you haven't specified a tenant ID below, use this value
-AUTH_JWKS_URI="https://login.microsoftonline.com/common/discovery/v2.0/keys?appId=[YOUR_CLIENT_ID]"
-
-# If you have, place your tenant ID in the URL and use this value
-# AUTH_JWKS_URI="https://login.microsoftonline.com/[TENANT_ID]/discovery/v2.0/keys?appId=[YOUR_CLIENT_ID]"
-
+# Your client ID is the ID of the app registration in Entra
 VITE_MICROSOFT_ENTRA_CLIENT_ID="YOUR_ENTRA_CLIENT_ID"
-VITE_MICROSOFT_ENTRA_TENANT_ID="[OPTIONAL, supply if you need to not use the 'common' tenant]"
+
+# If your app is single-tenant (e.g. just for your company), specify your tenant ID in the values here
+# AUTH_JWKS_URI="https://login.microsoftonline.com/[TENANT_ID]/discovery/v2.0/keys?appId=[YOUR_CLIENT_ID]"
+# VITE_MICROSOFT_ENTRA_TENANT_ID="[TENANT_ID]"
+
+# Otherwise use 'common' to allow any tenant to authenticate
+AUTH_JWKS_URI="https://login.microsoftonline.com/common/discovery/v2.0/keys?appId=[YOUR_CLIENT_ID]"
+VITE_MICROSOFT_ENTRA_TENANT_ID="common"

--- a/src/packages/auth-ui-components/src/components/microsoft-entra/login/component.tsx
+++ b/src/packages/auth-ui-components/src/components/microsoft-entra/login/component.tsx
@@ -58,6 +58,7 @@ export const MicrosoftEntra = () => {
 			// "interaction_in_progress" is a specific error that is expected to be generated when the user is already in the process of logging out.
 			// Everything works fine, so there's no reason to trouble the user with it.
 			if (error.message && error.errorCode !== 'interaction_in_progress') {
+				console.error(error);
 				setError(error.message);
 				setLoading(false);
 			} else if (error.errorCode === 'interaction_in_progress') {


### PR DESCRIPTION
This PR:

* Updates the example .env file to make it clear how to use the 'common' tenant with Entra auth.
* Adds console logging for errors that are caught by the login component instead of swallowing them and just printing the message.