### PR TITLE
Fix / Race condition on database connection

### DIFF
--- a/src/examples/databases/src/backend/database.ts
+++ b/src/examples/databases/src/backend/database.ts
@@ -11,6 +11,7 @@ export const pgConnection = {
 		dbName: process.env.POSTGRES_DB_NAME ?? 'todo_app',
 		user: process.env.POSTGRES_DB_USER ?? 'postgres',
 		password: process.env.POSTGRES_DB_PASSWORD ?? '',
+		host: process.env.POSTGRES_DB_HOST ?? 'localhost',
 		port: parseInt(process.env.POSTGRES_DB_PORT ?? '5432'),
 	},
 };
@@ -23,6 +24,7 @@ export const myConnection = {
 		dbName: process.env.MYSQL_DB_NAME ?? 'todo_app',
 		user: process.env.MYSQL_DB_USER ?? 'root',
 		password: process.env.MYSQL_DB_PASSWORD ?? '',
+		host: process.env.MYSQL_DB_HOST ?? 'localhost',
 		port: parseInt(process.env.MYSQL_DB_PORT ?? '3306'),
 	},
 };

--- a/src/packages/mikroorm/src/database.ts
+++ b/src/packages/mikroorm/src/database.ts
@@ -298,7 +298,7 @@ class ConnectionsManager {
 		return databaseConnection;
 	}
 
-	public connect = async (id: string, connectionOptions: ConnectionOptions) => {
+	public connect = (id: string, connectionOptions: ConnectionOptions) => {
 		if (this.connections.has(id)) return this.connections.get(id);
 
 		const connect = new Promise<DatabaseImplementation>((resolve, reject) => {

--- a/src/packages/mikroorm/src/provider/provider.ts
+++ b/src/packages/mikroorm/src/provider/provider.ts
@@ -157,11 +157,16 @@ export class MikroBackendProvider<D> implements BackendProvider<D> {
 		const connectionPlugin = {
 			name: connectionManagerId,
 			event: GraphweaverRequestEvent.OnRequest,
-			next: (_: GraphweaverRequestEvent, _next: GraphweaverPluginNextFunction) => {
+			next: async (_: GraphweaverRequestEvent, _next: GraphweaverPluginNextFunction) => {
 				logger.trace(`Graphweaver OnRequest plugin called`);
 
-				const connection = ConnectionManager.database(connectionManagerId);
-				if (!connection) throw new Error('No database connection found');
+				const connection = await ConnectionManager.awaitableDatabase(connectionManagerId);
+
+				if (!connection) {
+					throw new Error(
+						`No database connection found for connectionManagerId: ${connectionManagerId} after waiting for connection. This should not happen.`
+					);
+				}
 
 				return RequestContext.create(connection.orm.em, _next, {});
 			},


### PR DESCRIPTION
If the database wasn't quick enough to establish a connection when a request came in, we had a race condition where users could receive the error "No database connection found".

Users in a docker environment were unlikely to encounter this because of the server startup plugin which establishes a database connection, but lambda users could experience this.

What was happening was the plugin to establish a connection was correctly executing, but while it was waiting for the connection to be ready, if a request came in it would not immediately have a connection, so it would error.

Now when a request comes in, if a connection attempt is currently in progress, we wait for it to be complete before proceeding with handling the request. All logic after the plugin still does not need to use async code to get the connection as it's now ready, this is only a problem for that first request, but unfortunately once that error happened, it'd put apollo server in an error state and all subsequent requests would fail.