### PR TITLE
Allow addUserToContext exceptions into logs

### DIFF
--- a/src/packages/auth/src/authentication/apollo/plugin.ts
+++ b/src/packages/auth/src/authentication/apollo/plugin.ts
@@ -227,7 +227,7 @@ export const authApolloPlugin = <R>(
 
 						upsertAuthorizationContext(contextValue);
 					} catch (err: unknown) {
-						logger.trace(`JWT verification failed. ${err}`);
+						logger.error(`JWT verification failed. ${err}`);
 						tokenVerificationFailed = true;
 					}
 				}

--- a/src/packages/auth/src/authentication/apollo/plugin.ts
+++ b/src/packages/auth/src/authentication/apollo/plugin.ts
@@ -227,7 +227,7 @@ export const authApolloPlugin = <R>(
 
 						upsertAuthorizationContext(contextValue);
 					} catch (err: unknown) {
-						logger.error(`JWT verification failed. ${err}`);
+						logger.error({ err }, 'JWT verification failed.');
 						tokenVerificationFailed = true;
 					}
 				}


### PR DESCRIPTION
Small PR to address the issue recorded in https://github.com/exogee-technology/graphweaver/issues/1190. The message of an exception thrown anywhere during the auth processing in `authApolloPlugin` gets appended to the generic message `JWT verification failed. `.

There's many individual steps that can all individually fail within this `try` block. It could almost justify some [railway oriented programming](https://www.jonminter.dev/posts/railway-oriented-programming-async/) to handle the happy vs sad paths, that felt like a bit of a rabbit hole in the code base where it's not already used though.