### PR TITLE
Fix / Smaller Bundle for CDK Deploys

### DIFF
--- a/src/packages/cdk/src/app/lambda.ts
+++ b/src/packages/cdk/src/app/lambda.ts
@@ -51,6 +51,7 @@ export class LambdaStack extends cdk.NestedStack {
 				: config.lambda.buildPath,
 			bundling: {
 				externalModules: [
+					'@aws-sdk/*',
 					'sqlite3',
 					'better-sqlite3',
 					'pg-query-stream',


### PR DESCRIPTION
Mark AWS SDK as external for smaller bundles when deploying with cdk construct.