### PR TITLE
Fix / Expand Vite peer dep range to include v6.

### DIFF
--- a/src/packages/vite-plugin-graphweaver/package.json
+++ b/src/packages/vite-plugin-graphweaver/package.json
@@ -26,7 +26,7 @@
 		"vite": "6.0.3"
 	},
 	"peerDependencies": {
-		"vite": "^5.0.0"
+		"vite": "^5.0.0 || ^6.0.0"
 	},
 	"dependencies": {
 		"@exogee/graphweaver-config": "workspace:*"


### PR DESCRIPTION
We are compatible with Vite v6, so we can declare that in peer dependencies.