### PR TITLE
Fix / Restore missing `_and` and `_or` in schema generation for filters

### DIFF
--- a/src/examples/auth-zero/src/frontend/types.generated.ts
+++ b/src/examples/auth-zero/src/frontend/types.generated.ts
@@ -168,6 +168,9 @@ export type AlbumUpdateInput = {
 };
 
 export type AlbumsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
+  _not?: InputMaybe<AlbumsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
   albumId?: InputMaybe<Scalars['ID']['input']>;
   albumId_gt?: InputMaybe<Scalars['ID']['input']>;
   albumId_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -230,6 +233,9 @@ export type ApiKeyUpdateInput = {
 };
 
 export type ApiKeysListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
+  _not?: InputMaybe<ApiKeysListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -299,6 +305,9 @@ export type ArtistUpdateInput = {
 };
 
 export type ArtistsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
+  _not?: InputMaybe<ArtistsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
   albums?: InputMaybe<AlbumsListFilter>;
   artistId?: InputMaybe<Scalars['ID']['input']>;
   artistId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -356,6 +365,9 @@ export type CredentialUpdateInput = {
 };
 
 export type CredentialsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
+  _not?: InputMaybe<CredentialsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -474,6 +486,9 @@ export type CustomerUpdateInput = {
 };
 
 export type CustomersListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
+  _not?: InputMaybe<CustomersListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
   address_gte?: InputMaybe<Scalars['String']['input']>;
@@ -763,6 +778,9 @@ export type EmployeeUpdateInput = {
 };
 
 export type EmployeesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
+  _not?: InputMaybe<EmployeesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
   address_gte?: InputMaybe<Scalars['String']['input']>;
@@ -993,6 +1011,9 @@ export type GenreUpdateInput = {
 };
 
 export type GenresListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
+  _not?: InputMaybe<GenresListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
   genreId?: InputMaybe<Scalars['ID']['input']>;
   genreId_gt?: InputMaybe<Scalars['ID']['input']>;
   genreId_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -1151,6 +1172,9 @@ export type InvoiceLineUpdateInput = {
 };
 
 export type InvoiceLinesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
+  _not?: InputMaybe<InvoiceLinesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
   invoice?: InputMaybe<InvoicesListFilter>;
   invoiceLineId?: InputMaybe<Scalars['ID']['input']>;
   invoiceLineId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -1211,6 +1235,9 @@ export type InvoiceUpdateInput = {
 };
 
 export type InvoicesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
+  _not?: InputMaybe<InvoicesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
   billingAddress?: InputMaybe<Scalars['String']['input']>;
   billingAddress_gt?: InputMaybe<Scalars['String']['input']>;
   billingAddress_gte?: InputMaybe<Scalars['String']['input']>;
@@ -1364,6 +1391,9 @@ export type MediaTypeUpdateInput = {
 };
 
 export type MediaTypesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
+  _not?: InputMaybe<MediaTypesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
   mediaTypeId?: InputMaybe<Scalars['ID']['input']>;
   mediaTypeId_gt?: InputMaybe<Scalars['ID']['input']>;
   mediaTypeId_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -1952,6 +1982,9 @@ export type PlaylistUpdateInput = {
 };
 
 export type PlaylistsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
+  _not?: InputMaybe<PlaylistsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
   name?: InputMaybe<Scalars['String']['input']>;
   name_gt?: InputMaybe<Scalars['String']['input']>;
   name_gte?: InputMaybe<Scalars['String']['input']>;
@@ -2340,6 +2373,9 @@ export type TrackUpdateInput = {
 };
 
 export type TracksListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
+  _not?: InputMaybe<TracksListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
   album?: InputMaybe<AlbumsListFilter>;
   bytes?: InputMaybe<Scalars['Float']['input']>;
   bytes_in?: InputMaybe<Array<Scalars['Float']['input']>>;

--- a/src/examples/auth-zero/src/frontend/types.generated.ts
+++ b/src/examples/auth-zero/src/frontend/types.generated.ts
@@ -169,7 +169,6 @@ export type AlbumUpdateInput = {
 
 export type AlbumsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
-  _not?: InputMaybe<AlbumsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
   albumId?: InputMaybe<Scalars['ID']['input']>;
   albumId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -234,7 +233,6 @@ export type ApiKeyUpdateInput = {
 
 export type ApiKeysListFilter = {
   _and?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
-  _not?: InputMaybe<ApiKeysListFilter>;
   _or?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -306,7 +304,6 @@ export type ArtistUpdateInput = {
 
 export type ArtistsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
-  _not?: InputMaybe<ArtistsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
   albums?: InputMaybe<AlbumsListFilter>;
   artistId?: InputMaybe<Scalars['ID']['input']>;
@@ -366,7 +363,6 @@ export type CredentialUpdateInput = {
 
 export type CredentialsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
-  _not?: InputMaybe<CredentialsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -487,7 +483,6 @@ export type CustomerUpdateInput = {
 
 export type CustomersListFilter = {
   _and?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
-  _not?: InputMaybe<CustomersListFilter>;
   _or?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
@@ -779,7 +774,6 @@ export type EmployeeUpdateInput = {
 
 export type EmployeesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
-  _not?: InputMaybe<EmployeesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
@@ -1012,7 +1006,6 @@ export type GenreUpdateInput = {
 
 export type GenresListFilter = {
   _and?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
-  _not?: InputMaybe<GenresListFilter>;
   _or?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
   genreId?: InputMaybe<Scalars['ID']['input']>;
   genreId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -1173,7 +1166,6 @@ export type InvoiceLineUpdateInput = {
 
 export type InvoiceLinesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
-  _not?: InputMaybe<InvoiceLinesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
   invoice?: InputMaybe<InvoicesListFilter>;
   invoiceLineId?: InputMaybe<Scalars['ID']['input']>;
@@ -1236,7 +1228,6 @@ export type InvoiceUpdateInput = {
 
 export type InvoicesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
-  _not?: InputMaybe<InvoicesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
   billingAddress?: InputMaybe<Scalars['String']['input']>;
   billingAddress_gt?: InputMaybe<Scalars['String']['input']>;
@@ -1392,7 +1383,6 @@ export type MediaTypeUpdateInput = {
 
 export type MediaTypesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
-  _not?: InputMaybe<MediaTypesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
   mediaTypeId?: InputMaybe<Scalars['ID']['input']>;
   mediaTypeId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -1983,7 +1973,6 @@ export type PlaylistUpdateInput = {
 
 export type PlaylistsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
-  _not?: InputMaybe<PlaylistsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
   name?: InputMaybe<Scalars['String']['input']>;
   name_gt?: InputMaybe<Scalars['String']['input']>;
@@ -2374,7 +2363,6 @@ export type TrackUpdateInput = {
 
 export type TracksListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
-  _not?: InputMaybe<TracksListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
   album?: InputMaybe<AlbumsListFilter>;
   bytes?: InputMaybe<Scalars['Float']['input']>;

--- a/src/examples/auth-zero/src/types.generated.ts
+++ b/src/examples/auth-zero/src/types.generated.ts
@@ -168,6 +168,9 @@ export type AlbumUpdateInput = {
 };
 
 export type AlbumsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
+  _not?: InputMaybe<AlbumsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
   albumId?: InputMaybe<Scalars['ID']['input']>;
   albumId_gt?: InputMaybe<Scalars['ID']['input']>;
   albumId_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -230,6 +233,9 @@ export type ApiKeyUpdateInput = {
 };
 
 export type ApiKeysListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
+  _not?: InputMaybe<ApiKeysListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -299,6 +305,9 @@ export type ArtistUpdateInput = {
 };
 
 export type ArtistsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
+  _not?: InputMaybe<ArtistsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
   albums?: InputMaybe<AlbumsListFilter>;
   artistId?: InputMaybe<Scalars['ID']['input']>;
   artistId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -356,6 +365,9 @@ export type CredentialUpdateInput = {
 };
 
 export type CredentialsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
+  _not?: InputMaybe<CredentialsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -474,6 +486,9 @@ export type CustomerUpdateInput = {
 };
 
 export type CustomersListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
+  _not?: InputMaybe<CustomersListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
   address_gte?: InputMaybe<Scalars['String']['input']>;
@@ -763,6 +778,9 @@ export type EmployeeUpdateInput = {
 };
 
 export type EmployeesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
+  _not?: InputMaybe<EmployeesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
   address_gte?: InputMaybe<Scalars['String']['input']>;
@@ -993,6 +1011,9 @@ export type GenreUpdateInput = {
 };
 
 export type GenresListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
+  _not?: InputMaybe<GenresListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
   genreId?: InputMaybe<Scalars['ID']['input']>;
   genreId_gt?: InputMaybe<Scalars['ID']['input']>;
   genreId_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -1151,6 +1172,9 @@ export type InvoiceLineUpdateInput = {
 };
 
 export type InvoiceLinesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
+  _not?: InputMaybe<InvoiceLinesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
   invoice?: InputMaybe<InvoicesListFilter>;
   invoiceLineId?: InputMaybe<Scalars['ID']['input']>;
   invoiceLineId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -1211,6 +1235,9 @@ export type InvoiceUpdateInput = {
 };
 
 export type InvoicesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
+  _not?: InputMaybe<InvoicesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
   billingAddress?: InputMaybe<Scalars['String']['input']>;
   billingAddress_gt?: InputMaybe<Scalars['String']['input']>;
   billingAddress_gte?: InputMaybe<Scalars['String']['input']>;
@@ -1364,6 +1391,9 @@ export type MediaTypeUpdateInput = {
 };
 
 export type MediaTypesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
+  _not?: InputMaybe<MediaTypesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
   mediaTypeId?: InputMaybe<Scalars['ID']['input']>;
   mediaTypeId_gt?: InputMaybe<Scalars['ID']['input']>;
   mediaTypeId_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -1952,6 +1982,9 @@ export type PlaylistUpdateInput = {
 };
 
 export type PlaylistsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
+  _not?: InputMaybe<PlaylistsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
   name?: InputMaybe<Scalars['String']['input']>;
   name_gt?: InputMaybe<Scalars['String']['input']>;
   name_gte?: InputMaybe<Scalars['String']['input']>;
@@ -2340,6 +2373,9 @@ export type TrackUpdateInput = {
 };
 
 export type TracksListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
+  _not?: InputMaybe<TracksListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
   album?: InputMaybe<AlbumsListFilter>;
   bytes?: InputMaybe<Scalars['Float']['input']>;
   bytes_in?: InputMaybe<Array<Scalars['Float']['input']>>;

--- a/src/examples/auth-zero/src/types.generated.ts
+++ b/src/examples/auth-zero/src/types.generated.ts
@@ -169,7 +169,6 @@ export type AlbumUpdateInput = {
 
 export type AlbumsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
-  _not?: InputMaybe<AlbumsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
   albumId?: InputMaybe<Scalars['ID']['input']>;
   albumId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -234,7 +233,6 @@ export type ApiKeyUpdateInput = {
 
 export type ApiKeysListFilter = {
   _and?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
-  _not?: InputMaybe<ApiKeysListFilter>;
   _or?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -306,7 +304,6 @@ export type ArtistUpdateInput = {
 
 export type ArtistsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
-  _not?: InputMaybe<ArtistsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
   albums?: InputMaybe<AlbumsListFilter>;
   artistId?: InputMaybe<Scalars['ID']['input']>;
@@ -366,7 +363,6 @@ export type CredentialUpdateInput = {
 
 export type CredentialsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
-  _not?: InputMaybe<CredentialsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -487,7 +483,6 @@ export type CustomerUpdateInput = {
 
 export type CustomersListFilter = {
   _and?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
-  _not?: InputMaybe<CustomersListFilter>;
   _or?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
@@ -779,7 +774,6 @@ export type EmployeeUpdateInput = {
 
 export type EmployeesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
-  _not?: InputMaybe<EmployeesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
@@ -1012,7 +1006,6 @@ export type GenreUpdateInput = {
 
 export type GenresListFilter = {
   _and?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
-  _not?: InputMaybe<GenresListFilter>;
   _or?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
   genreId?: InputMaybe<Scalars['ID']['input']>;
   genreId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -1173,7 +1166,6 @@ export type InvoiceLineUpdateInput = {
 
 export type InvoiceLinesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
-  _not?: InputMaybe<InvoiceLinesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
   invoice?: InputMaybe<InvoicesListFilter>;
   invoiceLineId?: InputMaybe<Scalars['ID']['input']>;
@@ -1236,7 +1228,6 @@ export type InvoiceUpdateInput = {
 
 export type InvoicesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
-  _not?: InputMaybe<InvoicesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
   billingAddress?: InputMaybe<Scalars['String']['input']>;
   billingAddress_gt?: InputMaybe<Scalars['String']['input']>;
@@ -1392,7 +1383,6 @@ export type MediaTypeUpdateInput = {
 
 export type MediaTypesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
-  _not?: InputMaybe<MediaTypesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
   mediaTypeId?: InputMaybe<Scalars['ID']['input']>;
   mediaTypeId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -1983,7 +1973,6 @@ export type PlaylistUpdateInput = {
 
 export type PlaylistsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
-  _not?: InputMaybe<PlaylistsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
   name?: InputMaybe<Scalars['String']['input']>;
   name_gt?: InputMaybe<Scalars['String']['input']>;
@@ -2374,7 +2363,6 @@ export type TrackUpdateInput = {
 
 export type TracksListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
-  _not?: InputMaybe<TracksListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
   album?: InputMaybe<AlbumsListFilter>;
   bytes?: InputMaybe<Scalars['Float']['input']>;

--- a/src/examples/aws-cognito/src/frontend/types.generated.ts
+++ b/src/examples/aws-cognito/src/frontend/types.generated.ts
@@ -157,7 +157,6 @@ export type CognitoUserUpdateInput = {
 
 export type CognitoUsersListFilter = {
   _and?: InputMaybe<Array<InputMaybe<CognitoUsersListFilter>>>;
-  _not?: InputMaybe<CognitoUsersListFilter>;
   _or?: InputMaybe<Array<InputMaybe<CognitoUsersListFilter>>>;
   attributes?: InputMaybe<Scalars['String']['input']>;
   attributes_gt?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/aws-cognito/src/frontend/types.generated.ts
+++ b/src/examples/aws-cognito/src/frontend/types.generated.ts
@@ -156,6 +156,9 @@ export type CognitoUserUpdateInput = {
 };
 
 export type CognitoUsersListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<CognitoUsersListFilter>>>;
+  _not?: InputMaybe<CognitoUsersListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<CognitoUsersListFilter>>>;
   attributes?: InputMaybe<Scalars['String']['input']>;
   attributes_gt?: InputMaybe<Scalars['String']['input']>;
   attributes_gte?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/aws-cognito/src/types.generated.ts
+++ b/src/examples/aws-cognito/src/types.generated.ts
@@ -157,7 +157,6 @@ export type CognitoUserUpdateInput = {
 
 export type CognitoUsersListFilter = {
   _and?: InputMaybe<Array<InputMaybe<CognitoUsersListFilter>>>;
-  _not?: InputMaybe<CognitoUsersListFilter>;
   _or?: InputMaybe<Array<InputMaybe<CognitoUsersListFilter>>>;
   attributes?: InputMaybe<Scalars['String']['input']>;
   attributes_gt?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/aws-cognito/src/types.generated.ts
+++ b/src/examples/aws-cognito/src/types.generated.ts
@@ -156,6 +156,9 @@ export type CognitoUserUpdateInput = {
 };
 
 export type CognitoUsersListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<CognitoUsersListFilter>>>;
+  _not?: InputMaybe<CognitoUsersListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<CognitoUsersListFilter>>>;
   attributes?: InputMaybe<Scalars['String']['input']>;
   attributes_gt?: InputMaybe<Scalars['String']['input']>;
   attributes_gte?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/databases/src/frontend/types.generated.ts
+++ b/src/examples/databases/src/frontend/types.generated.ts
@@ -336,6 +336,9 @@ export type TaskUpdateInput = {
 };
 
 export type TasksListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
+  _not?: InputMaybe<TasksListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
   createdAt?: InputMaybe<Scalars['ISOString']['input']>;
   createdAt_gt?: InputMaybe<Scalars['ISOString']['input']>;
   createdAt_gte?: InputMaybe<Scalars['ISOString']['input']>;
@@ -458,6 +461,9 @@ export type UserUpdateInput = {
 };
 
 export type UsersListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
+  _not?: InputMaybe<UsersListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
   email?: InputMaybe<Scalars['String']['input']>;
   email_gt?: InputMaybe<Scalars['String']['input']>;
   email_gte?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/databases/src/frontend/types.generated.ts
+++ b/src/examples/databases/src/frontend/types.generated.ts
@@ -337,7 +337,6 @@ export type TaskUpdateInput = {
 
 export type TasksListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
-  _not?: InputMaybe<TasksListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
   createdAt?: InputMaybe<Scalars['ISOString']['input']>;
   createdAt_gt?: InputMaybe<Scalars['ISOString']['input']>;
@@ -462,7 +461,6 @@ export type UserUpdateInput = {
 
 export type UsersListFilter = {
   _and?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
-  _not?: InputMaybe<UsersListFilter>;
   _or?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
   email?: InputMaybe<Scalars['String']['input']>;
   email_gt?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/databases/src/types.generated.ts
+++ b/src/examples/databases/src/types.generated.ts
@@ -336,6 +336,9 @@ export type TaskUpdateInput = {
 };
 
 export type TasksListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
+  _not?: InputMaybe<TasksListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
   createdAt?: InputMaybe<Scalars['ISOString']['input']>;
   createdAt_gt?: InputMaybe<Scalars['ISOString']['input']>;
   createdAt_gte?: InputMaybe<Scalars['ISOString']['input']>;
@@ -458,6 +461,9 @@ export type UserUpdateInput = {
 };
 
 export type UsersListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
+  _not?: InputMaybe<UsersListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
   email?: InputMaybe<Scalars['String']['input']>;
   email_gt?: InputMaybe<Scalars['String']['input']>;
   email_gte?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/databases/src/types.generated.ts
+++ b/src/examples/databases/src/types.generated.ts
@@ -337,7 +337,6 @@ export type TaskUpdateInput = {
 
 export type TasksListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
-  _not?: InputMaybe<TasksListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
   createdAt?: InputMaybe<Scalars['ISOString']['input']>;
   createdAt_gt?: InputMaybe<Scalars['ISOString']['input']>;
@@ -462,7 +461,6 @@ export type UserUpdateInput = {
 
 export type UsersListFilter = {
   _and?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
-  _not?: InputMaybe<UsersListFilter>;
   _or?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
   email?: InputMaybe<Scalars['String']['input']>;
   email_gt?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/federation/src/frontend/types.generated.ts
+++ b/src/examples/federation/src/frontend/types.generated.ts
@@ -231,6 +231,9 @@ export type ProductVariation = {
 };
 
 export type ProductsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<ProductsListFilter>>>;
+  _not?: InputMaybe<ProductsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<ProductsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;

--- a/src/examples/federation/src/frontend/types.generated.ts
+++ b/src/examples/federation/src/frontend/types.generated.ts
@@ -232,7 +232,6 @@ export type ProductVariation = {
 
 export type ProductsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<ProductsListFilter>>>;
-  _not?: InputMaybe<ProductsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<ProductsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;

--- a/src/examples/federation/src/types.generated.ts
+++ b/src/examples/federation/src/types.generated.ts
@@ -231,6 +231,9 @@ export type ProductVariation = {
 };
 
 export type ProductsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<ProductsListFilter>>>;
+  _not?: InputMaybe<ProductsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<ProductsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;

--- a/src/examples/federation/src/types.generated.ts
+++ b/src/examples/federation/src/types.generated.ts
@@ -232,7 +232,6 @@ export type ProductVariation = {
 
 export type ProductsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<ProductsListFilter>>>;
-  _not?: InputMaybe<ProductsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<ProductsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;

--- a/src/examples/microsoft-entra/src/frontend/types.generated.ts
+++ b/src/examples/microsoft-entra/src/frontend/types.generated.ts
@@ -168,6 +168,9 @@ export type AlbumUpdateInput = {
 };
 
 export type AlbumsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
+  _not?: InputMaybe<AlbumsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
   albumId?: InputMaybe<Scalars['ID']['input']>;
   albumId_gt?: InputMaybe<Scalars['ID']['input']>;
   albumId_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -230,6 +233,9 @@ export type ApiKeyUpdateInput = {
 };
 
 export type ApiKeysListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
+  _not?: InputMaybe<ApiKeysListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -299,6 +305,9 @@ export type ArtistUpdateInput = {
 };
 
 export type ArtistsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
+  _not?: InputMaybe<ArtistsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
   albums?: InputMaybe<AlbumsListFilter>;
   artistId?: InputMaybe<Scalars['ID']['input']>;
   artistId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -356,6 +365,9 @@ export type CredentialUpdateInput = {
 };
 
 export type CredentialsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
+  _not?: InputMaybe<CredentialsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -474,6 +486,9 @@ export type CustomerUpdateInput = {
 };
 
 export type CustomersListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
+  _not?: InputMaybe<CustomersListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
   address_gte?: InputMaybe<Scalars['String']['input']>;
@@ -763,6 +778,9 @@ export type EmployeeUpdateInput = {
 };
 
 export type EmployeesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
+  _not?: InputMaybe<EmployeesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
   address_gte?: InputMaybe<Scalars['String']['input']>;
@@ -993,6 +1011,9 @@ export type GenreUpdateInput = {
 };
 
 export type GenresListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
+  _not?: InputMaybe<GenresListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
   genreId?: InputMaybe<Scalars['ID']['input']>;
   genreId_gt?: InputMaybe<Scalars['ID']['input']>;
   genreId_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -1151,6 +1172,9 @@ export type InvoiceLineUpdateInput = {
 };
 
 export type InvoiceLinesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
+  _not?: InputMaybe<InvoiceLinesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
   invoice?: InputMaybe<InvoicesListFilter>;
   invoiceLineId?: InputMaybe<Scalars['ID']['input']>;
   invoiceLineId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -1211,6 +1235,9 @@ export type InvoiceUpdateInput = {
 };
 
 export type InvoicesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
+  _not?: InputMaybe<InvoicesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
   billingAddress?: InputMaybe<Scalars['String']['input']>;
   billingAddress_gt?: InputMaybe<Scalars['String']['input']>;
   billingAddress_gte?: InputMaybe<Scalars['String']['input']>;
@@ -1364,6 +1391,9 @@ export type MediaTypeUpdateInput = {
 };
 
 export type MediaTypesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
+  _not?: InputMaybe<MediaTypesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
   mediaTypeId?: InputMaybe<Scalars['ID']['input']>;
   mediaTypeId_gt?: InputMaybe<Scalars['ID']['input']>;
   mediaTypeId_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -1952,6 +1982,9 @@ export type PlaylistUpdateInput = {
 };
 
 export type PlaylistsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
+  _not?: InputMaybe<PlaylistsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
   name?: InputMaybe<Scalars['String']['input']>;
   name_gt?: InputMaybe<Scalars['String']['input']>;
   name_gte?: InputMaybe<Scalars['String']['input']>;
@@ -2340,6 +2373,9 @@ export type TrackUpdateInput = {
 };
 
 export type TracksListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
+  _not?: InputMaybe<TracksListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
   album?: InputMaybe<AlbumsListFilter>;
   bytes?: InputMaybe<Scalars['Float']['input']>;
   bytes_in?: InputMaybe<Array<Scalars['Float']['input']>>;

--- a/src/examples/microsoft-entra/src/frontend/types.generated.ts
+++ b/src/examples/microsoft-entra/src/frontend/types.generated.ts
@@ -169,7 +169,6 @@ export type AlbumUpdateInput = {
 
 export type AlbumsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
-  _not?: InputMaybe<AlbumsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
   albumId?: InputMaybe<Scalars['ID']['input']>;
   albumId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -234,7 +233,6 @@ export type ApiKeyUpdateInput = {
 
 export type ApiKeysListFilter = {
   _and?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
-  _not?: InputMaybe<ApiKeysListFilter>;
   _or?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -306,7 +304,6 @@ export type ArtistUpdateInput = {
 
 export type ArtistsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
-  _not?: InputMaybe<ArtistsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
   albums?: InputMaybe<AlbumsListFilter>;
   artistId?: InputMaybe<Scalars['ID']['input']>;
@@ -366,7 +363,6 @@ export type CredentialUpdateInput = {
 
 export type CredentialsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
-  _not?: InputMaybe<CredentialsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -487,7 +483,6 @@ export type CustomerUpdateInput = {
 
 export type CustomersListFilter = {
   _and?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
-  _not?: InputMaybe<CustomersListFilter>;
   _or?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
@@ -779,7 +774,6 @@ export type EmployeeUpdateInput = {
 
 export type EmployeesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
-  _not?: InputMaybe<EmployeesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
@@ -1012,7 +1006,6 @@ export type GenreUpdateInput = {
 
 export type GenresListFilter = {
   _and?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
-  _not?: InputMaybe<GenresListFilter>;
   _or?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
   genreId?: InputMaybe<Scalars['ID']['input']>;
   genreId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -1173,7 +1166,6 @@ export type InvoiceLineUpdateInput = {
 
 export type InvoiceLinesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
-  _not?: InputMaybe<InvoiceLinesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
   invoice?: InputMaybe<InvoicesListFilter>;
   invoiceLineId?: InputMaybe<Scalars['ID']['input']>;
@@ -1236,7 +1228,6 @@ export type InvoiceUpdateInput = {
 
 export type InvoicesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
-  _not?: InputMaybe<InvoicesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
   billingAddress?: InputMaybe<Scalars['String']['input']>;
   billingAddress_gt?: InputMaybe<Scalars['String']['input']>;
@@ -1392,7 +1383,6 @@ export type MediaTypeUpdateInput = {
 
 export type MediaTypesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
-  _not?: InputMaybe<MediaTypesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
   mediaTypeId?: InputMaybe<Scalars['ID']['input']>;
   mediaTypeId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -1983,7 +1973,6 @@ export type PlaylistUpdateInput = {
 
 export type PlaylistsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
-  _not?: InputMaybe<PlaylistsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
   name?: InputMaybe<Scalars['String']['input']>;
   name_gt?: InputMaybe<Scalars['String']['input']>;
@@ -2374,7 +2363,6 @@ export type TrackUpdateInput = {
 
 export type TracksListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
-  _not?: InputMaybe<TracksListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
   album?: InputMaybe<AlbumsListFilter>;
   bytes?: InputMaybe<Scalars['Float']['input']>;

--- a/src/examples/microsoft-entra/src/types.generated.ts
+++ b/src/examples/microsoft-entra/src/types.generated.ts
@@ -168,6 +168,9 @@ export type AlbumUpdateInput = {
 };
 
 export type AlbumsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
+  _not?: InputMaybe<AlbumsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
   albumId?: InputMaybe<Scalars['ID']['input']>;
   albumId_gt?: InputMaybe<Scalars['ID']['input']>;
   albumId_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -230,6 +233,9 @@ export type ApiKeyUpdateInput = {
 };
 
 export type ApiKeysListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
+  _not?: InputMaybe<ApiKeysListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -299,6 +305,9 @@ export type ArtistUpdateInput = {
 };
 
 export type ArtistsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
+  _not?: InputMaybe<ArtistsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
   albums?: InputMaybe<AlbumsListFilter>;
   artistId?: InputMaybe<Scalars['ID']['input']>;
   artistId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -356,6 +365,9 @@ export type CredentialUpdateInput = {
 };
 
 export type CredentialsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
+  _not?: InputMaybe<CredentialsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -474,6 +486,9 @@ export type CustomerUpdateInput = {
 };
 
 export type CustomersListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
+  _not?: InputMaybe<CustomersListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
   address_gte?: InputMaybe<Scalars['String']['input']>;
@@ -763,6 +778,9 @@ export type EmployeeUpdateInput = {
 };
 
 export type EmployeesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
+  _not?: InputMaybe<EmployeesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
   address_gte?: InputMaybe<Scalars['String']['input']>;
@@ -993,6 +1011,9 @@ export type GenreUpdateInput = {
 };
 
 export type GenresListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
+  _not?: InputMaybe<GenresListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
   genreId?: InputMaybe<Scalars['ID']['input']>;
   genreId_gt?: InputMaybe<Scalars['ID']['input']>;
   genreId_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -1151,6 +1172,9 @@ export type InvoiceLineUpdateInput = {
 };
 
 export type InvoiceLinesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
+  _not?: InputMaybe<InvoiceLinesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
   invoice?: InputMaybe<InvoicesListFilter>;
   invoiceLineId?: InputMaybe<Scalars['ID']['input']>;
   invoiceLineId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -1211,6 +1235,9 @@ export type InvoiceUpdateInput = {
 };
 
 export type InvoicesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
+  _not?: InputMaybe<InvoicesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
   billingAddress?: InputMaybe<Scalars['String']['input']>;
   billingAddress_gt?: InputMaybe<Scalars['String']['input']>;
   billingAddress_gte?: InputMaybe<Scalars['String']['input']>;
@@ -1364,6 +1391,9 @@ export type MediaTypeUpdateInput = {
 };
 
 export type MediaTypesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
+  _not?: InputMaybe<MediaTypesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
   mediaTypeId?: InputMaybe<Scalars['ID']['input']>;
   mediaTypeId_gt?: InputMaybe<Scalars['ID']['input']>;
   mediaTypeId_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -1952,6 +1982,9 @@ export type PlaylistUpdateInput = {
 };
 
 export type PlaylistsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
+  _not?: InputMaybe<PlaylistsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
   name?: InputMaybe<Scalars['String']['input']>;
   name_gt?: InputMaybe<Scalars['String']['input']>;
   name_gte?: InputMaybe<Scalars['String']['input']>;
@@ -2340,6 +2373,9 @@ export type TrackUpdateInput = {
 };
 
 export type TracksListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
+  _not?: InputMaybe<TracksListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
   album?: InputMaybe<AlbumsListFilter>;
   bytes?: InputMaybe<Scalars['Float']['input']>;
   bytes_in?: InputMaybe<Array<Scalars['Float']['input']>>;

--- a/src/examples/microsoft-entra/src/types.generated.ts
+++ b/src/examples/microsoft-entra/src/types.generated.ts
@@ -169,7 +169,6 @@ export type AlbumUpdateInput = {
 
 export type AlbumsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
-  _not?: InputMaybe<AlbumsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
   albumId?: InputMaybe<Scalars['ID']['input']>;
   albumId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -234,7 +233,6 @@ export type ApiKeyUpdateInput = {
 
 export type ApiKeysListFilter = {
   _and?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
-  _not?: InputMaybe<ApiKeysListFilter>;
   _or?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -306,7 +304,6 @@ export type ArtistUpdateInput = {
 
 export type ArtistsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
-  _not?: InputMaybe<ArtistsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
   albums?: InputMaybe<AlbumsListFilter>;
   artistId?: InputMaybe<Scalars['ID']['input']>;
@@ -366,7 +363,6 @@ export type CredentialUpdateInput = {
 
 export type CredentialsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
-  _not?: InputMaybe<CredentialsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -487,7 +483,6 @@ export type CustomerUpdateInput = {
 
 export type CustomersListFilter = {
   _and?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
-  _not?: InputMaybe<CustomersListFilter>;
   _or?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
@@ -779,7 +774,6 @@ export type EmployeeUpdateInput = {
 
 export type EmployeesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
-  _not?: InputMaybe<EmployeesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
@@ -1012,7 +1006,6 @@ export type GenreUpdateInput = {
 
 export type GenresListFilter = {
   _and?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
-  _not?: InputMaybe<GenresListFilter>;
   _or?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
   genreId?: InputMaybe<Scalars['ID']['input']>;
   genreId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -1173,7 +1166,6 @@ export type InvoiceLineUpdateInput = {
 
 export type InvoiceLinesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
-  _not?: InputMaybe<InvoiceLinesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
   invoice?: InputMaybe<InvoicesListFilter>;
   invoiceLineId?: InputMaybe<Scalars['ID']['input']>;
@@ -1236,7 +1228,6 @@ export type InvoiceUpdateInput = {
 
 export type InvoicesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
-  _not?: InputMaybe<InvoicesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
   billingAddress?: InputMaybe<Scalars['String']['input']>;
   billingAddress_gt?: InputMaybe<Scalars['String']['input']>;
@@ -1392,7 +1383,6 @@ export type MediaTypeUpdateInput = {
 
 export type MediaTypesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
-  _not?: InputMaybe<MediaTypesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
   mediaTypeId?: InputMaybe<Scalars['ID']['input']>;
   mediaTypeId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -1983,7 +1973,6 @@ export type PlaylistUpdateInput = {
 
 export type PlaylistsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
-  _not?: InputMaybe<PlaylistsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
   name?: InputMaybe<Scalars['String']['input']>;
   name_gt?: InputMaybe<Scalars['String']['input']>;
@@ -2374,7 +2363,6 @@ export type TrackUpdateInput = {
 
 export type TracksListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
-  _not?: InputMaybe<TracksListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
   album?: InputMaybe<AlbumsListFilter>;
   bytes?: InputMaybe<Scalars['Float']['input']>;

--- a/src/examples/rest-with-auth/src/frontend/types.generated.ts
+++ b/src/examples/rest-with-auth/src/frontend/types.generated.ts
@@ -141,7 +141,6 @@ export type ApiKeyUpdateInput = {
 
 export type ApiKeysListFilter = {
   _and?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
-  _not?: InputMaybe<ApiKeysListFilter>;
   _or?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -211,7 +210,6 @@ export type CredentialUpdateInput = {
 
 export type CredentialsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
-  _not?: InputMaybe<CredentialsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -686,7 +684,6 @@ export type TagUpdateInput = {
 
 export type TagsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TagsListFilter>>>;
-  _not?: InputMaybe<TagsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TagsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -768,7 +765,6 @@ export type TaskCountByTagTag_AggregateArgs = {
 
 export type TaskCountByTagsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TaskCountByTagsListFilter>>>;
-  _not?: InputMaybe<TaskCountByTagsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TaskCountByTagsListFilter>>>;
   count?: InputMaybe<Scalars['Float']['input']>;
   count_in?: InputMaybe<Array<Scalars['Float']['input']>>;
@@ -835,7 +831,6 @@ export type TaskUpdateInput = {
 
 export type TasksListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
-  _not?: InputMaybe<TasksListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
   description?: InputMaybe<Scalars['String']['input']>;
   description_gt?: InputMaybe<Scalars['String']['input']>;
@@ -931,7 +926,6 @@ export type Trace = {
 
 export type TracesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
-  _not?: InputMaybe<TracesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
   attributes?: InputMaybe<Scalars['JSON']['input']>;
   attributes_in?: InputMaybe<Array<Scalars['JSON']['input']>>;
@@ -1057,7 +1051,6 @@ export type UserTasks_AggregateArgs = {
 
 export type UsersListFilter = {
   _and?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
-  _not?: InputMaybe<UsersListFilter>;
   _or?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
   name?: InputMaybe<Scalars['String']['input']>;
   name_gt?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/rest-with-auth/src/frontend/types.generated.ts
+++ b/src/examples/rest-with-auth/src/frontend/types.generated.ts
@@ -140,6 +140,9 @@ export type ApiKeyUpdateInput = {
 };
 
 export type ApiKeysListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
+  _not?: InputMaybe<ApiKeysListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -207,6 +210,9 @@ export type CredentialUpdateInput = {
 };
 
 export type CredentialsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
+  _not?: InputMaybe<CredentialsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -679,6 +685,9 @@ export type TagUpdateInput = {
 };
 
 export type TagsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TagsListFilter>>>;
+  _not?: InputMaybe<TagsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TagsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -758,6 +767,9 @@ export type TaskCountByTagTag_AggregateArgs = {
 };
 
 export type TaskCountByTagsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TaskCountByTagsListFilter>>>;
+  _not?: InputMaybe<TaskCountByTagsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TaskCountByTagsListFilter>>>;
   count?: InputMaybe<Scalars['Float']['input']>;
   count_in?: InputMaybe<Array<Scalars['Float']['input']>>;
   count_ne?: InputMaybe<Scalars['Float']['input']>;
@@ -822,6 +834,9 @@ export type TaskUpdateInput = {
 };
 
 export type TasksListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
+  _not?: InputMaybe<TasksListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
   description?: InputMaybe<Scalars['String']['input']>;
   description_gt?: InputMaybe<Scalars['String']['input']>;
   description_gte?: InputMaybe<Scalars['String']['input']>;
@@ -915,6 +930,9 @@ export type Trace = {
 };
 
 export type TracesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
+  _not?: InputMaybe<TracesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
   attributes?: InputMaybe<Scalars['JSON']['input']>;
   attributes_in?: InputMaybe<Array<Scalars['JSON']['input']>>;
   attributes_ne?: InputMaybe<Scalars['JSON']['input']>;
@@ -1038,6 +1056,9 @@ export type UserTasks_AggregateArgs = {
 };
 
 export type UsersListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
+  _not?: InputMaybe<UsersListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
   name?: InputMaybe<Scalars['String']['input']>;
   name_gt?: InputMaybe<Scalars['String']['input']>;
   name_gte?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/rest-with-auth/src/types.generated.ts
+++ b/src/examples/rest-with-auth/src/types.generated.ts
@@ -141,7 +141,6 @@ export type ApiKeyUpdateInput = {
 
 export type ApiKeysListFilter = {
   _and?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
-  _not?: InputMaybe<ApiKeysListFilter>;
   _or?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -211,7 +210,6 @@ export type CredentialUpdateInput = {
 
 export type CredentialsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
-  _not?: InputMaybe<CredentialsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -686,7 +684,6 @@ export type TagUpdateInput = {
 
 export type TagsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TagsListFilter>>>;
-  _not?: InputMaybe<TagsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TagsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -768,7 +765,6 @@ export type TaskCountByTagTag_AggregateArgs = {
 
 export type TaskCountByTagsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TaskCountByTagsListFilter>>>;
-  _not?: InputMaybe<TaskCountByTagsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TaskCountByTagsListFilter>>>;
   count?: InputMaybe<Scalars['Float']['input']>;
   count_in?: InputMaybe<Array<Scalars['Float']['input']>>;
@@ -835,7 +831,6 @@ export type TaskUpdateInput = {
 
 export type TasksListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
-  _not?: InputMaybe<TasksListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
   description?: InputMaybe<Scalars['String']['input']>;
   description_gt?: InputMaybe<Scalars['String']['input']>;
@@ -931,7 +926,6 @@ export type Trace = {
 
 export type TracesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
-  _not?: InputMaybe<TracesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
   attributes?: InputMaybe<Scalars['JSON']['input']>;
   attributes_in?: InputMaybe<Array<Scalars['JSON']['input']>>;
@@ -1057,7 +1051,6 @@ export type UserTasks_AggregateArgs = {
 
 export type UsersListFilter = {
   _and?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
-  _not?: InputMaybe<UsersListFilter>;
   _or?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
   name?: InputMaybe<Scalars['String']['input']>;
   name_gt?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/rest-with-auth/src/types.generated.ts
+++ b/src/examples/rest-with-auth/src/types.generated.ts
@@ -140,6 +140,9 @@ export type ApiKeyUpdateInput = {
 };
 
 export type ApiKeysListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
+  _not?: InputMaybe<ApiKeysListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -207,6 +210,9 @@ export type CredentialUpdateInput = {
 };
 
 export type CredentialsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
+  _not?: InputMaybe<CredentialsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -679,6 +685,9 @@ export type TagUpdateInput = {
 };
 
 export type TagsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TagsListFilter>>>;
+  _not?: InputMaybe<TagsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TagsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -758,6 +767,9 @@ export type TaskCountByTagTag_AggregateArgs = {
 };
 
 export type TaskCountByTagsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TaskCountByTagsListFilter>>>;
+  _not?: InputMaybe<TaskCountByTagsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TaskCountByTagsListFilter>>>;
   count?: InputMaybe<Scalars['Float']['input']>;
   count_in?: InputMaybe<Array<Scalars['Float']['input']>>;
   count_ne?: InputMaybe<Scalars['Float']['input']>;
@@ -822,6 +834,9 @@ export type TaskUpdateInput = {
 };
 
 export type TasksListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
+  _not?: InputMaybe<TasksListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
   description?: InputMaybe<Scalars['String']['input']>;
   description_gt?: InputMaybe<Scalars['String']['input']>;
   description_gte?: InputMaybe<Scalars['String']['input']>;
@@ -915,6 +930,9 @@ export type Trace = {
 };
 
 export type TracesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
+  _not?: InputMaybe<TracesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
   attributes?: InputMaybe<Scalars['JSON']['input']>;
   attributes_in?: InputMaybe<Array<Scalars['JSON']['input']>>;
   attributes_ne?: InputMaybe<Scalars['JSON']['input']>;
@@ -1038,6 +1056,9 @@ export type UserTasks_AggregateArgs = {
 };
 
 export type UsersListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
+  _not?: InputMaybe<UsersListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
   name?: InputMaybe<Scalars['String']['input']>;
   name_gt?: InputMaybe<Scalars['String']['input']>;
   name_gte?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/rest-with-auth/types.generated.ts
+++ b/src/examples/rest-with-auth/types.generated.ts
@@ -141,7 +141,6 @@ export type ApiKeyUpdateInput = {
 
 export type ApiKeysListFilter = {
   _and?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
-  _not?: InputMaybe<ApiKeysListFilter>;
   _or?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -211,7 +210,6 @@ export type CredentialUpdateInput = {
 
 export type CredentialsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
-  _not?: InputMaybe<CredentialsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -686,7 +684,6 @@ export type TagUpdateInput = {
 
 export type TagsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TagsListFilter>>>;
-  _not?: InputMaybe<TagsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TagsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -768,7 +765,6 @@ export type TaskCountByTagTag_AggregateArgs = {
 
 export type TaskCountByTagsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TaskCountByTagsListFilter>>>;
-  _not?: InputMaybe<TaskCountByTagsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TaskCountByTagsListFilter>>>;
   count?: InputMaybe<Scalars['Float']['input']>;
   count_in?: InputMaybe<Array<Scalars['Float']['input']>>;
@@ -835,7 +831,6 @@ export type TaskUpdateInput = {
 
 export type TasksListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
-  _not?: InputMaybe<TasksListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
   description?: InputMaybe<Scalars['String']['input']>;
   description_gt?: InputMaybe<Scalars['String']['input']>;
@@ -931,7 +926,6 @@ export type Trace = {
 
 export type TracesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
-  _not?: InputMaybe<TracesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
   attributes?: InputMaybe<Scalars['JSON']['input']>;
   attributes_in?: InputMaybe<Array<Scalars['JSON']['input']>>;
@@ -1057,7 +1051,6 @@ export type UserTasks_AggregateArgs = {
 
 export type UsersListFilter = {
   _and?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
-  _not?: InputMaybe<UsersListFilter>;
   _or?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
   name?: InputMaybe<Scalars['String']['input']>;
   name_gt?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/rest-with-auth/types.generated.ts
+++ b/src/examples/rest-with-auth/types.generated.ts
@@ -140,6 +140,9 @@ export type ApiKeyUpdateInput = {
 };
 
 export type ApiKeysListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
+  _not?: InputMaybe<ApiKeysListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<ApiKeysListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -207,6 +210,9 @@ export type CredentialUpdateInput = {
 };
 
 export type CredentialsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
+  _not?: InputMaybe<CredentialsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<CredentialsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -679,6 +685,9 @@ export type TagUpdateInput = {
 };
 
 export type TagsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TagsListFilter>>>;
+  _not?: InputMaybe<TagsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TagsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -758,6 +767,9 @@ export type TaskCountByTagTag_AggregateArgs = {
 };
 
 export type TaskCountByTagsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TaskCountByTagsListFilter>>>;
+  _not?: InputMaybe<TaskCountByTagsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TaskCountByTagsListFilter>>>;
   count?: InputMaybe<Scalars['Float']['input']>;
   count_in?: InputMaybe<Array<Scalars['Float']['input']>>;
   count_ne?: InputMaybe<Scalars['Float']['input']>;
@@ -822,6 +834,9 @@ export type TaskUpdateInput = {
 };
 
 export type TasksListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
+  _not?: InputMaybe<TasksListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TasksListFilter>>>;
   description?: InputMaybe<Scalars['String']['input']>;
   description_gt?: InputMaybe<Scalars['String']['input']>;
   description_gte?: InputMaybe<Scalars['String']['input']>;
@@ -915,6 +930,9 @@ export type Trace = {
 };
 
 export type TracesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
+  _not?: InputMaybe<TracesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
   attributes?: InputMaybe<Scalars['JSON']['input']>;
   attributes_in?: InputMaybe<Array<Scalars['JSON']['input']>>;
   attributes_ne?: InputMaybe<Scalars['JSON']['input']>;
@@ -1038,6 +1056,9 @@ export type UserTasks_AggregateArgs = {
 };
 
 export type UsersListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
+  _not?: InputMaybe<UsersListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<UsersListFilter>>>;
   name?: InputMaybe<Scalars['String']['input']>;
   name_gt?: InputMaybe<Scalars['String']['input']>;
   name_gte?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/rest/src/frontend/types.generated.ts
+++ b/src/examples/rest/src/frontend/types.generated.ts
@@ -118,7 +118,6 @@ export type DeleteOneFilterInput = {
 
 export type PeopleListFilter = {
   _and?: InputMaybe<Array<InputMaybe<PeopleListFilter>>>;
-  _not?: InputMaybe<PeopleListFilter>;
   _or?: InputMaybe<Array<InputMaybe<PeopleListFilter>>>;
   birth_year?: InputMaybe<Scalars['String']['input']>;
   birth_year_gt?: InputMaybe<Scalars['String']['input']>;
@@ -276,7 +275,6 @@ export type Vehicle = {
 
 export type VehiclesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<VehiclesListFilter>>>;
-  _not?: InputMaybe<VehiclesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<VehiclesListFilter>>>;
   cost_in_credits?: InputMaybe<Scalars['String']['input']>;
   cost_in_credits_gt?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/rest/src/frontend/types.generated.ts
+++ b/src/examples/rest/src/frontend/types.generated.ts
@@ -117,6 +117,9 @@ export type DeleteOneFilterInput = {
 };
 
 export type PeopleListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<PeopleListFilter>>>;
+  _not?: InputMaybe<PeopleListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<PeopleListFilter>>>;
   birth_year?: InputMaybe<Scalars['String']['input']>;
   birth_year_gt?: InputMaybe<Scalars['String']['input']>;
   birth_year_gte?: InputMaybe<Scalars['String']['input']>;
@@ -272,6 +275,9 @@ export type Vehicle = {
 };
 
 export type VehiclesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<VehiclesListFilter>>>;
+  _not?: InputMaybe<VehiclesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<VehiclesListFilter>>>;
   cost_in_credits?: InputMaybe<Scalars['String']['input']>;
   cost_in_credits_gt?: InputMaybe<Scalars['String']['input']>;
   cost_in_credits_gte?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/rest/src/types.generated.ts
+++ b/src/examples/rest/src/types.generated.ts
@@ -118,7 +118,6 @@ export type DeleteOneFilterInput = {
 
 export type PeopleListFilter = {
   _and?: InputMaybe<Array<InputMaybe<PeopleListFilter>>>;
-  _not?: InputMaybe<PeopleListFilter>;
   _or?: InputMaybe<Array<InputMaybe<PeopleListFilter>>>;
   birth_year?: InputMaybe<Scalars['String']['input']>;
   birth_year_gt?: InputMaybe<Scalars['String']['input']>;
@@ -276,7 +275,6 @@ export type Vehicle = {
 
 export type VehiclesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<VehiclesListFilter>>>;
-  _not?: InputMaybe<VehiclesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<VehiclesListFilter>>>;
   cost_in_credits?: InputMaybe<Scalars['String']['input']>;
   cost_in_credits_gt?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/rest/src/types.generated.ts
+++ b/src/examples/rest/src/types.generated.ts
@@ -117,6 +117,9 @@ export type DeleteOneFilterInput = {
 };
 
 export type PeopleListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<PeopleListFilter>>>;
+  _not?: InputMaybe<PeopleListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<PeopleListFilter>>>;
   birth_year?: InputMaybe<Scalars['String']['input']>;
   birth_year_gt?: InputMaybe<Scalars['String']['input']>;
   birth_year_gte?: InputMaybe<Scalars['String']['input']>;
@@ -272,6 +275,9 @@ export type Vehicle = {
 };
 
 export type VehiclesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<VehiclesListFilter>>>;
+  _not?: InputMaybe<VehiclesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<VehiclesListFilter>>>;
   cost_in_credits?: InputMaybe<Scalars['String']['input']>;
   cost_in_credits_gt?: InputMaybe<Scalars['String']['input']>;
   cost_in_credits_gte?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/s3-storage/src/frontend/types.generated.ts
+++ b/src/examples/s3-storage/src/frontend/types.generated.ts
@@ -142,6 +142,9 @@ export type GraphweaverMediaUpdateInput = {
 };
 
 export type GraphweaverMediasListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<GraphweaverMediasListFilter>>>;
+  _not?: InputMaybe<GraphweaverMediasListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<GraphweaverMediasListFilter>>>;
   filename?: InputMaybe<Scalars['String']['input']>;
   filename_gt?: InputMaybe<Scalars['String']['input']>;
   filename_gte?: InputMaybe<Scalars['String']['input']>;
@@ -304,6 +307,9 @@ export type SubmissionUpdateInput = {
 };
 
 export type SubmissionsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<SubmissionsListFilter>>>;
+  _not?: InputMaybe<SubmissionsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<SubmissionsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;

--- a/src/examples/s3-storage/src/frontend/types.generated.ts
+++ b/src/examples/s3-storage/src/frontend/types.generated.ts
@@ -143,7 +143,6 @@ export type GraphweaverMediaUpdateInput = {
 
 export type GraphweaverMediasListFilter = {
   _and?: InputMaybe<Array<InputMaybe<GraphweaverMediasListFilter>>>;
-  _not?: InputMaybe<GraphweaverMediasListFilter>;
   _or?: InputMaybe<Array<InputMaybe<GraphweaverMediasListFilter>>>;
   filename?: InputMaybe<Scalars['String']['input']>;
   filename_gt?: InputMaybe<Scalars['String']['input']>;
@@ -308,7 +307,6 @@ export type SubmissionUpdateInput = {
 
 export type SubmissionsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<SubmissionsListFilter>>>;
-  _not?: InputMaybe<SubmissionsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<SubmissionsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;

--- a/src/examples/s3-storage/src/types.generated.ts
+++ b/src/examples/s3-storage/src/types.generated.ts
@@ -142,6 +142,9 @@ export type GraphweaverMediaUpdateInput = {
 };
 
 export type GraphweaverMediasListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<GraphweaverMediasListFilter>>>;
+  _not?: InputMaybe<GraphweaverMediasListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<GraphweaverMediasListFilter>>>;
   filename?: InputMaybe<Scalars['String']['input']>;
   filename_gt?: InputMaybe<Scalars['String']['input']>;
   filename_gte?: InputMaybe<Scalars['String']['input']>;
@@ -304,6 +307,9 @@ export type SubmissionUpdateInput = {
 };
 
 export type SubmissionsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<SubmissionsListFilter>>>;
+  _not?: InputMaybe<SubmissionsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<SubmissionsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;

--- a/src/examples/s3-storage/src/types.generated.ts
+++ b/src/examples/s3-storage/src/types.generated.ts
@@ -143,7 +143,6 @@ export type GraphweaverMediaUpdateInput = {
 
 export type GraphweaverMediasListFilter = {
   _and?: InputMaybe<Array<InputMaybe<GraphweaverMediasListFilter>>>;
-  _not?: InputMaybe<GraphweaverMediasListFilter>;
   _or?: InputMaybe<Array<InputMaybe<GraphweaverMediasListFilter>>>;
   filename?: InputMaybe<Scalars['String']['input']>;
   filename_gt?: InputMaybe<Scalars['String']['input']>;
@@ -308,7 +307,6 @@ export type SubmissionUpdateInput = {
 
 export type SubmissionsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<SubmissionsListFilter>>>;
-  _not?: InputMaybe<SubmissionsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<SubmissionsListFilter>>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;

--- a/src/examples/sqlite/src/frontend/types.generated.ts
+++ b/src/examples/sqlite/src/frontend/types.generated.ts
@@ -173,7 +173,6 @@ export type AlbumUpdateInput = {
 
 export type AlbumsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
-  _not?: InputMaybe<AlbumsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
   albumId?: InputMaybe<Scalars['ID']['input']>;
   albumId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -253,7 +252,6 @@ export type ArtistUpdateInput = {
 
 export type ArtistsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
-  _not?: InputMaybe<ArtistsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
   albums?: InputMaybe<AlbumsListFilter>;
   artistId?: InputMaybe<Scalars['ID']['input']>;
@@ -387,7 +385,6 @@ export type CustomerUpdateInput = {
 
 export type CustomersListFilter = {
   _and?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
-  _not?: InputMaybe<CustomersListFilter>;
   _or?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
@@ -679,7 +676,6 @@ export type EmployeeUpdateInput = {
 
 export type EmployeesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
-  _not?: InputMaybe<EmployeesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
@@ -913,7 +909,6 @@ export type GenreUpdateInput = {
 
 export type GenresListFilter = {
   _and?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
-  _not?: InputMaybe<GenresListFilter>;
   _or?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
   genreId?: InputMaybe<Scalars['ID']['input']>;
   genreId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -1074,7 +1069,6 @@ export type InvoiceLineUpdateInput = {
 
 export type InvoiceLinesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
-  _not?: InputMaybe<InvoiceLinesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
   invoice?: InputMaybe<InvoicesListFilter>;
   invoiceLineId?: InputMaybe<Scalars['ID']['input']>;
@@ -1137,7 +1131,6 @@ export type InvoiceUpdateInput = {
 
 export type InvoicesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
-  _not?: InputMaybe<InvoicesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
   billingAddress?: InputMaybe<Scalars['String']['input']>;
   billingAddress_gt?: InputMaybe<Scalars['String']['input']>;
@@ -1293,7 +1286,6 @@ export type MediaTypeUpdateInput = {
 
 export type MediaTypesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
-  _not?: InputMaybe<MediaTypesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
   mediaTypeId?: InputMaybe<Scalars['ID']['input']>;
   mediaTypeId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -1866,7 +1858,6 @@ export type PlaylistUpdateInput = {
 
 export type PlaylistsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
-  _not?: InputMaybe<PlaylistsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
   name?: InputMaybe<Scalars['String']['input']>;
   name_gt?: InputMaybe<Scalars['String']['input']>;
@@ -2200,7 +2191,6 @@ export type TotalInvoicesByCustomerCustomer_AggregateArgs = {
 
 export type TotalInvoicesByCustomersListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TotalInvoicesByCustomersListFilter>>>;
-  _not?: InputMaybe<TotalInvoicesByCustomersListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TotalInvoicesByCustomersListFilter>>>;
   customer?: InputMaybe<CustomersListFilter>;
   customerId?: InputMaybe<Scalars['ID']['input']>;
@@ -2253,7 +2243,6 @@ export type Trace = {
 
 export type TracesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
-  _not?: InputMaybe<TracesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
   attributes?: InputMaybe<Scalars['JSON']['input']>;
   attributes_in?: InputMaybe<Array<Scalars['JSON']['input']>>;
@@ -2475,7 +2464,6 @@ export type TrackUpdateInput = {
 
 export type TracksListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
-  _not?: InputMaybe<TracksListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
   album?: InputMaybe<AlbumsListFilter>;
   bytes?: InputMaybe<Scalars['Float']['input']>;

--- a/src/examples/sqlite/src/frontend/types.generated.ts
+++ b/src/examples/sqlite/src/frontend/types.generated.ts
@@ -172,6 +172,9 @@ export type AlbumUpdateInput = {
 };
 
 export type AlbumsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
+  _not?: InputMaybe<AlbumsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
   albumId?: InputMaybe<Scalars['ID']['input']>;
   albumId_gt?: InputMaybe<Scalars['ID']['input']>;
   albumId_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -249,6 +252,9 @@ export type ArtistUpdateInput = {
 };
 
 export type ArtistsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
+  _not?: InputMaybe<ArtistsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
   albums?: InputMaybe<AlbumsListFilter>;
   artistId?: InputMaybe<Scalars['ID']['input']>;
   artistId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -380,6 +386,9 @@ export type CustomerUpdateInput = {
 };
 
 export type CustomersListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
+  _not?: InputMaybe<CustomersListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
   address_gte?: InputMaybe<Scalars['String']['input']>;
@@ -669,6 +678,9 @@ export type EmployeeUpdateInput = {
 };
 
 export type EmployeesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
+  _not?: InputMaybe<EmployeesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
   address_gte?: InputMaybe<Scalars['String']['input']>;
@@ -900,6 +912,9 @@ export type GenreUpdateInput = {
 };
 
 export type GenresListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
+  _not?: InputMaybe<GenresListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
   genreId?: InputMaybe<Scalars['ID']['input']>;
   genreId_gt?: InputMaybe<Scalars['ID']['input']>;
   genreId_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -1058,6 +1073,9 @@ export type InvoiceLineUpdateInput = {
 };
 
 export type InvoiceLinesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
+  _not?: InputMaybe<InvoiceLinesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
   invoice?: InputMaybe<InvoicesListFilter>;
   invoiceLineId?: InputMaybe<Scalars['ID']['input']>;
   invoiceLineId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -1118,6 +1136,9 @@ export type InvoiceUpdateInput = {
 };
 
 export type InvoicesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
+  _not?: InputMaybe<InvoicesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
   billingAddress?: InputMaybe<Scalars['String']['input']>;
   billingAddress_gt?: InputMaybe<Scalars['String']['input']>;
   billingAddress_gte?: InputMaybe<Scalars['String']['input']>;
@@ -1271,6 +1292,9 @@ export type MediaTypeUpdateInput = {
 };
 
 export type MediaTypesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
+  _not?: InputMaybe<MediaTypesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
   mediaTypeId?: InputMaybe<Scalars['ID']['input']>;
   mediaTypeId_gt?: InputMaybe<Scalars['ID']['input']>;
   mediaTypeId_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -1841,6 +1865,9 @@ export type PlaylistUpdateInput = {
 };
 
 export type PlaylistsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
+  _not?: InputMaybe<PlaylistsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
   name?: InputMaybe<Scalars['String']['input']>;
   name_gt?: InputMaybe<Scalars['String']['input']>;
   name_gte?: InputMaybe<Scalars['String']['input']>;
@@ -2172,6 +2199,9 @@ export type TotalInvoicesByCustomerCustomer_AggregateArgs = {
 };
 
 export type TotalInvoicesByCustomersListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TotalInvoicesByCustomersListFilter>>>;
+  _not?: InputMaybe<TotalInvoicesByCustomersListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TotalInvoicesByCustomersListFilter>>>;
   customer?: InputMaybe<CustomersListFilter>;
   customerId?: InputMaybe<Scalars['ID']['input']>;
   customerId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -2222,6 +2252,9 @@ export type Trace = {
 };
 
 export type TracesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
+  _not?: InputMaybe<TracesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
   attributes?: InputMaybe<Scalars['JSON']['input']>;
   attributes_in?: InputMaybe<Array<Scalars['JSON']['input']>>;
   attributes_ne?: InputMaybe<Scalars['JSON']['input']>;
@@ -2441,6 +2474,9 @@ export type TrackUpdateInput = {
 };
 
 export type TracksListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
+  _not?: InputMaybe<TracksListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
   album?: InputMaybe<AlbumsListFilter>;
   bytes?: InputMaybe<Scalars['Float']['input']>;
   bytes_in?: InputMaybe<Array<Scalars['Float']['input']>>;

--- a/src/examples/sqlite/src/types.generated.ts
+++ b/src/examples/sqlite/src/types.generated.ts
@@ -173,7 +173,6 @@ export type AlbumUpdateInput = {
 
 export type AlbumsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
-  _not?: InputMaybe<AlbumsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
   albumId?: InputMaybe<Scalars['ID']['input']>;
   albumId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -253,7 +252,6 @@ export type ArtistUpdateInput = {
 
 export type ArtistsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
-  _not?: InputMaybe<ArtistsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
   albums?: InputMaybe<AlbumsListFilter>;
   artistId?: InputMaybe<Scalars['ID']['input']>;
@@ -387,7 +385,6 @@ export type CustomerUpdateInput = {
 
 export type CustomersListFilter = {
   _and?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
-  _not?: InputMaybe<CustomersListFilter>;
   _or?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
@@ -679,7 +676,6 @@ export type EmployeeUpdateInput = {
 
 export type EmployeesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
-  _not?: InputMaybe<EmployeesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
@@ -913,7 +909,6 @@ export type GenreUpdateInput = {
 
 export type GenresListFilter = {
   _and?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
-  _not?: InputMaybe<GenresListFilter>;
   _or?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
   genreId?: InputMaybe<Scalars['ID']['input']>;
   genreId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -1074,7 +1069,6 @@ export type InvoiceLineUpdateInput = {
 
 export type InvoiceLinesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
-  _not?: InputMaybe<InvoiceLinesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
   invoice?: InputMaybe<InvoicesListFilter>;
   invoiceLineId?: InputMaybe<Scalars['ID']['input']>;
@@ -1137,7 +1131,6 @@ export type InvoiceUpdateInput = {
 
 export type InvoicesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
-  _not?: InputMaybe<InvoicesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
   billingAddress?: InputMaybe<Scalars['String']['input']>;
   billingAddress_gt?: InputMaybe<Scalars['String']['input']>;
@@ -1293,7 +1286,6 @@ export type MediaTypeUpdateInput = {
 
 export type MediaTypesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
-  _not?: InputMaybe<MediaTypesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
   mediaTypeId?: InputMaybe<Scalars['ID']['input']>;
   mediaTypeId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -1866,7 +1858,6 @@ export type PlaylistUpdateInput = {
 
 export type PlaylistsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
-  _not?: InputMaybe<PlaylistsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
   name?: InputMaybe<Scalars['String']['input']>;
   name_gt?: InputMaybe<Scalars['String']['input']>;
@@ -2200,7 +2191,6 @@ export type TotalInvoicesByCustomerCustomer_AggregateArgs = {
 
 export type TotalInvoicesByCustomersListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TotalInvoicesByCustomersListFilter>>>;
-  _not?: InputMaybe<TotalInvoicesByCustomersListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TotalInvoicesByCustomersListFilter>>>;
   customer?: InputMaybe<CustomersListFilter>;
   customerId?: InputMaybe<Scalars['ID']['input']>;
@@ -2253,7 +2243,6 @@ export type Trace = {
 
 export type TracesListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
-  _not?: InputMaybe<TracesListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
   attributes?: InputMaybe<Scalars['JSON']['input']>;
   attributes_in?: InputMaybe<Array<Scalars['JSON']['input']>>;
@@ -2475,7 +2464,6 @@ export type TrackUpdateInput = {
 
 export type TracksListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
-  _not?: InputMaybe<TracksListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
   album?: InputMaybe<AlbumsListFilter>;
   bytes?: InputMaybe<Scalars['Float']['input']>;

--- a/src/examples/sqlite/src/types.generated.ts
+++ b/src/examples/sqlite/src/types.generated.ts
@@ -172,6 +172,9 @@ export type AlbumUpdateInput = {
 };
 
 export type AlbumsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
+  _not?: InputMaybe<AlbumsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<AlbumsListFilter>>>;
   albumId?: InputMaybe<Scalars['ID']['input']>;
   albumId_gt?: InputMaybe<Scalars['ID']['input']>;
   albumId_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -249,6 +252,9 @@ export type ArtistUpdateInput = {
 };
 
 export type ArtistsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
+  _not?: InputMaybe<ArtistsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<ArtistsListFilter>>>;
   albums?: InputMaybe<AlbumsListFilter>;
   artistId?: InputMaybe<Scalars['ID']['input']>;
   artistId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -380,6 +386,9 @@ export type CustomerUpdateInput = {
 };
 
 export type CustomersListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
+  _not?: InputMaybe<CustomersListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<CustomersListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
   address_gte?: InputMaybe<Scalars['String']['input']>;
@@ -669,6 +678,9 @@ export type EmployeeUpdateInput = {
 };
 
 export type EmployeesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
+  _not?: InputMaybe<EmployeesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<EmployeesListFilter>>>;
   address?: InputMaybe<Scalars['String']['input']>;
   address_gt?: InputMaybe<Scalars['String']['input']>;
   address_gte?: InputMaybe<Scalars['String']['input']>;
@@ -900,6 +912,9 @@ export type GenreUpdateInput = {
 };
 
 export type GenresListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
+  _not?: InputMaybe<GenresListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<GenresListFilter>>>;
   genreId?: InputMaybe<Scalars['ID']['input']>;
   genreId_gt?: InputMaybe<Scalars['ID']['input']>;
   genreId_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -1058,6 +1073,9 @@ export type InvoiceLineUpdateInput = {
 };
 
 export type InvoiceLinesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
+  _not?: InputMaybe<InvoiceLinesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<InvoiceLinesListFilter>>>;
   invoice?: InputMaybe<InvoicesListFilter>;
   invoiceLineId?: InputMaybe<Scalars['ID']['input']>;
   invoiceLineId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -1118,6 +1136,9 @@ export type InvoiceUpdateInput = {
 };
 
 export type InvoicesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
+  _not?: InputMaybe<InvoicesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<InvoicesListFilter>>>;
   billingAddress?: InputMaybe<Scalars['String']['input']>;
   billingAddress_gt?: InputMaybe<Scalars['String']['input']>;
   billingAddress_gte?: InputMaybe<Scalars['String']['input']>;
@@ -1271,6 +1292,9 @@ export type MediaTypeUpdateInput = {
 };
 
 export type MediaTypesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
+  _not?: InputMaybe<MediaTypesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<MediaTypesListFilter>>>;
   mediaTypeId?: InputMaybe<Scalars['ID']['input']>;
   mediaTypeId_gt?: InputMaybe<Scalars['ID']['input']>;
   mediaTypeId_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -1841,6 +1865,9 @@ export type PlaylistUpdateInput = {
 };
 
 export type PlaylistsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
+  _not?: InputMaybe<PlaylistsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<PlaylistsListFilter>>>;
   name?: InputMaybe<Scalars['String']['input']>;
   name_gt?: InputMaybe<Scalars['String']['input']>;
   name_gte?: InputMaybe<Scalars['String']['input']>;
@@ -2172,6 +2199,9 @@ export type TotalInvoicesByCustomerCustomer_AggregateArgs = {
 };
 
 export type TotalInvoicesByCustomersListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TotalInvoicesByCustomersListFilter>>>;
+  _not?: InputMaybe<TotalInvoicesByCustomersListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TotalInvoicesByCustomersListFilter>>>;
   customer?: InputMaybe<CustomersListFilter>;
   customerId?: InputMaybe<Scalars['ID']['input']>;
   customerId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -2222,6 +2252,9 @@ export type Trace = {
 };
 
 export type TracesListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
+  _not?: InputMaybe<TracesListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TracesListFilter>>>;
   attributes?: InputMaybe<Scalars['JSON']['input']>;
   attributes_in?: InputMaybe<Array<Scalars['JSON']['input']>>;
   attributes_ne?: InputMaybe<Scalars['JSON']['input']>;
@@ -2441,6 +2474,9 @@ export type TrackUpdateInput = {
 };
 
 export type TracksListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
+  _not?: InputMaybe<TracksListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TracksListFilter>>>;
   album?: InputMaybe<AlbumsListFilter>;
   bytes?: InputMaybe<Scalars['Float']['input']>;
   bytes_in?: InputMaybe<Array<Scalars['Float']['input']>>;

--- a/src/examples/xero/src/frontend/types.generated.ts
+++ b/src/examples/xero/src/frontend/types.generated.ts
@@ -83,6 +83,9 @@ export type AccountUpdateInput = {
 };
 
 export type AccountsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<AccountsListFilter>>>;
+  _not?: InputMaybe<AccountsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<AccountsListFilter>>>;
   code?: InputMaybe<Scalars['String']['input']>;
   code_gt?: InputMaybe<Scalars['String']['input']>;
   code_gte?: InputMaybe<Scalars['String']['input']>;
@@ -445,6 +448,9 @@ export type ProfitAndLossRowUpdateInput = {
 };
 
 export type ProfitAndLossRowsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<ProfitAndLossRowsListFilter>>>;
+  _not?: InputMaybe<ProfitAndLossRowsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<ProfitAndLossRowsListFilter>>>;
   account?: InputMaybe<AccountsListFilter>;
   accountId?: InputMaybe<Scalars['ID']['input']>;
   accountId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -619,6 +625,9 @@ export type TenantUpdateInput = {
 };
 
 export type TenantsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TenantsListFilter>>>;
+  _not?: InputMaybe<TenantsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TenantsListFilter>>>;
   authEventId?: InputMaybe<Scalars['String']['input']>;
   authEventId_gt?: InputMaybe<Scalars['String']['input']>;
   authEventId_gte?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/xero/src/frontend/types.generated.ts
+++ b/src/examples/xero/src/frontend/types.generated.ts
@@ -84,7 +84,6 @@ export type AccountUpdateInput = {
 
 export type AccountsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<AccountsListFilter>>>;
-  _not?: InputMaybe<AccountsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<AccountsListFilter>>>;
   code?: InputMaybe<Scalars['String']['input']>;
   code_gt?: InputMaybe<Scalars['String']['input']>;
@@ -449,7 +448,6 @@ export type ProfitAndLossRowUpdateInput = {
 
 export type ProfitAndLossRowsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<ProfitAndLossRowsListFilter>>>;
-  _not?: InputMaybe<ProfitAndLossRowsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<ProfitAndLossRowsListFilter>>>;
   account?: InputMaybe<AccountsListFilter>;
   accountId?: InputMaybe<Scalars['ID']['input']>;
@@ -626,7 +624,6 @@ export type TenantUpdateInput = {
 
 export type TenantsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TenantsListFilter>>>;
-  _not?: InputMaybe<TenantsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TenantsListFilter>>>;
   authEventId?: InputMaybe<Scalars['String']['input']>;
   authEventId_gt?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/xero/src/types.generated.ts
+++ b/src/examples/xero/src/types.generated.ts
@@ -83,6 +83,9 @@ export type AccountUpdateInput = {
 };
 
 export type AccountsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<AccountsListFilter>>>;
+  _not?: InputMaybe<AccountsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<AccountsListFilter>>>;
   code?: InputMaybe<Scalars['String']['input']>;
   code_gt?: InputMaybe<Scalars['String']['input']>;
   code_gte?: InputMaybe<Scalars['String']['input']>;
@@ -445,6 +448,9 @@ export type ProfitAndLossRowUpdateInput = {
 };
 
 export type ProfitAndLossRowsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<ProfitAndLossRowsListFilter>>>;
+  _not?: InputMaybe<ProfitAndLossRowsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<ProfitAndLossRowsListFilter>>>;
   account?: InputMaybe<AccountsListFilter>;
   accountId?: InputMaybe<Scalars['ID']['input']>;
   accountId_gt?: InputMaybe<Scalars['ID']['input']>;
@@ -619,6 +625,9 @@ export type TenantUpdateInput = {
 };
 
 export type TenantsListFilter = {
+  _and?: InputMaybe<Array<InputMaybe<TenantsListFilter>>>;
+  _not?: InputMaybe<TenantsListFilter>;
+  _or?: InputMaybe<Array<InputMaybe<TenantsListFilter>>>;
   authEventId?: InputMaybe<Scalars['String']['input']>;
   authEventId_gt?: InputMaybe<Scalars['String']['input']>;
   authEventId_gte?: InputMaybe<Scalars['String']['input']>;

--- a/src/examples/xero/src/types.generated.ts
+++ b/src/examples/xero/src/types.generated.ts
@@ -84,7 +84,6 @@ export type AccountUpdateInput = {
 
 export type AccountsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<AccountsListFilter>>>;
-  _not?: InputMaybe<AccountsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<AccountsListFilter>>>;
   code?: InputMaybe<Scalars['String']['input']>;
   code_gt?: InputMaybe<Scalars['String']['input']>;
@@ -449,7 +448,6 @@ export type ProfitAndLossRowUpdateInput = {
 
 export type ProfitAndLossRowsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<ProfitAndLossRowsListFilter>>>;
-  _not?: InputMaybe<ProfitAndLossRowsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<ProfitAndLossRowsListFilter>>>;
   account?: InputMaybe<AccountsListFilter>;
   accountId?: InputMaybe<Scalars['ID']['input']>;
@@ -626,7 +624,6 @@ export type TenantUpdateInput = {
 
 export type TenantsListFilter = {
   _and?: InputMaybe<Array<InputMaybe<TenantsListFilter>>>;
-  _not?: InputMaybe<TenantsListFilter>;
   _or?: InputMaybe<Array<InputMaybe<TenantsListFilter>>>;
   authEventId?: InputMaybe<Scalars['String']['input']>;
   authEventId_gt?: InputMaybe<Scalars['String']['input']>;

--- a/src/packages/core/src/query-manager.ts
+++ b/src/packages/core/src/query-manager.ts
@@ -47,6 +47,11 @@ const visit = async (currentEntityMetadata: EntityMetadata, currentFilter: any) 
 					return filter;
 				})
 			);
+		} else if (fieldName === '_not') {
+			// The _not is an exception because the value is not an array, but it is just like above, we need
+			// to visit on down the tree.
+			const { filter } = await visit(currentEntityMetadata, value);
+			currentFilter[fieldName] = filter;
 		} else if (typeof value === 'object') {
 			// Let's recurse. To do that we need to look up the field.
 			const field = getFieldFromEntity(currentEntityMetadata, fieldName);

--- a/src/packages/core/src/schema-builder.ts
+++ b/src/packages/core/src/schema-builder.ts
@@ -488,7 +488,9 @@ const filterTypeForEntity = (
 				const selfFilter = filterTypeForEntity(entity, entityFilter);
 				fields['_and'] = { type: new GraphQLList(selfFilter) };
 				fields['_or'] = { type: new GraphQLList(selfFilter) };
-				fields['_not'] = { type: selfFilter };
+
+				// There's currently a problem with the _not operator and MikroORM, so we're not adding it for now.
+				// fields['_not'] = { type: selfFilter };
 
 				for (const field of Object.values(entity.fields)) {
 					const fieldType = getFieldType(field);

--- a/src/packages/core/src/schema-builder.ts
+++ b/src/packages/core/src/schema-builder.ts
@@ -484,6 +484,12 @@ const filterTypeForEntity = (
 			fields: () => {
 				const fields: ObjMap<GraphQLInputFieldConfig> = {};
 
+				// Add top level and/or/not
+				const selfFilter = filterTypeForEntity(entity, entityFilter);
+				fields['_and'] = { type: new GraphQLList(selfFilter) };
+				fields['_or'] = { type: new GraphQLList(selfFilter) };
+				fields['_not'] = { type: selfFilter };
+
 				for (const field of Object.values(entity.fields)) {
 					const fieldType = getFieldType(field);
 					const metadata = graphweaverMetadata.metadataForType(fieldType);

--- a/src/packages/end-to-end/src/__tests__/api/sqlite/issues/gh1388.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/sqlite/issues/gh1388.test.ts
@@ -1,0 +1,119 @@
+import gql from 'graphql-tag';
+import assert from 'assert';
+import Graphweaver from '@exogee/graphweaver-server';
+import {
+	Entity as DataEntity,
+	Collection,
+	Ref,
+	ManyToOne,
+	OneToMany,
+	PrimaryKey,
+} from '@mikro-orm/core';
+import { Field, ID, Entity, RelationshipField } from '@exogee/graphweaver';
+import { ConnectionManager, MikroBackendProvider } from '@exogee/graphweaver-mikroorm';
+
+import { resetDatabase } from '../../../../utils';
+
+import { SqliteDriver } from '@mikro-orm/sqlite';
+
+/** Setup entities and resolvers  */
+@DataEntity({ tableName: 'Album' })
+class OrmAlbum {
+	@PrimaryKey({ fieldName: 'AlbumId', type: 'number' })
+	id!: number;
+
+	@ManyToOne({
+		entity: () => OrmArtist,
+		ref: true,
+		fieldName: 'ArtistId',
+		index: 'IFK_AlbumArtistId',
+	})
+	artist!: Ref<OrmArtist>;
+}
+
+@DataEntity({ tableName: 'Artist' })
+class OrmArtist {
+	@PrimaryKey({ fieldName: 'ArtistId', type: 'number' })
+	id!: number;
+
+	@OneToMany({ entity: () => OrmAlbum, mappedBy: 'artist' })
+	albums = new Collection<OrmAlbum>(this);
+}
+
+const connection = {
+	connectionManagerId: 'sqlite',
+	mikroOrmConfig: {
+		entities: [OrmAlbum, OrmArtist],
+		driver: SqliteDriver,
+		dbName: 'databases/database.sqlite',
+	},
+};
+
+@Entity('Album', {
+	provider: new MikroBackendProvider(OrmAlbum, connection),
+})
+export class Album {
+	@Field(() => ID)
+	id!: number;
+
+	@RelationshipField<OrmAlbum>(() => Artist, {
+		id: (entity) => entity.artist?.id,
+	})
+	renamed_artist!: Artist;
+}
+
+@Entity('Artist', {
+	provider: new MikroBackendProvider(OrmArtist, connection),
+})
+export class Artist {
+	@Field(() => ID)
+	id!: number;
+
+	@RelationshipField<Album>(() => [Album], { relatedField: 'renamed_artist' })
+	renamed_albums!: Album[];
+}
+
+describe('Top level and/or/not', () => {
+	beforeEach(resetDatabase);
+
+	test('should correctly emit _and/_or/_not', async () => {
+		const graphweaver = new Graphweaver();
+		await ConnectionManager.connect('sqlite', connection);
+
+		const response = await graphweaver.executeOperation({
+			query: gql`
+				query {
+					albums(_and: [{ id: 1 }, { id: 2 }]) {
+						id
+					}
+				}
+			`,
+		});
+		assert(response.body.kind === 'single');
+		expect(response.body.singleResult.data?.albums).toHaveLength(0);
+
+		const response2 = await graphweaver.executeOperation({
+			query: gql`
+				query {
+					albums(_or: [{ id: 1 }, { id: 2 }]) {
+						id
+					}
+				}
+			`,
+		});
+		assert(response2.body.kind === 'single');
+		expect(response2.body.singleResult.data?.albums).toHaveLength(2);
+
+		const response3 = await graphweaver.executeOperation({
+			query: gql`
+				query {
+					albums(_not: { id: 1 }) {
+						id
+					}
+				}
+			`,
+		});
+		assert(response3.body.kind === 'single');
+		expect(response3.body.singleResult.data?.albums).toHaveLength(345);
+	});
+});

--- a/src/packages/mikroorm/src/provider/provider.ts
+++ b/src/packages/mikroorm/src/provider/provider.ts
@@ -202,8 +202,12 @@ export class MikroBackendProvider<D> implements BackendProvider<D> {
 		// Check for and/or/etc at the root level and handle correctly
 		for (const rootLevelKey of Object.keys(values)) {
 			if (mikroObjectOperations.has(rootLevelKey)) {
-				for (const field of values[rootLevelKey]) {
-					mapFieldNames(field);
+				if (Array.isArray(values[rootLevelKey])) {
+					for (const field of values[rootLevelKey]) {
+						mapFieldNames(field);
+					}
+				} else {
+					mapFieldNames(values[rootLevelKey]);
 				}
 			}
 		}
@@ -284,12 +288,6 @@ export class MikroBackendProvider<D> implements BackendProvider<D> {
 
 		// Strip custom types out of the equation.
 		// This query only works if we JSON.parse(JSON.stringify(filter)):
-		//
-		// query {
-		//   drivers (filter: { region: { name: "North Shore" }}) {
-		//     id
-		//   }
-		// }
 		const where = traceSync((trace?: TraceOptions) => {
 			trace?.span.updateName('Convert filter to Mikro-Orm format');
 			return filter ? gqlToMikro(JSON.parse(JSON.stringify(filter))) : undefined;


### PR DESCRIPTION
Added _and and _or to schema generation for entity filters. Added an integration test to ensure they continue to work in their most basic form.

Makes progress on #1388 but does not address _not yet.