### PR TITLE
Fix / Logging in with expired tokens does not work

### DIFF
--- a/.github/workflows/auth-end-to-end-tests.yml
+++ b/.github/workflows/auth-end-to-end-tests.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4.0.0
         with:
-          version: 9.11.0
+          version: 9.15.3
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/auth-ui-end-to-end-tests.yml
+++ b/.github/workflows/auth-ui-end-to-end-tests.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4.0.0
         with:
-          version: 9.11.0
+          version: 9.15.3
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/federation-tests.yml
+++ b/.github/workflows/federation-tests.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4.0.0
         with:
-          version: 9.11.0
+          version: 9.15.3
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/mysql-end-to-end-tests.yml
+++ b/.github/workflows/mysql-end-to-end-tests.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4.0.0
         with:
-          version: 9.11.0
+          version: 9.15.3
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/other-end-to-end-tests.yml
+++ b/.github/workflows/other-end-to-end-tests.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4.0.0
         with:
-          version: 9.11.0
+          version: 9.15.3
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/postgres-end-to-end-tests.yml
+++ b/.github/workflows/postgres-end-to-end-tests.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4.0.0
         with:
-          version: 9.11.0
+          version: 9.15.3
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4.0.0
         with:
-          version: 9.11.0
+          version: 9.15.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/rest-ui-end-to-end-tests.yml
+++ b/.github/workflows/rest-ui-end-to-end-tests.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4.0.0
         with:
-          version: 9.11.0
+          version: 9.15.3
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/sqlite-end-to-end-tests.yml
+++ b/.github/workflows/sqlite-end-to-end-tests.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4.0.0
         with:
-          version: 9.11.0
+          version: 9.15.3
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/storage-provider-end-to-end-tests.yml
+++ b/.github/workflows/storage-provider-end-to-end-tests.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4.0.0
         with:
-          version: 9.11.0
+          version: 9.15.3
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4.0.0
         with:
-          version: 9.11.0
+          version: 9.15.3
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/windows-end-to-end-tests.yml
+++ b/.github/workflows/windows-end-to-end-tests.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4.0.0
         with:
-          version: 9.11.0
+          version: 9.15.3
 
       - uses: actions/setup-node@v4
         with:

--- a/src/packages/auth/src/authentication/apollo/plugin.ts
+++ b/src/packages/auth/src/authentication/apollo/plugin.ts
@@ -171,9 +171,13 @@ export const authApolloPlugin = <R>(
 				});
 
 				if (!apiKey || !apiKey.secret) {
-					apiKeyVerificationFailedMessage = 'Bad Request: API Key Authentication Failed. (E0001)';
+					apiKeyVerificationFailedMessage = 'Bad Request: API Key Authentication Failed.';
+					logger.error(
+						`API Key Authentication Failed. No API Key was received, or it had no secret.`
+					);
 				} else if (apiKey.revoked) {
-					apiKeyVerificationFailedMessage = 'Bad Request: API Key Authentication Failed. (E0002)';
+					apiKeyVerificationFailedMessage = 'Bad Request: API Key Authentication Failed.';
+					logger.error({ apiKey }, `API Key Authentication Failed. API Key is revoked.`);
 				} else if (await verifyPassword(secret, apiKey.secret)) {
 					contextValue.user = new UserProfile({
 						id: String(apiKey.id),
@@ -183,7 +187,11 @@ export const authApolloPlugin = <R>(
 					contextValue.token = {};
 					upsertAuthorizationContext(contextValue);
 				} else {
-					apiKeyVerificationFailedMessage = 'Bad Request: API Key Authentication Failed. (E0003)';
+					apiKeyVerificationFailedMessage = 'Bad Request: API Key Authentication Failed.';
+					logger.error(
+						{ apiKey },
+						`API Key Authentication Failed. Verify password call did not succeed.`
+					);
 				}
 			} else {
 				// Ok, we are working in token land at this point. We either have the following scenarios:

--- a/src/packages/auth/src/authentication/methods/magic-link.ts
+++ b/src/packages/auth/src/authentication/methods/magic-link.ts
@@ -216,8 +216,15 @@ export class MagicLink extends BaseAuthMethod {
 
 	async verifyLoginMagicLink({
 		args: { username, token },
-	}: ResolverOptions<{ username: string; token: string }>): Promise<Token> {
-		return this.verifyMagicLink(username, token);
+		context,
+	}: ResolverOptions<{ username: string; token: string }, AuthorizationContext>): Promise<Token> {
+		const result = await this.verifyMagicLink(username, token);
+
+		// If they have an expired token while successfully trying to verify a magic link, they don't actually need to get
+		// redirected to login.
+		context.skipLoginRedirect = true;
+
+		return result;
 	}
 
 	async sendChallengeMagicLink({

--- a/src/packages/auth/src/authentication/methods/password.ts
+++ b/src/packages/auth/src/authentication/methods/password.ts
@@ -354,6 +354,12 @@ export class Password<D extends CredentialStorage> extends BaseAuthMethod {
 		if (!userProfile) throw new AuthenticationError('Login unsuccessful: Authentication failed.');
 
 		const authToken = await tokenProvider.generateToken(userProfile);
+
+		// This allows people with expired tokens to not get redirected to login while trying to log in.
+		// This happens at the end of this function so that we can be sure all the other checks have passed
+		// before we say it's ok not to redirect to login.
+		context.skipLoginRedirect = true;
+
 		return authToken;
 	}
 

--- a/src/packages/auth/src/types.ts
+++ b/src/packages/auth/src/types.ts
@@ -24,6 +24,7 @@ export interface AuthorizationContext extends BaseContext {
 	token?: string | JwtPayload;
 	user?: UserProfile<unknown>;
 	redirectUri?: URL;
+	skipLoginRedirect?: boolean;
 }
 
 export enum AccessType {

--- a/src/packages/end-to-end/src/__tests__/api/auth/api-key/api-key.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/auth/api-key/api-key.test.ts
@@ -109,7 +109,7 @@ describe('API Key Authentication', () => {
 		assert(response.body.kind === 'single');
 		expect(response.body.singleResult.errors).toBeDefined();
 		expect(response.body.singleResult.errors?.[0]?.message).toBe(
-			'Bad Request: API Key Authentication Failed. (E0001)'
+			'Bad Request: API Key Authentication Failed.'
 		);
 	});
 
@@ -130,7 +130,7 @@ describe('API Key Authentication', () => {
 		assert(response.body.kind === 'single');
 		expect(response.body.singleResult.errors).toBeDefined();
 		expect(response.body.singleResult.errors?.[0]?.message).toBe(
-			'Bad Request: API Key Authentication Failed. (E0002)'
+			'Bad Request: API Key Authentication Failed.'
 		);
 	});
 
@@ -151,7 +151,7 @@ describe('API Key Authentication', () => {
 		assert(response.body.kind === 'single');
 		expect(response.body.singleResult.errors).toBeDefined();
 		expect(response.body.singleResult.errors?.[0]?.message).toBe(
-			'Bad Request: API Key Authentication Failed. (E0003)'
+			'Bad Request: API Key Authentication Failed.'
 		);
 	});
 

--- a/src/packages/end-to-end/src/__tests__/api/auth/security/invalid-token.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/auth/security/invalid-token.test.ts
@@ -74,7 +74,7 @@ describe('Security', () => {
 		});
 
 		assert(response.body.kind === 'single');
-		expect(response.body.singleResult.data).toBe([]);
+		expect(response.body.singleResult.data).toBe({ tags: null });
 		expect(response.http.headers.get('X-Auth-Redirect')).toBe(
 			`${process.env.AUTH_BASE_URI}/auth/login?redirect_uri=${encodeURIComponent(
 				process.env.AUTH_BASE_URI + '/'

--- a/src/packages/end-to-end/src/__tests__/api/auth/security/invalid-token.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/auth/security/invalid-token.test.ts
@@ -74,7 +74,7 @@ describe('Security', () => {
 		});
 
 		assert(response.body.kind === 'single');
-		expect(response.body.singleResult.data).toBe({ tags: null });
+		expect(response.body.singleResult.data).toEqual({ tags: null });
 		expect(response.http.headers.get('X-Auth-Redirect')).toBe(
 			`${process.env.AUTH_BASE_URI}/auth/login?redirect_uri=${encodeURIComponent(
 				process.env.AUTH_BASE_URI + '/'

--- a/src/packages/end-to-end/src/__tests__/api/auth/security/invalid-token.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/auth/security/invalid-token.test.ts
@@ -74,9 +74,7 @@ describe('Security', () => {
 		});
 
 		assert(response.body.kind === 'single');
-		expect(response.body.singleResult.errors?.[0]?.message).toEqual(
-			'Unauthorized: Token verification failed.'
-		);
+		expect(response.body.singleResult.data).toBe([]);
 		expect(response.http.headers.get('X-Auth-Redirect')).toBe(
 			`${process.env.AUTH_BASE_URI}/auth/login?redirect_uri=${encodeURIComponent(
 				process.env.AUTH_BASE_URI + '/'


### PR DESCRIPTION
- Now treating users with expired tokens as guests instead of throwing
- If this error occurs while successfully logging in, there's no need to redirect to the login, so we no longer do.
- To achieve this, there's a new flag in context that a resolver can set to avoid the redirect to login specifically in the case of token expiry.
- This PR also resolves information disclosure in errors in the API key authentication module, instead logging the reason for the rejection.