### PR TITLE
Fix / Only Trigger Transactional Assertion in ACLs if Row Level ACL Rules are Specified

### DIFF
--- a/src/packages/auth/src/auth-utils.ts
+++ b/src/packages/auth/src/auth-utils.ts
@@ -181,7 +181,8 @@ export const assertObjectLevelPermissions = async <G, TContext extends Authoriza
 export async function checkEntityPermission<G = unknown, D = unknown>(
 	entityName: string,
 	id: string | number,
-	accessType: AccessType
+	accessType: AccessType,
+	transactional: boolean
 ) {
 	const acl = getACL(entityName);
 	const accessControlEntry = buildAccessControlEntryForUser(
@@ -222,6 +223,19 @@ export async function checkEntityPermission<G = unknown, D = unknown>(
 		_and: [{ [primaryKeyField]: id }, accessFilter],
 	};
 
+	// If we've made it down here, we need to assert that this is all happening within a transaction
+	// or it's possible we'll do a partial write before we discover they were trying to do something
+	// they shouldn't be allowed to do.
+	//
+	// We don't want this check higher up, because it should only be applied if they've actually configured
+	// row level security ACLs.
+	if (!transactional) {
+		logger.error(
+			'Row Level Security can only be applied within a transaction and this hook is not transactional.'
+		);
+		throw new Error(GENERIC_AUTH_ERROR_MESSAGE);
+	}
+
 	try {
 		const { provider } = graphweaverMetadata.getEntityByName(entityName) ?? {};
 		if (!provider) {
@@ -249,7 +263,8 @@ export async function checkAuthorization<G = unknown>(
 	entityName: string,
 	id: string | number,
 	requestInput: Partial<G>,
-	requiredPermission: AccessType
+	requiredPermission: AccessType,
+	transactional: boolean
 ) {
 	logger.trace({ entityName, id, requestInput, requiredPermission }, 'Entering checkAuthorization');
 
@@ -266,7 +281,7 @@ export async function checkAuthorization<G = unknown>(
 	logger.trace('They can, now checking entity permissions.');
 
 	// Now check whether the root entity passes permissions filters (if set)
-	await checkEntityPermission(entityName, id, requiredPermission);
+	await checkEntityPermission(entityName, id, requiredPermission, transactional);
 
 	// Recurse through the list
 	const relatedEntityAuthChecks: Promise<any>[] = [];
@@ -296,7 +311,13 @@ export async function checkAuthorization<G = unknown>(
 				// The creation hook will triggered for that entity and the permissions checked
 				if (relatedId) {
 					relatedEntityAuthChecks.push(
-						checkAuthorization(relatedEntityMetadata.name, relatedId, item, accessType)
+						checkAuthorization(
+							relatedEntityMetadata.name,
+							relatedId,
+							item,
+							accessType,
+							transactional
+						)
 					);
 				}
 			}

--- a/src/packages/auth/src/decorators/hooks/acl.ts
+++ b/src/packages/auth/src/decorators/hooks/acl.ts
@@ -462,9 +462,7 @@ export const afterCreateOrUpdate = (
 		const items = params.args.items;
 		const entities = (params.entities ?? []) as G[];
 
-		// 1. Check to ensure we are within a transaction
-		assertTransactional(params.transactional);
-		// 2. Check user has permission for each for each entity
+		// Check user has permission for each for each entity, recursing as we go.
 		const authChecks = entities.map((entity, index) =>
 			entity?.[primaryKeyField]
 				? checkAuthorization(
@@ -473,7 +471,8 @@ export const afterCreateOrUpdate = (
 							? Number(entity[primaryKeyField])
 							: String(entity[primaryKeyField]),
 						items[index],
-						accessType
+						accessType,
+						params.transactional
 					)
 				: undefined
 		);


### PR DESCRIPTION
Move the transactional assertion down in the checks so that it only triggers after create if a row level ACL is actually configured.

Currently if you do not configure any row level ACLs and do a create on a non-transactional provider, Graphweaver complains that you aren't in a transaction, when this is irrelevant because we're not even going to query the datasource to check ACL rules anyway.