### PR TITLE
Fix / Relative Paths for CDK construct

### DIFF
--- a/src/packages/cdk/src/app/website.ts
+++ b/src/packages/cdk/src/app/website.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import * as cdk from 'aws-cdk-lib';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment';
@@ -33,7 +32,7 @@ export class WebsiteStack extends cdk.Stack {
 		});
 
 		new s3deploy.BucketDeployment(this, `${id}BucketDeployment`, {
-			sources: [s3deploy.Source.asset(path.join(__dirname, config.adminUI.buildPath))], // Path to your built website files
+			sources: [s3deploy.Source.asset(config.adminUI.buildPath)], // Path to your built website files
 			destinationBucket: websiteBucket,
 		});
 

--- a/src/packages/cdk/src/examples/ecs.ts
+++ b/src/packages/cdk/src/examples/ecs.ts
@@ -54,7 +54,7 @@ export const graphweaverApp = new GraphweaverApp(rootStack, 'TestGraphweaverDock
 		instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
 	},
 	adminUI: {
-		buildPath: '../../../../examples/rest/.graphweaver/admin-ui',
+		buildPath: '../../examples/rest/.graphweaver/admin-ui',
 		cert: process.env.WEBSITE_CERTIFICATE_ARN ?? 'arn:aws:acm:us-east-1:test:test:test',
 		url: 'admin-ui-ecs.graphweaver.com',
 		customHeaders: [

--- a/src/packages/cdk/src/examples/lambda.ts
+++ b/src/packages/cdk/src/examples/lambda.ts
@@ -54,7 +54,7 @@ export const graphweaverApp = new GraphweaverApp(rootStack, 'TestGraphweaverDock
 		instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
 	},
 	adminUI: {
-		buildPath: '/',
+		buildPath: '../../examples/rest/.graphweaver/admin-ui',
 		cert: 'arn:aws:acm:us-east-1:test:test:test',
 		url: 'admin-ui.test.com',
 		csp: "default-src 'self';",


### PR DESCRIPTION
Remove forced `__dirname` which will then resolve even absolute paths from node_modules.