### PR TITLE
Chore / Save GitHub Actions Minutes with Jira Linker Action

### DIFF
--- a/.github/workflows/jira-linker.yml
+++ b/.github/workflows/jira-linker.yml
@@ -1,5 +1,8 @@
 name: action-jira-linker
-on: [pull_request]
+on:
+  pull_request:
+    types:
+      - opened
 
 jobs:
   action-jira-linker:


### PR DESCRIPTION
We only need to run the Jira linker when the PR is initially opened, so this will save some billable minutes in GitHub Actions.