### PR TITLE
Fix / Deduplicate keys should they come in to be loaded.

### DIFF
--- a/src/packages/core/src/base-loader.ts
+++ b/src/packages/core/src/base-loader.ts
@@ -57,13 +57,15 @@ const getBaseLoadOneLoader = <G = unknown, D = unknown>({
 		}
 
 		const fetchRecordsById = async (keys: readonly string[]) => {
+			const uniqueKeys = [...new Set(keys)];
+
 			logger.trace(
-				`DataLoader: Loading ${gqlTypeName}, ${keys.length} record(s): (${keys.join(', ')})`
+				`DataLoader: Loading ${gqlTypeName}, ${uniqueKeys.length} record(s): (${uniqueKeys.join(', ')})`
 			);
 			const primaryKeyField = graphweaverMetadata.primaryKeyFieldForEntity(entity) as keyof D;
 
 			let listFilter = {
-				[`${String(primaryKeyField)}_in`]: keys,
+				[`${String(primaryKeyField)}_in`]: uniqueKeys,
 				// Note: Typecast here shouldn't be necessary, but FilterEntity<G> doesn't like this.
 			} as Filter<G>;
 


### PR DESCRIPTION
Currently Dataloader sends us duplicate keys: https://github.com/graphql/dataloader/issues/49

This adds deduplication to the filter that's passed down to the provider to load. Most providers are fine with the duplicates, but it makes the request more difficult than it needs to be for the datasource.