### PR TITLE
Remove capitalize style on input component

### DIFF
--- a/src/packages/admin-ui-components/src/input/styles.module.css
+++ b/src/packages/admin-ui-components/src/input/styles.module.css
@@ -12,7 +12,6 @@
 
 .input input {
 	all: unset;
-	text-transform: capitalize;
 	color: hsl(0, 0%, 50%);
 	font-size: 100%;
 	background-color: var(--select-background);


### PR DESCRIPTION
The input component is styled to `capitalize`all input text, this makes it a bit hard to use, because the search Is case sensitive so it can be misleading why you have no hits