### PR TITLE
Fix: Pagination on Admin UI for some backend providers

### DIFF
--- a/src/examples/auth-zero/src/frontend/types.generated.ts
+++ b/src/examples/auth-zero/src/frontend/types.generated.ts
@@ -43,9 +43,9 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
-  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/auth-zero/src/frontend/types.generated.ts
+++ b/src/examples/auth-zero/src/frontend/types.generated.ts
@@ -43,6 +43,7 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
+  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
 };

--- a/src/examples/auth-zero/src/types.generated.ts
+++ b/src/examples/auth-zero/src/types.generated.ts
@@ -43,9 +43,9 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
-  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/auth-zero/src/types.generated.ts
+++ b/src/examples/auth-zero/src/types.generated.ts
@@ -43,6 +43,7 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
+  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
 };

--- a/src/examples/aws-cognito/src/frontend/types.generated.ts
+++ b/src/examples/aws-cognito/src/frontend/types.generated.ts
@@ -41,6 +41,7 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
+  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
 };

--- a/src/examples/aws-cognito/src/frontend/types.generated.ts
+++ b/src/examples/aws-cognito/src/frontend/types.generated.ts
@@ -41,9 +41,9 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
-  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/aws-cognito/src/types.generated.ts
+++ b/src/examples/aws-cognito/src/types.generated.ts
@@ -41,6 +41,7 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
+  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
 };

--- a/src/examples/aws-cognito/src/types.generated.ts
+++ b/src/examples/aws-cognito/src/types.generated.ts
@@ -41,9 +41,9 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
-  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/federation/src/frontend/types.generated.ts
+++ b/src/examples/federation/src/frontend/types.generated.ts
@@ -44,9 +44,9 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
-  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/federation/src/frontend/types.generated.ts
+++ b/src/examples/federation/src/frontend/types.generated.ts
@@ -44,6 +44,7 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
+  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
 };

--- a/src/examples/federation/src/types.generated.ts
+++ b/src/examples/federation/src/types.generated.ts
@@ -44,9 +44,9 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
-  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/federation/src/types.generated.ts
+++ b/src/examples/federation/src/types.generated.ts
@@ -44,6 +44,7 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
+  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
 };

--- a/src/examples/microsoft-entra/src/frontend/types.generated.ts
+++ b/src/examples/microsoft-entra/src/frontend/types.generated.ts
@@ -43,9 +43,9 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
-  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/microsoft-entra/src/frontend/types.generated.ts
+++ b/src/examples/microsoft-entra/src/frontend/types.generated.ts
@@ -43,6 +43,7 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
+  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
 };

--- a/src/examples/microsoft-entra/src/types.generated.ts
+++ b/src/examples/microsoft-entra/src/types.generated.ts
@@ -43,9 +43,9 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
-  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/microsoft-entra/src/types.generated.ts
+++ b/src/examples/microsoft-entra/src/types.generated.ts
@@ -43,6 +43,7 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
+  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
 };

--- a/src/examples/okta/src/frontend/types.generated.ts
+++ b/src/examples/okta/src/frontend/types.generated.ts
@@ -43,9 +43,9 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
-  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/okta/src/frontend/types.generated.ts
+++ b/src/examples/okta/src/frontend/types.generated.ts
@@ -43,6 +43,7 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
+  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
 };

--- a/src/examples/okta/src/types.generated.ts
+++ b/src/examples/okta/src/types.generated.ts
@@ -43,9 +43,9 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
-  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/okta/src/types.generated.ts
+++ b/src/examples/okta/src/types.generated.ts
@@ -43,6 +43,7 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
+  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
 };

--- a/src/examples/rest-with-auth/src/frontend/types.generated.ts
+++ b/src/examples/rest-with-auth/src/frontend/types.generated.ts
@@ -45,6 +45,7 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
+  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
 };

--- a/src/examples/rest-with-auth/src/frontend/types.generated.ts
+++ b/src/examples/rest-with-auth/src/frontend/types.generated.ts
@@ -45,9 +45,9 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
-  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/rest-with-auth/src/types.generated.ts
+++ b/src/examples/rest-with-auth/src/types.generated.ts
@@ -45,6 +45,7 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
+  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
 };

--- a/src/examples/rest-with-auth/src/types.generated.ts
+++ b/src/examples/rest-with-auth/src/types.generated.ts
@@ -45,9 +45,9 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
-  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/rest-with-auth/types.generated.ts
+++ b/src/examples/rest-with-auth/types.generated.ts
@@ -45,6 +45,7 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
+  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
 };

--- a/src/examples/rest-with-auth/types.generated.ts
+++ b/src/examples/rest-with-auth/types.generated.ts
@@ -45,9 +45,9 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
-  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/rest/src/frontend/types.generated.ts
+++ b/src/examples/rest/src/frontend/types.generated.ts
@@ -41,6 +41,7 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
+  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
 };

--- a/src/examples/rest/src/frontend/types.generated.ts
+++ b/src/examples/rest/src/frontend/types.generated.ts
@@ -41,9 +41,9 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
-  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/rest/src/types.generated.ts
+++ b/src/examples/rest/src/types.generated.ts
@@ -41,6 +41,7 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
+  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
 };

--- a/src/examples/rest/src/types.generated.ts
+++ b/src/examples/rest/src/types.generated.ts
@@ -41,9 +41,9 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
-  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/sqlite/src/frontend/types.generated.ts
+++ b/src/examples/sqlite/src/frontend/types.generated.ts
@@ -47,9 +47,9 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
-  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/sqlite/src/frontend/types.generated.ts
+++ b/src/examples/sqlite/src/frontend/types.generated.ts
@@ -47,6 +47,7 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
+  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
 };

--- a/src/examples/sqlite/src/types.generated.ts
+++ b/src/examples/sqlite/src/types.generated.ts
@@ -47,9 +47,9 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
-  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/sqlite/src/types.generated.ts
+++ b/src/examples/sqlite/src/types.generated.ts
@@ -47,6 +47,7 @@ export type AdminUiEntityMetadata = {
   name: Scalars['String']['output'];
   plural: Scalars['String']['output'];
   primaryKeyField: Scalars['String']['output'];
+  providerComparisonSupported: Scalars['Boolean']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
 };

--- a/src/packages/admin-ui-components/src/entity-list/component.tsx
+++ b/src/packages/admin-ui-components/src/entity-list/component.tsx
@@ -100,14 +100,18 @@ export const EntityList = <TData extends object>() => {
 
 	const handleFetchNextPage = async () => {
 		const nextPage = Math.ceil((data?.result.length ?? 0) / PAGE_SIZE);
+		const offset = providerComparisonSupported ? 0 : nextPage * PAGE_SIZE;
+
+		const filterVar = variables.filter ?? {};
+		const filter = providerComparisonSupported ? addStabilizationToFilter(filterVar, sort, data?.result?.[data.result.length - 1]) : filterVar;
 		fetchMore({
 			variables: {
 				...variables,
 				pagination: {
 					...variables.pagination,
-					offset: nextPage * PAGE_SIZE,
+					offset
 				},
-				filter: providerComparisonSupported ? variables.filter ?? {} : addStabilizationToFilter(variables.filter ?? {}, sort, data?.result?.[0]),
+				filter
 			},
 		});
 	};

--- a/src/packages/admin-ui-components/src/entity-list/component.tsx
+++ b/src/packages/admin-ui-components/src/entity-list/component.tsx
@@ -47,6 +47,7 @@ export const EntityList = <TData extends object>() => {
 		defaultFilter,
 		fieldForDetailPanelNavigationId,
 		excludeFromTracing,
+		providerComparisonSupported
 	} = entity;
 	const columns = useMemo(
 		() => convertEntityToColumns(entity, entityByType),
@@ -106,7 +107,7 @@ export const EntityList = <TData extends object>() => {
 					...variables.pagination,
 					offset: nextPage * PAGE_SIZE,
 				},
-				filter: addStabilizationToFilter(variables.filter ?? {}, sort, data?.result?.[0]),
+				filter: providerComparisonSupported ? variables.filter ?? {} : addStabilizationToFilter(variables.filter ?? {}, sort, data?.result?.[0]),
 			},
 		});
 	};

--- a/src/packages/admin-ui-components/src/entity-list/component.tsx
+++ b/src/packages/admin-ui-components/src/entity-list/component.tsx
@@ -47,7 +47,7 @@ export const EntityList = <TData extends object>() => {
 		defaultFilter,
 		fieldForDetailPanelNavigationId,
 		excludeFromTracing,
-		providerComparisonSupported
+		supportsPseudoCursorPagination
 	} = entity;
 	const columns = useMemo(
 		() => convertEntityToColumns(entity, entityByType),
@@ -100,10 +100,10 @@ export const EntityList = <TData extends object>() => {
 
 	const handleFetchNextPage = async () => {
 		const nextPage = Math.ceil((data?.result.length ?? 0) / PAGE_SIZE);
-		const offset = providerComparisonSupported ? 0 : nextPage * PAGE_SIZE;
+		const offset = supportsPseudoCursorPagination ? 0 : nextPage * PAGE_SIZE;
 
 		const filterVar = variables.filter ?? {};
-		const filter = providerComparisonSupported ? addStabilizationToFilter(filterVar, sort, data?.result?.[data.result.length - 1]) : filterVar;
+		const filter = supportsPseudoCursorPagination ? addStabilizationToFilter(filterVar, sort, data?.result?.[data.result.length - 1]) : filterVar;
 		fetchMore({
 			variables: {
 				...variables,

--- a/src/packages/admin-ui-components/src/utils/graphql.ts
+++ b/src/packages/admin-ui-components/src/utils/graphql.ts
@@ -17,7 +17,7 @@ export const SCHEMA_QUERY = gql`
 				defaultSort
 				hideInSideBar
 				supportedAggregationTypes
-				providerComparisonSupported
+				supportsPseudoCursorPagination
 				fields {
 					name
 					type

--- a/src/packages/admin-ui-components/src/utils/graphql.ts
+++ b/src/packages/admin-ui-components/src/utils/graphql.ts
@@ -17,6 +17,7 @@ export const SCHEMA_QUERY = gql`
 				defaultSort
 				hideInSideBar
 				supportedAggregationTypes
+				providerComparisonSupported
 				fields {
 					name
 					type

--- a/src/packages/admin-ui-components/src/utils/use-schema.ts
+++ b/src/packages/admin-ui-components/src/utils/use-schema.ts
@@ -32,6 +32,7 @@ export interface Entity {
 	summaryField?: string;
 	fieldForDetailPanelNavigationId: string;
 	supportedAggregationTypes: AggregationType[];
+	providerComparisonSupported: boolean;
 	fields: EntityField[];
 	defaultFilter?: Filter;
 	defaultSort?: SortEntity;

--- a/src/packages/admin-ui-components/src/utils/use-schema.ts
+++ b/src/packages/admin-ui-components/src/utils/use-schema.ts
@@ -32,7 +32,7 @@ export interface Entity {
 	summaryField?: string;
 	fieldForDetailPanelNavigationId: string;
 	supportedAggregationTypes: AggregationType[];
-	providerComparisonSupported: boolean;
+	supportsPseudoCursorPagination: boolean;
 	fields: EntityField[];
 	defaultFilter?: Filter;
 	defaultSort?: SortEntity;

--- a/src/packages/apollo-client/src/index.ts
+++ b/src/packages/apollo-client/src/index.ts
@@ -85,7 +85,7 @@ export const generateTypePolicies = (entities: Entity[]) => {
 export const addStabilizationToFilter = <TData>(
 	filter: Record<string, unknown>,
 	sort: SortEntity,
-	firstElement: TData
+	lastElement: TData
 ) => {
 	const filters = {
 		...filter,
@@ -98,7 +98,7 @@ export const addStabilizationToFilter = <TData>(
 
 		filters[stabilizationKeys] = filters[stabilizationKeys] ?? [];
 		filters[stabilizationKeys].push(`${key}_${operationKey}`);
-		filters[`${key}_${operationKey}`] = firstElement[key as keyof TData];
+		filters[`${key}_${operationKey}`] = lastElement[key as keyof TData];
 	}
 
 	return filters;

--- a/src/packages/core/src/metadata-service/entity.ts
+++ b/src/packages/core/src/metadata-service/entity.ts
@@ -52,7 +52,7 @@ export class AdminUiEntityMetadata {
 	supportedAggregationTypes!: AggregationType[];
 
 	@Field(() => Boolean)
-	providerComparisonSupported!: boolean;
+	supportsPseudoCursorPagination!: boolean;
 
 	@Field(() => Boolean)
 	hideInSideBar!: boolean;

--- a/src/packages/core/src/metadata-service/entity.ts
+++ b/src/packages/core/src/metadata-service/entity.ts
@@ -52,6 +52,9 @@ export class AdminUiEntityMetadata {
 	supportedAggregationTypes!: AggregationType[];
 
 	@Field(() => Boolean)
+	providerComparisonSupported!: boolean;
+
+	@Field(() => Boolean)
 	hideInSideBar!: boolean;
 
 	@Field(() => Boolean)

--- a/src/packages/core/src/metadata-service/resolver.ts
+++ b/src/packages/core/src/metadata-service/resolver.ts
@@ -166,6 +166,7 @@ export const resolveAdminUiMetadata = (hooks?: Hooks) => {
 				supportedAggregationTypes: [
 					...(provider?.backendProviderConfig?.supportedAggregationTypes ?? new Set()),
 				],
+				providerComparisonSupported: provider?.backendProviderConfig?.providerComparisonSupported ?? false,
 			};
 		});
 

--- a/src/packages/core/src/metadata-service/resolver.ts
+++ b/src/packages/core/src/metadata-service/resolver.ts
@@ -166,7 +166,7 @@ export const resolveAdminUiMetadata = (hooks?: Hooks) => {
 				supportedAggregationTypes: [
 					...(provider?.backendProviderConfig?.supportedAggregationTypes ?? new Set()),
 				],
-				providerComparisonSupported: provider?.backendProviderConfig?.providerComparisonSupported ?? false,
+				supportsPseudoCursorPagination: provider?.backendProviderConfig?.supportsPseudoCursorPagination ?? false,
 			};
 		});
 

--- a/src/packages/core/src/types.ts
+++ b/src/packages/core/src/types.ts
@@ -216,6 +216,7 @@ export interface BackendProviderConfig {
 	// Default is 'find', which will call the find method on the provider with a filter like `{ id_in: ['1', '2'] }`.
 	// If you specify 'findOne', it will repeatedly call the findOne method on the provider with a filter like `{ id: '1' }`.
 	idListLoadingMethod?: 'find' | 'findOne';
+	providerComparisonSupported?: boolean;
 }
 
 export type Constructor<T extends object, Arguments extends unknown[] = any[]> = new (

--- a/src/packages/core/src/types.ts
+++ b/src/packages/core/src/types.ts
@@ -216,7 +216,7 @@ export interface BackendProviderConfig {
 	// Default is 'find', which will call the find method on the provider with a filter like `{ id_in: ['1', '2'] }`.
 	// If you specify 'findOne', it will repeatedly call the findOne method on the provider with a filter like `{ id: '1' }`.
 	idListLoadingMethod?: 'find' | 'findOne';
-	providerComparisonSupported?: boolean;
+	supportsPseudoCursorPagination?: boolean;
 }
 
 export type Constructor<T extends object, Arguments extends unknown[] = any[]> = new (

--- a/src/packages/mikroorm/src/provider/provider.ts
+++ b/src/packages/mikroorm/src/provider/provider.ts
@@ -99,6 +99,7 @@ export class MikroBackendProvider<D> implements BackendProvider<D> {
 		pagination: false,
 		orderBy: false,
 		supportedAggregationTypes: new Set<AggregationType>([AggregationType.COUNT]),
+		providerComparisonSupported: true,
 	};
 
 	get backendId() {

--- a/src/packages/mikroorm/src/provider/provider.ts
+++ b/src/packages/mikroorm/src/provider/provider.ts
@@ -99,7 +99,7 @@ export class MikroBackendProvider<D> implements BackendProvider<D> {
 		pagination: false,
 		orderBy: false,
 		supportedAggregationTypes: new Set<AggregationType>([AggregationType.COUNT]),
-		providerComparisonSupported: true,
+		supportsPseudoCursorPagination: true,
 	};
 
 	get backendId() {


### PR DESCRIPTION
The Admin UI uses a pseudo-cursor for pagination, and to avoid duplicate records that would appear when something gets created or deleted if paging with limit/offset, it instead uses comparison with the last record on the last page to get the next page.

We discovered that this doesn't work as expected for some providers, because they don't support comparing string ID fields. This PR adds a flag to `BackendProviderConfig` for if comparison is supported or not by the provider (false by default). This is set true for all the built-in MikroORM providers. The Admin UI queries for this flag and changes how it paginates accordingly.
