### PR TITLE
Fix / Declare `graphql` peer dependency.

### DIFF
--- a/src/packages/scalars/package.json
+++ b/src/packages/scalars/package.json
@@ -22,6 +22,9 @@
 		"graphql-scalars": "1.24.0",
 		"luxon": "3.5.0"
 	},
+	"peerDependencies": {
+		"graphql": "^16.0.0"
+	},
 	"devDependencies": {
 		"@types/luxon": "3.4.2",
 		"decimal.js": "10.4.3",


### PR DESCRIPTION
We depend on `graphql` being installed but do not declare it as a dependency. It should be a peer dep.