### PR TITLE
Expose config option for allowed origins

### DIFF
--- a/src/packages/cdk/src/app/lambda.ts
+++ b/src/packages/cdk/src/app/lambda.ts
@@ -1,15 +1,14 @@
-import path from 'node:path';
 import * as cdk from 'aws-cdk-lib';
+import { AccessLogFormat, LambdaRestApi, LogGroupLogDestination } from 'aws-cdk-lib/aws-apigateway';
+import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { LogGroup } from 'aws-cdk-lib/aws-logs';
-import { AccessLogFormat, LambdaRestApi, LogGroupLogDestination } from 'aws-cdk-lib/aws-apigateway';
-import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { Construct } from 'constructs';
 
-import { GraphweaverAppConfig } from './types';
 import { DatabaseStack } from './database';
+import { GraphweaverAppConfig } from './types';
 
 export class LambdaStack extends cdk.NestedStack {
 	public readonly lambda: lambda.Function;
@@ -107,7 +106,7 @@ export class LambdaStack extends cdk.NestedStack {
 				accessLogFormat: AccessLogFormat.jsonWithStandardFields(),
 			},
 			defaultCorsPreflightOptions: {
-				allowOrigins: [`https://${config.adminUI.url}`],
+				allowOrigins: config.lambda.allowedOrigins ?? [`https://${config.adminUI.url}`],
 				allowMethods: ['GET', 'POST', 'OPTIONS'],
 				allowHeaders: [
 					'Content-Type',

--- a/src/packages/cdk/src/app/types.ts
+++ b/src/packages/cdk/src/app/types.ts
@@ -1,5 +1,5 @@
 import { ResponseCustomHeader } from 'aws-cdk-lib/aws-cloudfront';
-import { IVpc, SecurityGroup, InstanceType } from 'aws-cdk-lib/aws-ec2';
+import { InstanceType, IVpc, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { PostgresEngineVersion } from 'aws-cdk-lib/aws-rds';
 
@@ -78,5 +78,7 @@ export type GraphweaverAppConfig = {
 		handler?: string;
 		// Pass the database secret ARN to the Lambda function
 		databaseSecretFullArn?: string;
+		// A list of CORS origins to allow. Defaults to the admin UI URL.
+		allowedOrigins?: string[];
 	};
 };


### PR DESCRIPTION
The CORS headers configured on the CDK lambda wrapper only allow requests from the admin UI. Exposing a config option to pass it in