### PR TITLE
When acl says create:true, read:false then we should allow creation of record if query is not asking for any fields to be read

### DIFF
--- a/src/packages/auth/src/authentication/entities/credential.ts
+++ b/src/packages/auth/src/authentication/entities/credential.ts
@@ -11,6 +11,7 @@ export interface CredentialStorage {
 	Everyone: {
 		// everyone can read their own credentials by default
 		read: (context) => ({ id: context.user?.id }),
+		create: true,
 	},
 })
 @Entity('Credential', {

--- a/src/packages/auth/src/decorators/hooks/acl.ts
+++ b/src/packages/auth/src/decorators/hooks/acl.ts
@@ -167,13 +167,16 @@ const generatePermissionListFromFields = <G>(
 	entityMetadata: EntityMetadata<G>,
 	requestedFields: ResolveTree
 ) => {
-	const permissionsList: RequiredPermission[] = [
-		{
+	const permissionsList: RequiredPermission[] = [];
+
+	if (Object.keys(requestedFields.fieldsByTypeName).length > 0) {
+		// If at least one field is requested, do they have permission to read the entity?
+		permissionsList.push({
 			entityName: entityMetadata.name,
 			accessType: AccessType.Read,
 			type: RequirePermissionType.ENTITY,
-		},
-	];
+		});
+	}
 
 	for (const [entityName, fields] of Object.entries(requestedFields.fieldsByTypeName)) {
 		if (entityName === graphweaverMetadata.federationNameForGraphQLTypeName('AggregationResult')) {


### PR DESCRIPTION
This started because currently the `loginPassword` flow where there is a `Credential` entity automatically created by Graphweaver required that entity to have ACL

> "allow `read` access to all and `create` access to all" 

in order for anonymous users to create a credential record. Note that we should 

> "allow `read` access to owner and `create` access to all" 

in order for users to only read their record, but also anonymous users that are first signing-up to create a record.

This was because we were restricting `read` access to any entity that needed `create` access.

This PR makes it so that if you are creating an entity record and not asking for reading any properties of that entity, then we don't look at the `read` access, only at the `create` access.

If you are creating an entity record and also asking for properties on that entity then we do have to look at the `read` access because you are reading that record.

For the `Credential` entity, we are using `await password.createCredential(...)` which doesn't ask for any properties on the newly created record. Thus, we can create that record without looking at the `read` access permissions, only at the `create` access permission.