### PR TITLE
Chore / Restore JIRA Linker

### DIFF
--- a/.github/workflows/jira-linker.yml
+++ b/.github/workflows/jira-linker.yml
@@ -1,8 +1,5 @@
 name: action-jira-linker
-on:
-  pull_request:
-    types:
-      - opened
+on: [pull_request]
 
 jobs:
   action-jira-linker:


### PR DESCRIPTION
Jira linker is no longer running. This will restore it.