### PR TITLE
Fix / Do not update generated primary key fields

### DIFF
--- a/src/packages/mikroorm/src/provider/provider.ts
+++ b/src/packages/mikroorm/src/provider/provider.ts
@@ -452,8 +452,7 @@ export class MikroBackendProvider<D> implements BackendProvider<D> {
 		// cause an error.
 		const meta = this.database.em.getMetadata().get(this.entityType.name);
 		for (const key of meta.primaryKeys) {
-			const { autoincrement } = meta.properties[key];
-			if (autoincrement) delete (updateArgsWithoutVersion as any)[key];
+			if (meta.properties[key].autoincrement) delete (updateArgsWithoutVersion as any)[key];
 		}
 
 		await this.mapAndAssignKeys(entity, this.entityType, updateArgsWithoutVersion as Partial<D>);
@@ -491,8 +490,7 @@ export class MikroBackendProvider<D> implements BackendProvider<D> {
 					// GENERATED ALWAYS AS IDENTITY where even supplying the primary key in the update query will
 					// cause an error.
 					for (const key of meta.primaryKeys) {
-						const { autoincrement } = meta.properties[key];
-						if (autoincrement) delete (item as any)[key];
+						if (meta.properties[key].autoincrement) delete (item as any)[key];
 					}
 
 					await this.mapAndAssignKeys(entity, this.entityType, item);


### PR DESCRIPTION
Fix - don't update generated primary key fields on updates. If they're autoincrement they should stay at their original values at all times, and we should not supply new ones to the queries even.