### PR TITLE
Removed capitalisation in Admin UI filter inputs

### DIFF
--- a/src/packages/admin-ui-components/src/combo-box/styles.module.css
+++ b/src/packages/admin-ui-components/src/combo-box/styles.module.css
@@ -79,7 +79,6 @@
 
 .placeholder {
 	color: #6c757d;
-	text-transform: capitalize;
 	padding: 4px 30px 4px 12px;
 	line-height: 23px;
 }

--- a/src/packages/admin-ui-components/src/date-picker/styles.module.css
+++ b/src/packages/admin-ui-components/src/date-picker/styles.module.css
@@ -103,7 +103,6 @@
 	overflow: hidden;
 	color: #6c757d;
 	padding: 5px 8px;
-	text-transform: capitalize;
 }
 
 .inputFieldActive {


### PR DESCRIPTION
Re-opening this PR on the main repo instead of a fork while the issue with auth test secrets remains unresolved.

https://github.com/exogee-technology/graphweaver/issues/1563

Removed some CSS that was capitalising the placeholders for some input components used for filtering on the Admin UI.

Now the field names should match the GraphQL entity field names by default.