### PR TITLE
Chore / Remove vite-plugin-svgr

### DIFF
--- a/src/packages/admin-ui-components/package.json
+++ b/src/packages/admin-ui-components/package.json
@@ -61,8 +61,7 @@
 		"react-dom": "18.3.1",
 		"react-router-dom": "6.26.2",
 		"typescript": "5.6.3",
-		"vite": "5.4.8",
-		"vite-plugin-svgr": "4.2.0"
+		"vite": "5.4.8"
 	},
 	"keywords": [
 		"graphql",

--- a/src/packages/admin-ui/package.json
+++ b/src/packages/admin-ui/package.json
@@ -42,7 +42,6 @@
 		"esbuild-plugin-copy": "2.1.1",
 		"glob": "10.4.3",
 		"typescript": "5.6.3",
-		"vite-plugin-svgr": "4.2.0",
 		"vite": "5.4.8"
 	},
 	"keywords": [

--- a/src/packages/auth-ui-components/package.json
+++ b/src/packages/auth-ui-components/package.json
@@ -53,8 +53,7 @@
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
 		"typescript": "5.6.3",
-		"vite": "5.4.8",
-		"vite-plugin-svgr": "4.2.0"
+		"vite": "5.4.8"
 	},
 	"keywords": [
 		"graphql",

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -82,10 +82,10 @@ importers:
         version: 6.3.13
       '@mikro-orm/knex':
         specifier: 6.3.13
-        version: 6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.1)(sqlite3@5.1.7)
+        version: 6.3.13(@mikro-orm/core@6.3.13)
       '@mikro-orm/sqlite':
         specifier: 6.3.13
-        version: 6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.1)
+        version: 6.3.13(@mikro-orm/core@6.3.13)
       graphql:
         specifier: 16.9.0
         version: 16.9.0
@@ -281,10 +281,10 @@ importers:
         version: 6.3.13
       '@mikro-orm/knex':
         specifier: 6.3.13
-        version: 6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.1)(sqlite3@5.1.7)
+        version: 6.3.13(@mikro-orm/core@6.3.13)
       '@mikro-orm/sqlite':
         specifier: 6.3.13
-        version: 6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.1)
+        version: 6.3.13(@mikro-orm/core@6.3.13)
       graphql:
         specifier: 16.9.0
         version: 16.9.0
@@ -321,10 +321,10 @@ importers:
         version: 6.3.13
       '@mikro-orm/knex':
         specifier: 6.3.13
-        version: 6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.1)(sqlite3@5.1.7)
+        version: 6.3.13(@mikro-orm/core@6.3.13)
       '@mikro-orm/mysql':
         specifier: 6.3.13
-        version: 6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.0)
+        version: 6.3.13(@mikro-orm/core@6.3.13)
       dotenv:
         specifier: 16.4.5
         version: 16.4.5
@@ -373,7 +373,7 @@ importers:
         version: 6.3.13
       '@mikro-orm/mysql':
         specifier: 6.3.13
-        version: 6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.0)
+        version: 6.3.13(@mikro-orm/core@6.3.13)
       dotenv:
         specifier: 16.4.5
         version: 16.4.5
@@ -440,7 +440,7 @@ importers:
         version: 6.3.13
       '@mikro-orm/knex':
         specifier: 6.3.13
-        version: 6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.1)(sqlite3@5.1.7)
+        version: 6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.1)
       '@mikro-orm/postgresql':
         specifier: 6.3.13
         version: 6.3.13(@mikro-orm/core@6.3.13)
@@ -498,10 +498,10 @@ importers:
         version: 6.3.13
       '@mikro-orm/knex':
         specifier: 6.3.13
-        version: 6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.1)(sqlite3@5.1.7)
+        version: 6.3.13(@mikro-orm/core@6.3.13)
       '@mikro-orm/sqlite':
         specifier: 6.3.13
-        version: 6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.1)
+        version: 6.3.13(@mikro-orm/core@6.3.13)
       graphql:
         specifier: 16.9.0
         version: 16.9.0
@@ -679,9 +679,6 @@ importers:
       vite:
         specifier: 5.4.8
         version: 5.4.8(@types/node@22.7.5)(lightningcss@1.27.0)
-      vite-plugin-svgr:
-        specifier: 4.2.0
-        version: 4.2.0(rollup@4.22.4)(typescript@5.6.3)(vite@5.4.8(@types/node@22.7.5)(lightningcss@1.27.0))
 
   packages/admin-ui-components:
     dependencies:
@@ -770,9 +767,6 @@ importers:
       vite:
         specifier: 5.4.8
         version: 5.4.8(@types/node@22.7.5)(lightningcss@1.27.0)
-      vite-plugin-svgr:
-        specifier: 4.2.0
-        version: 4.2.0(rollup@4.22.4)(typescript@5.6.3)(vite@5.4.8(@types/node@22.7.5)(lightningcss@1.27.0))
 
   packages/apollo-client:
     devDependencies:
@@ -931,9 +925,6 @@ importers:
       vite:
         specifier: 5.4.8
         version: 5.4.8(@types/node@22.7.5)(lightningcss@1.27.0)
-      vite-plugin-svgr:
-        specifier: 4.2.0
-        version: 4.2.0(rollup@4.22.4)(typescript@5.6.3)(vite@5.4.8(@types/node@22.7.5)(lightningcss@1.27.0))
 
   packages/aws-cognito:
     dependencies:
@@ -1386,10 +1377,10 @@ importers:
     dependencies:
       '@mikro-orm/knex':
         specifier: 6.3.13
-        version: 6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.1)(sqlite3@5.1.7)
+        version: 6.3.13(@mikro-orm/core@6.3.13)
       '@mikro-orm/sqlite':
         specifier: 6.3.13
-        version: 6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.1)
+        version: 6.3.13(@mikro-orm/core@6.3.13)
       node-sqlite3-wasm:
         specifier: 0.8.26
         version: 0.8.26
@@ -1448,7 +1439,7 @@ importers:
     optionalDependencies:
       '@mikro-orm/knex':
         specifier: 6.3.13
-        version: 6.3.13(@mikro-orm/core@6.3.13)(mysql2@3.11.3)(pg@8.13.0)
+        version: 6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.0)
       '@mikro-orm/mysql':
         specifier: 6.3.13
         version: 6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.0)
@@ -4597,15 +4588,6 @@ packages:
   '@repeaterjs/repeater@3.0.6':
     resolution: {integrity: sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==}
 
-  '@rollup/pluginutils@5.1.2':
-    resolution: {integrity: sha512-/FIdS3PyZ39bjZlwqFnWqCOVnW7o963LtKMwQOD0NhQqw22gSr2YY1afu3FxRip4ZCZNsD5jq6Aaz6QV3D/Njw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
   '@rollup/rollup-android-arm-eabi@4.22.4':
     resolution: {integrity: sha512-Fxamp4aEZnfPOcGA8KSNEohV8hX7zVHOemC8jVBoBUHu5zpJK/Eu3uJwt6BMgy9fkvzxDaurgj96F/NiLukF2w==}
     cpu: [arm]
@@ -4915,74 +4897,6 @@ packages:
   '@smithy/util-waiter@3.1.7':
     resolution: {integrity: sha512-d5yGlQtmN/z5eoTtIYgkvOw27US2Ous4VycnXatyoImIF9tzlcpnKqQ/V7qhvJmb2p6xZne1NopCLakdTnkBBQ==}
     engines: {node: '>=16.0.0'}
-
-  '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
-    resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0':
-    resolution: {integrity: sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0':
-    resolution: {integrity: sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0':
-    resolution: {integrity: sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@svgr/babel-plugin-svg-dynamic-title@8.0.0':
-    resolution: {integrity: sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@svgr/babel-plugin-svg-em-dimensions@8.0.0':
-    resolution: {integrity: sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@svgr/babel-plugin-transform-react-native-svg@8.1.0':
-    resolution: {integrity: sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@svgr/babel-plugin-transform-svg-component@8.0.0':
-    resolution: {integrity: sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@svgr/babel-preset@8.1.0':
-    resolution: {integrity: sha512-7EYDbHE7MxHpv4sxvnVPngw5fuR6pw79SkcrILHJ/iMpuKySNCl5W1qcwPEpU+LgyRXOaAFgH0KhwD18wwg6ug==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@svgr/core@8.1.0':
-    resolution: {integrity: sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==}
-    engines: {node: '>=14'}
-
-  '@svgr/hast-util-to-babel-ast@8.0.0':
-    resolution: {integrity: sha512-EbDKwO9GpfWP4jN9sGdYwPBU0kdomaPIL2Eu4YwmgP+sJeXT+L7bMwJUBnhzfH8Q2qMBqZ4fJwpCyYsAN3mt2Q==}
-    engines: {node: '>=14'}
-
-  '@svgr/plugin-jsx@8.1.0':
-    resolution: {integrity: sha512-0xiIyBsLlr8quN+WyuxooNW9RJ0Dpr8uOnH/xrCVO8GLUcwHISwj1AG0k+LFzteTkAA0GbX0kj9q6Dk70PTiPA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@svgr/core': '*'
 
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
@@ -6644,9 +6558,6 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
-
-  estree-walker@2.0.2:
-    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -9569,9 +9480,6 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svg-parser@2.0.4:
-    resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
-
   swap-case@2.0.2:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
 
@@ -9974,11 +9882,6 @@ packages:
     resolution: {integrity: sha512-kqa9v+oi4HwkG6g8ufRnb5AeplcRw8jUF6/7/Qz1qRQOXHImG8YnLbB+LLszENwFnoBl9xIf9nVdCFzNd7GQEg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
-
-  vite-plugin-svgr@4.2.0:
-    resolution: {integrity: sha512-SC7+FfVtNQk7So0XMjrrtLAbEC8qjFPifyD7+fs/E6aaNdVde6umlVVh0QuwDLdOMu7vp5RiGFsB70nj5yo0XA==}
-    peerDependencies:
-      vite: ^2.6.0 || 3 || 4 || 5
 
   vite@5.4.8:
     resolution: {integrity: sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==}
@@ -13448,6 +13351,36 @@ snapshots:
       mikro-orm: 6.3.13
       reflect-metadata: 0.2.2
 
+  '@mikro-orm/knex@6.3.13(@mikro-orm/core@6.3.13)':
+    dependencies:
+      '@mikro-orm/core': 6.3.13
+      fs-extra: 11.2.0
+      knex: 3.1.0
+      sqlstring: 2.3.3
+    transitivePeerDependencies:
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+
+  '@mikro-orm/knex@6.3.13(@mikro-orm/core@6.3.13)(mysql2@3.11.3)':
+    dependencies:
+      '@mikro-orm/core': 6.3.13
+      fs-extra: 11.2.0
+      knex: 3.1.0(mysql2@3.11.3)
+      sqlstring: 2.3.3
+    transitivePeerDependencies:
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+
   '@mikro-orm/knex@6.3.13(@mikro-orm/core@6.3.13)(mysql2@3.11.3)(pg@8.13.0)':
     dependencies:
       '@mikro-orm/core': 6.3.13
@@ -13462,6 +13395,7 @@ snapshots:
       - sqlite3
       - supports-color
       - tedious
+    optional: true
 
   '@mikro-orm/knex@6.3.13(@mikro-orm/core@6.3.13)(mysql2@3.11.3)(pg@8.13.1)':
     dependencies:
@@ -13508,6 +13442,21 @@ snapshots:
       - supports-color
       - tedious
 
+  '@mikro-orm/knex@6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.0)':
+    dependencies:
+      '@mikro-orm/core': 6.3.13
+      fs-extra: 11.2.0
+      knex: 3.1.0(pg@8.13.0)
+      sqlstring: 2.3.3
+    transitivePeerDependencies:
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+
   '@mikro-orm/knex@6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.0)(sqlite3@5.1.7)':
     dependencies:
       '@mikro-orm/core': 6.3.13
@@ -13524,6 +13473,21 @@ snapshots:
       - tedious
     optional: true
 
+  '@mikro-orm/knex@6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.1)':
+    dependencies:
+      '@mikro-orm/core': 6.3.13
+      fs-extra: 11.2.0
+      knex: 3.1.0(pg@8.13.1)
+      sqlstring: 2.3.3
+    transitivePeerDependencies:
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+
   '@mikro-orm/knex@6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.1)(sqlite3@5.1.7)':
     dependencies:
       '@mikro-orm/core': 6.3.13
@@ -13533,6 +13497,37 @@ snapshots:
     transitivePeerDependencies:
       - mysql
       - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+
+  '@mikro-orm/knex@6.3.13(@mikro-orm/core@6.3.13)(sqlite3@5.1.7)':
+    dependencies:
+      '@mikro-orm/core': 6.3.13
+      fs-extra: 11.2.0
+      knex: 3.1.0(sqlite3@5.1.7)
+      sqlstring: 2.3.3
+    transitivePeerDependencies:
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+
+  '@mikro-orm/mysql@6.3.13(@mikro-orm/core@6.3.13)':
+    dependencies:
+      '@mikro-orm/core': 6.3.13
+      '@mikro-orm/knex': 6.3.13(@mikro-orm/core@6.3.13)(mysql2@3.11.3)
+      mysql2: 3.11.3
+    transitivePeerDependencies:
+      - better-sqlite3
+      - libsql
+      - mariadb
+      - mysql
       - pg
       - pg-native
       - sqlite3
@@ -13554,6 +13549,7 @@ snapshots:
       - sqlite3
       - supports-color
       - tedious
+    optional: true
 
   '@mikro-orm/mysql@6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.1)':
     dependencies:
@@ -13574,7 +13570,7 @@ snapshots:
   '@mikro-orm/postgresql@6.3.13(@mikro-orm/core@6.3.13)':
     dependencies:
       '@mikro-orm/core': 6.3.13
-      '@mikro-orm/knex': 6.3.13(@mikro-orm/core@6.3.13)(mysql2@3.11.3)(pg@8.13.0)
+      '@mikro-orm/knex': 6.3.13(@mikro-orm/core@6.3.13)(pg@8.13.0)
       pg: 8.13.0
       postgres-array: 3.0.2
       postgres-date: 2.1.0
@@ -13606,6 +13602,25 @@ snapshots:
       - mysql2
       - pg-native
       - sqlite3
+      - supports-color
+      - tedious
+
+  '@mikro-orm/sqlite@6.3.13(@mikro-orm/core@6.3.13)':
+    dependencies:
+      '@mikro-orm/core': 6.3.13
+      '@mikro-orm/knex': 6.3.13(@mikro-orm/core@6.3.13)(sqlite3@5.1.7)
+      fs-extra: 11.2.0
+      sqlite3: 5.1.7
+      sqlstring-sqlite: 0.1.1
+    transitivePeerDependencies:
+      - better-sqlite3
+      - bluebird
+      - libsql
+      - mariadb
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
       - supports-color
       - tedious
 
@@ -14437,14 +14452,6 @@ snapshots:
 
   '@repeaterjs/repeater@3.0.6': {}
 
-  '@rollup/pluginutils@5.1.2(rollup@4.22.4)':
-    dependencies:
-      '@types/estree': 1.0.6
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    optionalDependencies:
-      rollup: 4.22.4
-
   '@rollup/rollup-android-arm-eabi@4.22.4':
     optional: true
 
@@ -14893,76 +14900,6 @@ snapshots:
       '@smithy/abort-controller': 3.1.6
       '@smithy/types': 3.6.0
       tslib: 2.7.0
-
-  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-
-  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-
-  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-
-  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-
-  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-
-  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-
-  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-
-  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-
-  '@svgr/babel-preset@8.1.0(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.25.2)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.25.2)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.25.2)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.25.2)
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.25.2)
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.25.2)
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.25.2)
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.25.2)
-
-  '@svgr/core@8.1.0(typescript@5.6.3)':
-    dependencies:
-      '@babel/core': 7.25.2
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.25.2)
-      camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@5.6.3)
-      snake-case: 3.0.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  '@svgr/hast-util-to-babel-ast@8.0.0':
-    dependencies:
-      '@babel/types': 7.25.6
-      entities: 4.5.0
-
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.6.3))':
-    dependencies:
-      '@babel/core': 7.25.2
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.25.2)
-      '@svgr/core': 8.1.0(typescript@5.6.3)
-      '@svgr/hast-util-to-babel-ast': 8.0.0
-      svg-parser: 2.0.4
-    transitivePeerDependencies:
-      - supports-color
 
   '@szmarczak/http-timer@4.0.6':
     dependencies:
@@ -16924,8 +16861,6 @@ snapshots:
 
   estraverse@5.3.0: {}
 
-  estree-walker@2.0.2: {}
-
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.6
@@ -18503,6 +18438,46 @@ snapshots:
 
   kleur@3.0.3: {}
 
+  knex@3.1.0:
+    dependencies:
+      colorette: 2.0.19
+      commander: 10.0.1
+      debug: 4.3.4
+      escalade: 3.2.0
+      esm: 3.2.25
+      get-package-type: 0.1.0
+      getopts: 2.3.0
+      interpret: 2.2.0
+      lodash: 4.17.21
+      pg-connection-string: 2.6.2
+      rechoir: 0.8.0
+      resolve-from: 5.0.0
+      tarn: 3.0.2
+      tildify: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  knex@3.1.0(mysql2@3.11.3):
+    dependencies:
+      colorette: 2.0.19
+      commander: 10.0.1
+      debug: 4.3.4
+      escalade: 3.2.0
+      esm: 3.2.25
+      get-package-type: 0.1.0
+      getopts: 2.3.0
+      interpret: 2.2.0
+      lodash: 4.17.21
+      pg-connection-string: 2.6.2
+      rechoir: 0.8.0
+      resolve-from: 5.0.0
+      tarn: 3.0.2
+      tildify: 2.0.0
+    optionalDependencies:
+      mysql2: 3.11.3
+    transitivePeerDependencies:
+      - supports-color
+
   knex@3.1.0(mysql2@3.11.3)(pg@8.13.0):
     dependencies:
       colorette: 2.0.19
@@ -18524,6 +18499,7 @@ snapshots:
       pg: 8.13.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   knex@3.1.0(mysql2@3.11.3)(pg@8.13.1):
     dependencies:
@@ -18591,6 +18567,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  knex@3.1.0(pg@8.13.0):
+    dependencies:
+      colorette: 2.0.19
+      commander: 10.0.1
+      debug: 4.3.4
+      escalade: 3.2.0
+      esm: 3.2.25
+      get-package-type: 0.1.0
+      getopts: 2.3.0
+      interpret: 2.2.0
+      lodash: 4.17.21
+      pg-connection-string: 2.6.2
+      rechoir: 0.8.0
+      resolve-from: 5.0.0
+      tarn: 3.0.2
+      tildify: 2.0.0
+    optionalDependencies:
+      pg: 8.13.0
+    transitivePeerDependencies:
+      - supports-color
+
   knex@3.1.0(pg@8.13.0)(sqlite3@5.1.7):
     dependencies:
       colorette: 2.0.19
@@ -18614,6 +18611,27 @@ snapshots:
       - supports-color
     optional: true
 
+  knex@3.1.0(pg@8.13.1):
+    dependencies:
+      colorette: 2.0.19
+      commander: 10.0.1
+      debug: 4.3.4
+      escalade: 3.2.0
+      esm: 3.2.25
+      get-package-type: 0.1.0
+      getopts: 2.3.0
+      interpret: 2.2.0
+      lodash: 4.17.21
+      pg-connection-string: 2.6.2
+      rechoir: 0.8.0
+      resolve-from: 5.0.0
+      tarn: 3.0.2
+      tildify: 2.0.0
+    optionalDependencies:
+      pg: 8.13.1
+    transitivePeerDependencies:
+      - supports-color
+
   knex@3.1.0(pg@8.13.1)(sqlite3@5.1.7):
     dependencies:
       colorette: 2.0.19
@@ -18632,6 +18650,27 @@ snapshots:
       tildify: 2.0.0
     optionalDependencies:
       pg: 8.13.1
+      sqlite3: 5.1.7
+    transitivePeerDependencies:
+      - supports-color
+
+  knex@3.1.0(sqlite3@5.1.7):
+    dependencies:
+      colorette: 2.0.19
+      commander: 10.0.1
+      debug: 4.3.4
+      escalade: 3.2.0
+      esm: 3.2.25
+      get-package-type: 0.1.0
+      getopts: 2.3.0
+      interpret: 2.2.0
+      lodash: 4.17.21
+      pg-connection-string: 2.6.2
+      rechoir: 0.8.0
+      resolve-from: 5.0.0
+      tarn: 3.0.2
+      tildify: 2.0.0
+    optionalDependencies:
       sqlite3: 5.1.7
     transitivePeerDependencies:
       - supports-color
@@ -20438,8 +20477,6 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svg-parser@2.0.4: {}
-
   swap-case@2.0.2:
     dependencies:
       tslib: 2.7.0
@@ -20803,17 +20840,6 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-
-  vite-plugin-svgr@4.2.0(rollup@4.22.4)(typescript@5.6.3)(vite@5.4.8(@types/node@22.7.5)(lightningcss@1.27.0)):
-    dependencies:
-      '@rollup/pluginutils': 5.1.2(rollup@4.22.4)
-      '@svgr/core': 8.1.0(typescript@5.6.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.6.3))
-      vite: 5.4.8(@types/node@22.7.5)(lightningcss@1.27.0)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-      - typescript
 
   vite@5.4.8(@types/node@22.7.5)(lightningcss@1.27.0):
     dependencies:


### PR DESCRIPTION
Since we're no longer using it we can completely remove `vite-plugin-svgr`.