### PR TITLE
Fix / Move CDK to Peer Dependencies

### DIFF
--- a/src/packages/cdk/package.json
+++ b/src/packages/cdk/package.json
@@ -23,14 +23,16 @@
 		"version": "npm version --no-git-tag-version",
 		"build:docker": "docker build -f src/docker/Dockerfile ../../examples/s3-storage"
 	},
-	"dependencies": {
-		"aws-cdk-lib": "2.173.1",
-		"constructs": "10.4.2"
+	"peerDependencies": {
+		"aws-cdk-lib": "^2.173.1",
+		"constructs": "^10.4.2"
 	},
 	"devDependencies": {
 		"@digitak/esrun": "3.2.26",
 		"dotenv-cli": "7.4.4",
 		"aws-cdk": "2.173.1",
+		"aws-cdk-lib": "2.173.1",
+		"constructs": "10.4.2",
 		"@exogee/graphweaver": "workspace:*",
 		"@types/node": "22.10.1",
 		"esbuild": "0.24.0",

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -1064,13 +1064,6 @@ importers:
         version: 2.1.8(@types/node@22.10.1)(lightningcss@1.27.0)
 
   packages/cdk:
-    dependencies:
-      aws-cdk-lib:
-        specifier: 2.173.1
-        version: 2.173.1(constructs@10.4.2)
-      constructs:
-        specifier: 10.4.2
-        version: 10.4.2
     devDependencies:
       '@digitak/esrun':
         specifier: 3.2.26
@@ -1084,6 +1077,12 @@ importers:
       aws-cdk:
         specifier: 2.173.1
         version: 2.173.1
+      aws-cdk-lib:
+        specifier: 2.173.1
+        version: 2.173.1(constructs@10.4.2)
+      constructs:
+        specifier: 10.4.2
+        version: 10.4.2
       dotenv-cli:
         specifier: 7.4.4
         version: 7.4.4


### PR DESCRIPTION
Move cdk and constructs out to peer dependencies so consumers can install and manage their own versions of these.