### PR TITLE
Add option to override existing ACL during registration

### DIFF
--- a/src/packages/auth/src/decorators/apply-access-control-list.ts
+++ b/src/packages/auth/src/decorators/apply-access-control-list.ts
@@ -10,11 +10,19 @@ import { AccessType, AccessControlList, AuthorizationContext } from '../types';
 import { AclMap } from '../helper-functions';
 import { afterCreateOrUpdate, beforeDelete, beforeRead, beforeCreateOrUpdate } from './hooks/acl';
 
+interface AclRegistrationOptions {
+	/**
+	 * By default if an ACL already exists for the entity, an error will be thrown. If you want to override the existing ACL if already exists, set this to true.
+	 */
+	overrideIfExists?: boolean;
+}
+
 export const registerAccessControlListHook = <G, TContext extends AuthorizationContext>(
 	entityName: string,
-	acl: Partial<AccessControlList<G, TContext>>
+	acl: Partial<AccessControlList<G, TContext>>,
+	options: AclRegistrationOptions = {}
 ) => {
-	if (AclMap.get(entityName)) {
+	if (!options.overrideIfExists && AclMap.get(entityName)) {
 		throw new Error(`An ACL already exists for ${entityName}`);
 	}
 	AclMap.set(entityName, acl);
@@ -51,9 +59,10 @@ export const registerAccessControlListHook = <G, TContext extends AuthorizationC
 };
 
 export function ApplyAccessControlList<G, TContext extends AuthorizationContext>(
-	acl: Partial<AccessControlList<G, TContext>>
+	acl: Partial<AccessControlList<G, TContext>>,
+	options: AclRegistrationOptions = {}
 ) {
 	return function (constructor: any): void {
-		registerAccessControlListHook(constructor.name, acl);
+		registerAccessControlListHook(constructor.name, acl, options);
 	};
 }


### PR DESCRIPTION
This change in Graphweaver allows us to do this:

<img width="611" alt="image" src="https://github.com/user-attachments/assets/8ee52052-208f-4cd3-9c73-96708c25c49e" />

without getting a `This entity already has a ACL registered` error.

It allows us to override ACLs.

This change came about because in one of our projects we wanted to restrict access to the Admin UI to users with ADMIN role only.