### PR TITLE
Change / Move from React Router to Wouter

### DIFF
--- a/src/examples/rest-with-auth/package.json
+++ b/src/examples/rest-with-auth/package.json
@@ -34,7 +34,8 @@
 		"graphql": "16.10.0",
 		"graphweaver": "workspace:*",
 		"mysql2": "3.12.0",
-		"react": "19.0.0"
+		"react": "19.0.0",
+		"wouter": "3.6.0"
 	},
 	"devDependencies": {
 		"@types/node": "22.10.1",

--- a/src/examples/rest-with-auth/src/admin-ui/custom-pages/welcome-page/component.tsx
+++ b/src/examples/rest-with-auth/src/admin-ui/custom-pages/welcome-page/component.tsx
@@ -1,46 +1,58 @@
 import {
 	Arrow,
 	Button,
+	localStorageAuthKey,
 	Spacer,
 	WelcomePage as WelcomePageLayout,
 } from '@exogee/graphweaver-admin-ui-components';
+import { Redirect } from 'wouter';
 import styles from './styles.module.css';
 
-export const WelcomePage = () => (
-	<WelcomePageLayout skipPath="/User">
-		<Spacer height={30} />
-		<h2 className={styles.heading}>Rest + Full Auth Example</h2>
-		<Spacer height={30} />
-		<p>
-			This example shows a MySQL database joined with a simple REST API with Graphweaver. Full auth
-			/ RBAC / multi-factor / etc is also demonstrated.
-		</p>
-		<Spacer height={20} />
-		<p>
-			In this example, there are two roles. Light side users are only able to see and manage their
-			own tasks, while dark side users can see and manage all tasks. When creating a task, the
-			application will prompt for step-up multifactor auth.
-		</p>
-		<Spacer height={20} />
-		<p>
-			To get started, copy the .env.example file to just .env, then follow the steps in the readme
-			to generate your keys.
-		</p>
-		<Spacer height={10} />
-		<p>
-			If you're stuck,{' '}
-			<a
-				href="https://join.slack.com/t/graphweaver/shared_invite/zt-2hxeb04d3-reNTqeVUAWy2YVXWscWRaw"
-				target="_blank"
-				rel="noopener noreferrer"
-			>
-				reach out to us on Slack
-			</a>
-			. We're here to help!
-		</p>
-		<Spacer height={30} />
-		<Button className={styles.button} href="/User">
-			Get started! <Arrow className={styles.arrow} />
-		</Button>
-	</WelcomePageLayout>
-);
+export const WelcomePage = () => {
+	// This specific welcome page should pretend to need auth. There's nothing secret about this
+	// content, but because it doesn't actually make any API calls, it would normally render.
+	//
+	// It's better for UX if we redirect to the login page instead.
+	if (!localStorage.getItem(localStorageAuthKey)) {
+		return <Redirect to={`/auth/login?redirect_uri=${encodeURIComponent('/welcome')}`} />;
+	}
+
+	return (
+		<WelcomePageLayout skipPath="/User">
+			<Spacer height={30} />
+			<h2 className={styles.heading}>Rest + Full Auth Example</h2>
+			<Spacer height={30} />
+			<p>
+				This example shows a MySQL database joined with a simple REST API with Graphweaver. Full
+				auth / RBAC / multi-factor / etc is also demonstrated.
+			</p>
+			<Spacer height={20} />
+			<p>
+				In this example, there are two roles. Light side users are only able to see and manage their
+				own tasks, while dark side users can see and manage all tasks. When creating a task, the
+				application will prompt for step-up multifactor auth.
+			</p>
+			<Spacer height={20} />
+			<p>
+				To get started, copy the .env.example file to just .env, then follow the steps in the readme
+				to generate your keys.
+			</p>
+			<Spacer height={10} />
+			<p>
+				If you're stuck,{' '}
+				<a
+					href="https://join.slack.com/t/graphweaver/shared_invite/zt-2hxeb04d3-reNTqeVUAWy2YVXWscWRaw"
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					reach out to us on Slack
+				</a>
+				. We're here to help!
+			</p>
+			<Spacer height={30} />
+			<Button className={styles.button} href="/User">
+				Get started! <Arrow className={styles.arrow} />
+			</Button>
+		</WelcomePageLayout>
+	);
+};

--- a/src/examples/rest-with-auth/src/admin-ui/custom-pages/welcome-page/component.tsx
+++ b/src/examples/rest-with-auth/src/admin-ui/custom-pages/welcome-page/component.tsx
@@ -14,7 +14,7 @@ export const WelcomePage = () => {
 	//
 	// It's better for UX if we redirect to the login page instead.
 	if (!localStorage.getItem(localStorageAuthKey)) {
-		return <Redirect to={`/auth/login?redirect_uri=${encodeURIComponent('/welcome')}`} />;
+		return <Redirect to={`/auth/login?redirect_uri=${encodeURI(window.location.href)}`} />;
 	}
 
 	return (

--- a/src/examples/s3-storage/src/frontend/types.generated.ts
+++ b/src/examples/s3-storage/src/frontend/types.generated.ts
@@ -43,6 +43,7 @@ export type AdminUiEntityMetadata = {
   primaryKeyField: Scalars['String']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/s3-storage/src/types.generated.ts
+++ b/src/examples/s3-storage/src/types.generated.ts
@@ -43,6 +43,7 @@ export type AdminUiEntityMetadata = {
   primaryKeyField: Scalars['String']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/xero/package.json
+++ b/src/examples/xero/package.json
@@ -44,7 +44,7 @@
 		"prop-types": "15.8.1",
 		"react": "19.0.0",
 		"react-dom": "19.0.0",
-		"react-router-dom": "6.28.0",
+		"wouter": "3.6.0",
 		"xero-node": "10.0.0"
 	},
 	"devDependencies": {

--- a/src/examples/xero/src/admin-ui/custom-pages/dashboards/single-company/component.tsx
+++ b/src/examples/xero/src/admin-ui/custom-pages/dashboards/single-company/component.tsx
@@ -1,6 +1,6 @@
 import { ResponsiveLine } from '@nivo/line';
 import React from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'wouter';
 import { gql } from '@apollo/client';
 import { Loader } from '@exogee/graphweaver-admin-ui-components';
 
@@ -26,7 +26,7 @@ export const singleCompanyQuery = gql`
 `;
 
 export const SingleCompany = () => {
-	const { tenantId } = useParams();
+	const { tenantId } = useParams<{ tenantId: string }>();
 
 	const { data, loading, error } = useSingleCompanyProfitAndLossRowsQuery({
 		variables: { tenantId },

--- a/src/examples/xero/src/admin-ui/custom-pages/index.tsx
+++ b/src/examples/xero/src/admin-ui/custom-pages/index.tsx
@@ -5,6 +5,7 @@ import { XeroAuthCodeReceiver } from './xero-auth-code-receiver';
 import { AllCompanies, SingleCompany } from './dashboards';
 import { TenantsQuery } from './index.generated';
 import { WelcomePage } from './welcome-page';
+import { Route } from 'wouter';
 
 const tenantsQuery = gql`
 	query Tenants {
@@ -31,17 +32,16 @@ export const customPages = {
 		},
 		{
 			path: 'xero-dashboard',
-			element: <DefaultLayout />,
-			children: [
-				{
-					index: true,
-					element: <AllCompanies />,
-				},
-				{
-					path: ':tenantId',
-					element: <SingleCompany />,
-				},
-			],
+			element: (
+				<DefaultLayout>
+					<Route path="/:tenantId">
+						<SingleCompany />
+					</Route>
+					<Route path="/">
+						<AllCompanies />
+					</Route>
+				</DefaultLayout>
+			),
 		},
 	],
 

--- a/src/examples/xero/src/admin-ui/custom-pages/xero-auth-code-receiver.tsx
+++ b/src/examples/xero/src/admin-ui/custom-pages/xero-auth-code-receiver.tsx
@@ -1,4 +1,4 @@
-import { useSearchParams, Navigate } from 'react-router-dom';
+import { useSearchParams, Redirect } from 'wouter';
 
 export const XeroAuthCodeReceiver = () => {
 	const [searchParams] = useSearchParams();
@@ -22,5 +22,5 @@ export const XeroAuthCodeReceiver = () => {
 	localStorage.setItem('graphweaver-auth', window.location.href);
 
 	// Ok, now that we've saved it we're good to go.
-	return <Navigate to="/" />;
+	return <Redirect to="/" />;
 };

--- a/src/examples/xero/src/frontend/types.generated.ts
+++ b/src/examples/xero/src/frontend/types.generated.ts
@@ -175,6 +175,7 @@ export type AdminUiEntityMetadata = {
   primaryKeyField: Scalars['String']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/examples/xero/src/types.generated.ts
+++ b/src/examples/xero/src/types.generated.ts
@@ -175,6 +175,7 @@ export type AdminUiEntityMetadata = {
   primaryKeyField: Scalars['String']['output'];
   summaryField?: Maybe<Scalars['String']['output']>;
   supportedAggregationTypes: Array<AggregationType>;
+  supportsPseudoCursorPagination: Scalars['Boolean']['output'];
 };
 
 export type AdminUiEnumMetadata = {

--- a/src/packages/admin-ui-components/@types/custom-pages.d.ts
+++ b/src/packages/admin-ui-components/@types/custom-pages.d.ts
@@ -1,5 +1,5 @@
 declare module 'virtual:graphweaver-user-supplied-custom-pages' {
-	import { RouteObject } from 'react-router-dom';
+	import { RouteObject } from '@exogee/graphweaver-admin-ui';
 	import { JSX } from 'react';
 
 	export interface NavLinkExport {

--- a/src/packages/admin-ui-components/package.json
+++ b/src/packages/admin-ui-components/package.json
@@ -36,16 +36,17 @@
 		"luxon": "3.5.0",
 		"papaparse": "5.5.2",
 		"react-day-picker": "9.4.1",
+		"react-error-boundary": "5.0.0",
 		"react-hot-toast": "2.4.1",
 		"react-resizable-panels": "2.1.7",
-		"react-syntax-highlighter": "15.6.1"
+		"react-syntax-highlighter": "15.6.1",
+		"wouter": "3.6.0"
 	},
 	"peerDependencies": {
 		"formik": "^2.4.6",
 		"graphql": "16",
 		"react": "^18.0.0 || ^19.0.0",
-		"react-dom": "^18.0.0 || ^19.0.0",
-		"react-router-dom": "^6.26.2"
+		"react-dom": "^18.0.0 || ^19.0.0"
 	},
 	"devDependencies": {
 		"@types/graphql-deduplicator": "2.0.2",
@@ -60,7 +61,6 @@
 		"graphql": "16.10.0",
 		"react": "19.0.0",
 		"react-dom": "19.0.0",
-		"react-router-dom": "6.28.0",
 		"typescript": "5.7.2",
 		"vite": "6.1.0"
 	},

--- a/src/packages/admin-ui-components/src/404-page/component.tsx
+++ b/src/packages/admin-ui-components/src/404-page/component.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'wouter';
 import { Button, GraphweaverLogo, Spacer, StarField } from '..';
 import { ErrorIcon } from '../assets';
 import styles from './styles.module.css';

--- a/src/packages/admin-ui-components/src/apollo.ts
+++ b/src/packages/admin-ui-components/src/apollo.ts
@@ -37,9 +37,16 @@ const authLink = new ApolloLink((operation, forward) => {
 
 	return forward(operation).map((response) => {
 		const context = operation.getContext();
-		//  If the server sends back a header called `X-Auth-Redirect` on any response, we need to redirect the user to that URL.
+		// If the server sends back a header called `X-Auth-Redirect` on any response, we need to redirect the user to that URL
+		// unless we're already there.
 		const redirectHeader = context.response.headers.get('X-Auth-Redirect');
-		if (redirectHeader) window.location.href = redirectHeader;
+		if (redirectHeader && redirectHeader !== window.location.href) {
+			window.location.href = redirectHeader;
+		} else if (redirectHeader && redirectHeader === window.location.href) {
+			console.warn(
+				"Received redirect header from server but we're already at the redirect URL, no need to redirect."
+			);
+		}
 
 		// If the server sends back a header called `Authorization` on any response, we need to
 		// update our `graphweaver-auth` local storage value with what we got from the server.

--- a/src/packages/admin-ui-components/src/button/button.tsx
+++ b/src/packages/admin-ui-components/src/button/button.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import { useEffect, useRef, PropsWithChildren } from 'react';
 import { Spinner, SpinnerSize } from '../spinner';
 import styles from './styles.module.css';
-import { useNavigate } from 'react-router-dom';
+import { useLocation } from 'wouter';
 
 export interface ButtonProps {
 	onClick?(): any /** Event emitted when clicked */;
@@ -25,7 +25,7 @@ export const Button = ({
 	loading = false,
 }: PropsWithChildren<ButtonProps>) => {
 	const buttonRef = useRef<HTMLButtonElement>(null);
-	const navigate = useNavigate();
+	const [, setLocation] = useLocation();
 
 	if (onClick && href) {
 		console.warn(
@@ -60,7 +60,7 @@ export const Button = ({
 		<button
 			ref={buttonRef}
 			onClick={() => {
-				if (href) navigate(href);
+				if (href) setLocation(href);
 				else onClick?.();
 			}}
 			className={clsx([className, styles.button, disabled && styles.disabled])}

--- a/src/packages/admin-ui-components/src/default-error-fallback/component.tsx
+++ b/src/packages/admin-ui-components/src/default-error-fallback/component.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react';
-import { Link, useRouteError } from 'react-router-dom';
+import { Link } from 'wouter';
+import type { FallbackProps } from 'react-error-boundary';
 import { Button, GraphweaverLogo, Spacer, StarField } from '..';
 import { ErrorIcon } from '../assets';
 import styles from './styles.module.css';
 
 const originalButtonText = 'Copy Error Information to Clipboard';
 
-export const DefaultErrorFallback = () => {
-	const error = useRouteError();
+export const DefaultErrorFallback = ({ error }: FallbackProps) => {
 	const [showingCopied, setShowingCopied] = useState(false);
 
 	// Ensure we log the error to the console so the developer can see it.

--- a/src/packages/admin-ui-components/src/detail-panel/component.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/component.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQuery, FetchResult } from '@apollo/client';
 import clsx from 'clsx';
 import { Form, Formik, FormikHelpers, useFormikContext } from 'formik';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useLocation, useParams, useSearchParams } from 'wouter';
 import toast from 'react-hot-toast';
 
 import { customFields } from 'virtual:graphweaver-user-supplied-custom-fields';
@@ -332,7 +332,7 @@ export const DetailPanel = () => {
 	const modalRedirectUrl = search.get('modalRedirectUrl');
 
 	const { id, entity } = useParams();
-	const navigate = useNavigate();
+	const [, setLocation] = useLocation();
 	const { selectedEntity } = useSelectedEntity();
 	const { entityByName, entityByType } = useSchema();
 
@@ -358,12 +358,12 @@ export const DetailPanel = () => {
 		// If the path does not include the entity name, then we've already moved to a different entity
 		// Navigate to the current path to close the overlay
 		if (!regexPattern.test(path)) {
-			navigate(path);
+			setLocation(path);
 			return;
 		}
 
 		const { filters, sort } = decodeSearchParams(search);
-		navigate(routeFor({ entity: selectedEntity, filters, sort }));
+		setLocation(routeFor({ entity: selectedEntity, filters, sort }));
 	};
 
 	const customFieldsToShow =
@@ -432,7 +432,7 @@ export const DetailPanel = () => {
 
 	const navigateToDetailForEntity = (id?: string) => {
 		if (!id) return;
-		navigate(routeFor({ entity: selectedEntity, id }));
+		setLocation(routeFor({ entity: selectedEntity, id }));
 	};
 
 	const handleOnSubmit = async (values: any, actions: FormikHelpers<any>) => {
@@ -508,7 +508,7 @@ export const DetailPanel = () => {
 	const handleConfirmLeave = () => {
 		if (!modalRedirectUrl) return;
 
-		navigate(modalRedirectUrl, { replace: true });
+		setLocation(modalRedirectUrl, { replace: true });
 	};
 
 	const handleCancelLeave = () => {

--- a/src/packages/admin-ui-components/src/detail-panel/fields/link-field.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/fields/link-field.tsx
@@ -1,10 +1,10 @@
 import { useField, useFormikContext } from 'formik';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'wouter';
 import { EntityField, routeFor } from '../../utils';
 
 export const LinkField = ({ name, field }: { name: string; field: EntityField }) => {
 	const { dirty } = useFormikContext();
-	const navigate = useNavigate();
+	const [, setLocation] = useLocation();
 	const [_, meta] = useField({ name: name, multiple: false });
 	const { initialValue: formEntity } = meta;
 	const [__, setSearchParams] = useSearchParams();
@@ -20,7 +20,7 @@ export const LinkField = ({ name, field }: { name: string; field: EntityField })
 			searchParams.set('modalRedirectUrl', route);
 			setSearchParams(searchParams);
 		} else {
-			navigate(route);
+			setLocation(route);
 		}
 	};
 

--- a/src/packages/admin-ui-components/src/entity-list/columns.tsx
+++ b/src/packages/admin-ui-components/src/entity-list/columns.tsx
@@ -1,6 +1,6 @@
 import { CellContext, createColumnHelper } from '@tanstack/react-table';
 import { customFields } from 'virtual:graphweaver-user-supplied-custom-fields';
-import { Link } from 'react-router-dom';
+import { Link } from 'wouter';
 
 import { Entity, EntityField, routeFor } from '../utils';
 import { cells } from '../table/cells';

--- a/src/packages/admin-ui-components/src/entity-list/component.tsx
+++ b/src/packages/admin-ui-components/src/entity-list/component.tsx
@@ -84,7 +84,14 @@ export const EntityList = <TData extends object>({ children }: { children: React
 	}
 
 	const handleRowClick = <T extends object>(row: Row<T>) => {
-		setLocation(`${row.original[fieldForDetailPanelNavigationId as keyof T]}`);
+		setLocation(
+			routeFor({
+				entity,
+				filters,
+				sort: sorting,
+				id: row.original[fieldForDetailPanelNavigationId as keyof T] as string,
+			})
+		);
 	};
 
 	const handleSortClick = (newSort: SortEntity) => {

--- a/src/packages/admin-ui-components/src/error-view/component.tsx
+++ b/src/packages/admin-ui-components/src/error-view/component.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'wouter';
 import { RequestIcon } from '../assets/request';
 import styles from './styles.module.css';
 import { Spacer } from '../spacer';

--- a/src/packages/admin-ui-components/src/filter-bar/component.tsx
+++ b/src/packages/admin-ui-components/src/filter-bar/component.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useCallback, useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useLocation, useParams, useSearchParams } from 'wouter';
 
 import { Button } from '../button';
 import {
@@ -23,7 +23,7 @@ export const FilterBar = ({ iconBefore }: { iconBefore?: ReactNode }) => {
 	if (!entityName) throw new Error('There should always be an entity at this point.');
 	const [search] = useSearchParams();
 	const { entityByName } = useSchema();
-	const navigate = useNavigate();
+	const [, setLocation] = useLocation();
 	const searchParams = decodeSearchParams(search);
 
 	const [filtersState, setFiltersState] = useState(searchParams.filters ?? {});
@@ -59,7 +59,7 @@ export const FilterBar = ({ iconBefore }: { iconBefore?: ReactNode }) => {
 			);
 
 			// Go off to a supported URL.
-			navigate(
+			setLocation(
 				routeFor({
 					entity: entityName,
 					id,
@@ -70,7 +70,7 @@ export const FilterBar = ({ iconBefore }: { iconBefore?: ReactNode }) => {
 			);
 		}
 
-		navigate(
+		setLocation(
 			routeFor({
 				entity: entityName,
 				id,

--- a/src/packages/admin-ui-components/src/filter-bar/component.tsx
+++ b/src/packages/admin-ui-components/src/filter-bar/component.tsx
@@ -41,6 +41,11 @@ export const FilterBar = ({ iconBefore }: { iconBefore?: ReactNode }) => {
 		800
 	);
 
+	useEffect(() => {
+		// Reset the filters to whatever is in the URL because the entity has changed.
+		setTemporaryFilters(searchParams.filters ?? {});
+	}, [entityName]);
+
 	const filterFieldsOnEntity = useCallback(() => {
 		const entity = entityByName(entityName);
 		// @todo - currently the filters are not fitting on the screen

--- a/src/packages/admin-ui-components/src/hooks/use-debounce.ts
+++ b/src/packages/admin-ui-components/src/hooks/use-debounce.ts
@@ -1,15 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
-export const useDebounce = <T>(value: T, delay?: number): T => {
-	const [debouncedValue, setDebouncedValue] = useState<T>(value);
-
+export const useDebounce = <T>(value: T, setter: (value: T) => any, delay: number = 500) => {
 	useEffect(() => {
-		const timer = setTimeout(() => setDebouncedValue(value), delay || 500);
+		const timer = setTimeout(() => setter(value), delay);
 
 		return () => {
 			clearTimeout(timer);
 		};
 	}, [value, delay]);
-
-	return debouncedValue;
 };

--- a/src/packages/admin-ui-components/src/layouts/default/component.tsx
+++ b/src/packages/admin-ui-components/src/layouts/default/component.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from 'react';
-import { Outlet } from 'react-router-dom';
 
 import { SideBar } from '../../side-bar';
 import { RequireSchema } from '../../require-schema';
@@ -12,7 +11,7 @@ const SIDEBAR_MIN_WIDTH = 220;
 const SIDEBAR_MAX_WIDTH = 820;
 const SIDEBAR_START_WIDTH = 320;
 
-export const DefaultLayout = () => {
+export const DefaultLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 	const resizer = useRef<HTMLDivElement>(null);
 	const [flexBasis, setFlexBasis] = useState(SIDEBAR_START_WIDTH);
 	const [openMenu, setOpenMenu] = useState(false);
@@ -55,9 +54,7 @@ export const DefaultLayout = () => {
 						<SideBar />
 					</div>
 					<div className={styles.resizer} ref={resizer}></div>
-					<div className={styles.content}>
-						<Outlet />
-					</div>
+					<div className={styles.content}>{children}</div>
 				</div>
 			</div>
 			<Modal

--- a/src/packages/admin-ui-components/src/list-toolbar/component.tsx
+++ b/src/packages/admin-ui-components/src/list-toolbar/component.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'wouter';
 
 import { useSchema } from '../utils';
 import { ToolBar } from '../toolbar';

--- a/src/packages/admin-ui-components/src/missing-entity/component.tsx
+++ b/src/packages/admin-ui-components/src/missing-entity/component.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'wouter';
 import { DataSourcesIcon } from '../assets/64-data-sources';
 import styles from './styles.module.css';
 import { Spacer } from '../spacer';

--- a/src/packages/admin-ui-components/src/side-bar/component.tsx
+++ b/src/packages/admin-ui-components/src/side-bar/component.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'wouter';
 
 import { graphweaverLogo, localStorageAuthKey } from '../config';
 

--- a/src/packages/admin-ui-components/src/side-bar/contents/dashboard-row.tsx
+++ b/src/packages/admin-ui-components/src/side-bar/contents/dashboard-row.tsx
@@ -14,7 +14,7 @@ export const DashboardRow = ({
 	route: string;
 	end?: boolean;
 }) => {
-	const [isActive] = useRoute(end ? route : `${route}/*`);
+	const [isActive] = useRoute(end ? route : `${route}/*?`);
 
 	return (
 		<li>

--- a/src/packages/admin-ui-components/src/side-bar/contents/dashboard-row.tsx
+++ b/src/packages/admin-ui-components/src/side-bar/contents/dashboard-row.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { NavLink } from 'react-router-dom';
+import { Link, useRoute } from 'wouter';
 
 import { TableIcon } from '../../assets';
 
@@ -13,15 +13,15 @@ export const DashboardRow = ({
 	name: string;
 	route: string;
 	end?: boolean;
-}) => (
-	<li>
-		<NavLink
-			to={route}
-			className={({ isActive }) => clsx(styles.subListItem, isActive && styles.active)}
-			end={end}
-		>
-			<TableIcon />
-			{name}
-		</NavLink>
-	</li>
-);
+}) => {
+	const [isActive] = useRoute(end ? route : `${route}/*`);
+
+	return (
+		<li>
+			<Link to={route} className={clsx(styles.subListItem, isActive && styles.active)}>
+				<TableIcon />
+				{name}
+			</Link>
+		</li>
+	);
+};

--- a/src/packages/admin-ui-components/src/side-bar/contents/entity-row.tsx
+++ b/src/packages/admin-ui-components/src/side-bar/contents/entity-row.tsx
@@ -8,7 +8,7 @@ import styles from '../styles.module.css';
 
 export const EntityRow = ({ entity }: { entity: Entity }) => {
 	const entityRoute = routeFor({ entity });
-	const [isActive] = useRoute(`${entityRoute}/*`);
+	const [isActive] = useRoute(`${entityRoute}/*?`);
 
 	return (
 		<li>

--- a/src/packages/admin-ui-components/src/side-bar/contents/entity-row.tsx
+++ b/src/packages/admin-ui-components/src/side-bar/contents/entity-row.tsx
@@ -1,20 +1,25 @@
 import clsx from 'clsx';
-import { NavLink } from 'react-router-dom';
+import { Link, useRoute } from 'wouter';
 
 import { TableIcon } from '../../assets';
 import { routeFor, Entity } from '../../utils';
 
 import styles from '../styles.module.css';
 
-export const EntityRow = ({ entity }: { entity: Entity }) => (
-	<li>
-		<NavLink
-			to={routeFor({ entity })}
-			className={({ isActive }) => clsx(styles.subListItem, isActive && styles.active)}
-			data-testid={`${entity.name}-entity-link`}
-		>
-			<TableIcon />
-			<span className={styles.subListItemText}>{entity.name}</span>
-		</NavLink>
-	</li>
-);
+export const EntityRow = ({ entity }: { entity: Entity }) => {
+	const entityRoute = routeFor({ entity });
+	const [isActive] = useRoute(`${entityRoute}/*`);
+
+	return (
+		<li>
+			<Link
+				to={entityRoute}
+				className={clsx(styles.subListItem, isActive && styles.active)}
+				data-testid={`${entity.name}-entity-link`}
+			>
+				<TableIcon />
+				<span className={styles.subListItemText}>{entity.name}</span>
+			</Link>
+		</li>
+	);
+};

--- a/src/packages/admin-ui-components/src/title-bar/component.tsx
+++ b/src/packages/admin-ui-components/src/title-bar/component.tsx
@@ -29,8 +29,8 @@ export const TitleBar = ({ title, subtitle, onExportToCSV }: Props) => {
 			</div>
 
 			<div className={styles.toolsWrapper}>
-				<Link
-					to="/playground"
+				<a
+					href="/playground"
 					// If we are in an iframe then open in the same window otherwise open in a new tab
 					target={window === window.parent ? '_blank' : '_self'}
 					rel="noopener noreferrer"
@@ -40,7 +40,7 @@ export const TitleBar = ({ title, subtitle, onExportToCSV }: Props) => {
 						Open Playground
 						<OpenExternalIcon />
 					</Button>
-				</Link>
+				</a>
 				{onExportToCSV && (
 					<Button className={styles.toolBarTrailingButton} onClick={onExportToCSV}>
 						Export to CSV

--- a/src/packages/admin-ui-components/src/title-bar/component.tsx
+++ b/src/packages/admin-ui-components/src/title-bar/component.tsx
@@ -1,4 +1,4 @@
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'wouter';
 import { Button } from '../button';
 import { Popover, PopoverItem } from '../popover';
 import { OpenExternalIcon } from '../assets/16-open-external';
@@ -30,7 +30,7 @@ export const TitleBar = ({ title, subtitle, onExportToCSV }: Props) => {
 
 			<div className={styles.toolsWrapper}>
 				<Link
-					to={{ pathname: '/playground' }}
+					to="/playground"
 					// If we are in an iframe then open in the same window otherwise open in a new tab
 					target={window === window.parent ? '_blank' : '_self'}
 					rel="noopener noreferrer"

--- a/src/packages/admin-ui-components/src/utils/use-selected-entity.ts
+++ b/src/packages/admin-ui-components/src/utils/use-selected-entity.ts
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'wouter';
 import { useSchema } from './use-schema';
 
 export const useSelectedEntity = () => {

--- a/src/packages/admin-ui-components/src/welcome-page/component.tsx
+++ b/src/packages/admin-ui-components/src/welcome-page/component.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren } from 'react';
 import { GraphweaverLogo } from '../assets';
 import { StarField } from '../star-field';
 import styles from './styles.module.css';
-import { Link } from 'react-router-dom';
+import { Link } from 'wouter';
 
 interface Props extends PropsWithChildren {
 	skipPath?: string;

--- a/src/packages/admin-ui/@types/auth.d.ts
+++ b/src/packages/admin-ui/@types/auth.d.ts
@@ -1,5 +1,5 @@
 declare module 'virtual:graphweaver-auth-ui-components' {
-	import { RouteObject } from 'react-router-dom';
+	import { RouteObject } from 'graphweaver-admin-ui';
 
 	export const loadRoutes: () => RouteObject[];
 }

--- a/src/packages/admin-ui/@types/custom-pages.d.ts
+++ b/src/packages/admin-ui/@types/custom-pages.d.ts
@@ -1,5 +1,5 @@
 declare module 'virtual:graphweaver-user-supplied-custom-pages' {
-	import { RouteObject } from 'react-router-dom';
+	import { RouteObject } from '@exogee/graphweaver-admin-ui';
 	import type { LoginProps } from '@exogee/graphweaver-admin-ui-components';
 
 	export interface NavLinkExport {

--- a/src/packages/admin-ui/package.json
+++ b/src/packages/admin-ui/package.json
@@ -31,8 +31,9 @@
 		"prop-types": "15.8.1",
 		"react": "19.0.0",
 		"react-dom": "19.0.0",
+		"react-error-boundary": "5.0.0",
 		"react-modal": "3.16.1",
-		"react-router-dom": "6.28.0"
+		"wouter": "3.6.0"
 	},
 	"devDependencies": {
 		"@chialab/esbuild-plugin-html": "0.18.2",
@@ -40,10 +41,10 @@
 		"@types/react-dom": "19.0.0",
 		"@types/react-modal": "3.16.3",
 		"@vitejs/plugin-react": "4.3.4",
-		"graphql": "16.10.0",
 		"esbuild": "0.25.0",
 		"esbuild-plugin-copy": "2.1.1",
 		"glob": "10.4.3",
+		"graphql": "16.10.0",
 		"typescript": "5.7.2",
 		"vite": "6.1.0"
 	},

--- a/src/packages/admin-ui/src/pages/analytics/component.tsx
+++ b/src/packages/admin-ui/src/pages/analytics/component.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@apollo/client';
 import { Header, Loader, Span, TraceViewer } from '@exogee/graphweaver-admin-ui-components';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'wouter';
 
 import { queryForTrace } from './graphql';
 

--- a/src/packages/admin-ui/src/pages/list/component.tsx
+++ b/src/packages/admin-ui/src/pages/list/component.tsx
@@ -1,7 +1,7 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'wouter';
 import { useSchema, EntityList, MissingEntity } from '@exogee/graphweaver-admin-ui-components';
 
-export const List = () => {
+export const List = ({ children }: { children: React.ReactNode }) => {
 	const { entity } = useParams();
 	const { entityByName } = useSchema();
 
@@ -11,5 +11,5 @@ export const List = () => {
 		return <MissingEntity entity={entity} />;
 	}
 
-	return <EntityList />;
+	return <EntityList>{children}</EntityList>;
 };

--- a/src/packages/admin-ui/src/router.tsx
+++ b/src/packages/admin-ui/src/router.tsx
@@ -38,12 +38,12 @@ export const Router = () => {
 				<Switch>
 					{/* render the custom routes allowing them to override our default routes */}
 					{routes.map((route) => (
-						<Route key={route.path} path={route.path} nest>
+						<Route key={route.path} path={route.path} nest={(route.children?.length ?? 0) > 0}>
 							{route.element}
 
 							{/* recurse into the children routes */}
 							{route.children?.map((child) => (
-								<Route key={child.path} path={child.path} nest>
+								<Route key={child.path} path={child.path} nest={(child.children?.length ?? 0) > 0}>
 									{child.element}
 								</Route>
 							))}

--- a/src/packages/admin-ui/src/router.tsx
+++ b/src/packages/admin-ui/src/router.tsx
@@ -67,16 +67,6 @@ export const Router = () => {
 						</DefaultLayout>
 					</Route>
 
-					<Route path="/:entity/:id?">
-						<DefaultLayout>
-							<List>
-								<Route path="/:entity/:id">
-									<DetailPanel />
-								</Route>
-							</List>
-						</DefaultLayout>
-					</Route>
-
 					<Route path="/loader">
 						<DefaultLayout>
 							<Loader />
@@ -85,6 +75,16 @@ export const Router = () => {
 
 					<Route path="/playground">
 						<Playground />
+					</Route>
+
+					<Route path="/:entity/:id?">
+						<DefaultLayout>
+							<List>
+								<Route path="/:entity/:id">
+									<DetailPanel />
+								</Route>
+							</List>
+						</DefaultLayout>
 					</Route>
 
 					<Route>

--- a/src/packages/admin-ui/src/router.tsx
+++ b/src/packages/admin-ui/src/router.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { createBrowserRouter, Navigate, RouteObject, RouterProvider } from 'react-router-dom';
+import { ErrorBoundary } from 'react-error-boundary';
+import { Router as WouterRouter, Route, Switch, Redirect } from 'wouter';
 import {
 	Loader,
 	DefaultLayout,
@@ -14,61 +15,84 @@ import { loadRoutes as loadAuthRoutes } from 'virtual:graphweaver-auth-ui-compon
 
 import { List, Root, Playground, TraceDetail } from './pages';
 
-const defaultRoutes: RouteObject[] = [
-	{
-		element: <DefaultLayout />,
-		errorElement: <DefaultErrorFallback />,
-		children: [
-			{
-				path: '/',
-				element: customPages.defaultRoute ? <Navigate to={customPages.defaultRoute} /> : <Root />,
-			},
-			{
-				path: 'Trace/:id',
-				element: <TraceDetail />,
-			},
-			{
-				path: ':entity',
-				element: <List />,
-				children: [
-					{
-						path: ':id',
-						element: <DetailPanel />,
-					},
-				],
-			},
-			{
-				path: 'loader',
-				element: <Loader />,
-			},
-		],
-	},
-	{
-		path: '/playground',
-		element: <Playground />,
-	},
-	{
-		path: '*',
-		element: <Page404 />,
-	},
-];
+export type RouteObject = {
+	path: string;
+	element: React.ReactNode;
+	children?: RouteObject[];
+};
 
 export const Router = () => {
-	const [router, setRouter] = useState<ReturnType<typeof createBrowserRouter> | null>(null);
+	const [routes, setRoutes] = useState<RouteObject[] | null>(null);
+	const basename = import.meta.env.VITE_ADMIN_UI_BASE || '/';
 
 	useEffect(() => {
 		(async () => {
-			// We need to blend their custom routes in at the top so they can override us if they want.
-			const routes = await customPages.routes();
-			setRouter(
-				createBrowserRouter([...routes, ...loadAuthRoutes(), ...defaultRoutes], {
-					basename: import.meta.env.VITE_ADMIN_UI_BASE || '/',
-				})
-			);
+			setRoutes([...(await customPages.routes()), ...loadAuthRoutes()]);
 		})();
 	}, []);
 
-	if (!router) return <Loader />;
+	if (!routes) return <Loader />;
 
-	return <RouterProvider router={router} />;
+	return (
+		<ErrorBoundary FallbackComponent={DefaultErrorFallback}>
+			<WouterRouter base={basename}>
+				<Switch>
+					{/* render the custom routes allowing them to override our default routes */}
+					{routes.map((route) => (
+						<Route key={route.path} path={route.path}>
+							{route.element}
+
+							{/* recurse into the children routes */}
+							{route.children?.map((child) => (
+								<Route key={child.path} path={child.path}>
+									{child.element}
+								</Route>
+							))}
+						</Route>
+					))}
+
+					{/* render the default routes */}
+					<Route path="/">
+						<DefaultLayout>
+							{customPages.defaultRoute && customPages.defaultRoute !== '/' ? (
+								<Redirect to={customPages.defaultRoute} />
+							) : (
+								<Root />
+							)}
+						</DefaultLayout>
+					</Route>
+
+					<Route path="/trace/:id">
+						<DefaultLayout>
+							<TraceDetail />
+						</DefaultLayout>
+					</Route>
+
+					<Route path="/:entity/:id?">
+						<DefaultLayout>
+							<List>
+								<Route path="/:entity/:id">
+									<DetailPanel />
+								</Route>
+							</List>
+						</DefaultLayout>
+					</Route>
+
+					<Route path="/loader">
+						<DefaultLayout>
+							<Loader />
+						</DefaultLayout>
+					</Route>
+
+					<Route path="/playground">
+						<Playground />
+					</Route>
+
+					<Route>
+						<Page404 />
+					</Route>
+				</Switch>
+			</WouterRouter>
+		</ErrorBoundary>
+	);
 };

--- a/src/packages/admin-ui/src/router.tsx
+++ b/src/packages/admin-ui/src/router.tsx
@@ -23,7 +23,6 @@ export type RouteObject = {
 
 export const Router = () => {
 	const [routes, setRoutes] = useState<RouteObject[] | null>(null);
-	const basename = import.meta.env.VITE_ADMIN_UI_BASE || '/';
 
 	useEffect(() => {
 		(async () => {
@@ -35,7 +34,7 @@ export const Router = () => {
 
 	return (
 		<ErrorBoundary FallbackComponent={DefaultErrorFallback}>
-			<WouterRouter base={basename}>
+			<WouterRouter base={import.meta.env.VITE_ADMIN_UI_BASE}>
 				<Switch>
 					{/* render the custom routes allowing them to override our default routes */}
 					{routes.map((route) => (

--- a/src/packages/admin-ui/src/router.tsx
+++ b/src/packages/admin-ui/src/router.tsx
@@ -38,12 +38,12 @@ export const Router = () => {
 				<Switch>
 					{/* render the custom routes allowing them to override our default routes */}
 					{routes.map((route) => (
-						<Route key={route.path} path={route.path}>
+						<Route key={route.path} path={route.path} nest>
 							{route.element}
 
 							{/* recurse into the children routes */}
 							{route.children?.map((child) => (
-								<Route key={child.path} path={child.path}>
+								<Route key={child.path} path={child.path} nest>
 									{child.element}
 								</Route>
 							))}

--- a/src/packages/auth-ui-components/package.json
+++ b/src/packages/auth-ui-components/package.json
@@ -29,18 +29,18 @@
 		"@simplewebauthn/browser": "10.0.0",
 		"@usedapp/core": "1.2.16",
 		"ethers": "5.7.2",
-		"web3-token": "1.0.6"
+		"web3-token": "1.0.6",
+		"wouter": "3.6.0"
 	},
 	"peerDependencies": {
 		"@auth0/auth0-spa-js": "^2.1.3",
 		"@azure/msal-browser": "^3.25.0",
 		"@exogee/graphweaver-admin-ui-components": "workspace:*",
+		"@okta/okta-auth-js": "^7.9.0",
 		"formik": "^2.2.9",
 		"graphql": "16",
-		"@okta/okta-auth-js": "^7.9.0",
 		"react": "^18.0.0 || ^19.0.0",
-		"react-dom": "^18.0.0 || ^19.0.0",
-		"react-router-dom": "^6.23.1"
+		"react-dom": "^18.0.0 || ^19.0.0"
 	},
 	"devDependencies": {
 		"@auth0/auth0-spa-js": "2.1.3",

--- a/src/packages/auth-ui-components/src/components/auth-zero/login/component.tsx
+++ b/src/packages/auth-ui-components/src/components/auth-zero/login/component.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@exogee/graphweaver-admin-ui-components';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'wouter';
 import { getAuth0Client } from '../client';
 
 export const Auth0 = () => {
@@ -9,7 +9,7 @@ export const Auth0 = () => {
 
 	const [searchParams] = useSearchParams();
 	const shouldRedirect = useRef(true);
-	const navigate = useNavigate();
+	const [, setLocation] = useLocation();
 
 	// In this effect we are checking if the user is coming back from the Auth0 login page or
 	// if the user is coming to the page for the first time. If the user is coming back from
@@ -53,7 +53,7 @@ export const Auth0 = () => {
 		try {
 			const client = await getAuth0Client();
 			await client.handleRedirectCallback();
-			navigate('/');
+			setLocation('/');
 		} catch (e: any) {
 			if (e.message) setError(e.message);
 		} finally {

--- a/src/packages/auth-ui-components/src/components/logout/component.tsx
+++ b/src/packages/auth-ui-components/src/components/logout/component.tsx
@@ -7,14 +7,14 @@ import {
 import { LogoutIcon } from '../../assets/16-logout';
 
 import styles from './styles.module.css';
-import { useNavigate } from 'react-router-dom';
+import { useLocation } from 'wouter';
 
 type LogoutProps = {
 	onLogout?: () => Promise<void>;
 };
 
 export const Logout = ({ onLogout }: LogoutProps) => {
-	const navigate = useNavigate();
+	const [, setLocation] = useLocation();
 
 	const handleOnLogout = async () => {
 		try {
@@ -23,7 +23,7 @@ export const Logout = ({ onLogout }: LogoutProps) => {
 			if (onLogout) {
 				await onLogout();
 			} else {
-				navigate(0);
+				setLocation('/');
 			}
 		} catch (error: any) {
 			const message = error?.message || 'Unknown error.';

--- a/src/packages/auth-ui-components/src/components/magic-link/challenge/component.tsx
+++ b/src/packages/auth-ui-components/src/components/magic-link/challenge/component.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'wouter';
 import { useMutation } from '@apollo/client';
 import {
 	GraphweaverLogo,

--- a/src/packages/auth-ui-components/src/components/magic-link/login/component.tsx
+++ b/src/packages/auth-ui-components/src/components/magic-link/login/component.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'wouter';
 import { Field, Form, Formik, FormikHelpers } from 'formik';
 import { useMutation } from '@apollo/client';
 import {

--- a/src/packages/auth-ui-components/src/components/microsoft-entra/login/component.tsx
+++ b/src/packages/auth-ui-components/src/components/microsoft-entra/login/component.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Button, localStorageAuthKey } from '@exogee/graphweaver-admin-ui-components';
-import { useNavigate } from 'react-router-dom';
+import { useLocation } from 'wouter';
 import { publicClientApplication } from '../client';
 
 const scopes = import.meta.env.VITE_MICROSOFT_ENTRA_SCOPES
@@ -10,7 +10,7 @@ const scopes = import.meta.env.VITE_MICROSOFT_ENTRA_SCOPES
 export const MicrosoftEntra = () => {
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | undefined>();
-	const navigate = useNavigate();
+	const [, setLocation] = useLocation();
 
 	useEffect(() => {
 		(async () => {
@@ -24,7 +24,7 @@ export const MicrosoftEntra = () => {
 					localStorage.setItem(localStorageAuthKey, tokenResponse.accessToken);
 
 					// Then off we go.
-					navigate('/');
+					setLocation('/');
 				} else {
 					// They're either just landing on the page or they're coming back from a failed login
 					await requestLogin();

--- a/src/packages/auth-ui-components/src/components/okta/login/component.tsx
+++ b/src/packages/auth-ui-components/src/components/okta/login/component.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Button, localStorageAuthKey } from '@exogee/graphweaver-admin-ui-components';
-import { useNavigate } from 'react-router-dom';
+import { useLocation } from 'wouter';
 import { okta } from '../client';
 import { AccessToken, IDToken } from '@okta/okta-auth-js';
 
@@ -12,7 +12,7 @@ if (import.meta.env.VITE_OKTA_ADDITIONAL_SCOPES) {
 export const Okta = () => {
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | undefined>();
-	const navigate = useNavigate();
+	const [, setLocation] = useLocation();
 
 	const handleLogin = async () => {
 		if (!okta) {
@@ -47,7 +47,7 @@ export const Okta = () => {
 
 			if (userInfo) {
 				// If there's a user we can go ahead and navigate to the home page.
-				navigate('/');
+				setLocation('/');
 			} else {
 				// Otherwise, we need to go through the login flow.
 				await okta.token.getWithRedirect({

--- a/src/packages/auth-ui-components/src/components/one-time-password/challenge/component.tsx
+++ b/src/packages/auth-ui-components/src/components/one-time-password/challenge/component.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'wouter';
 import { useMutation } from '@apollo/client';
 import {
 	GraphweaverLogo,
@@ -25,7 +25,7 @@ export const OTPChallenge = () => {
 	const [error, setError] = useState<Error | undefined>();
 	const [sent, setSent] = useState<boolean>(false);
 	const [searchParams] = useSearchParams();
-	const navigate = useNavigate();
+	const [, setLocation] = useLocation();
 
 	const redirectUri = searchParams.get('redirect_uri');
 	if (!redirectUri) throw new Error('Missing redirect URL');
@@ -59,7 +59,7 @@ export const OTPChallenge = () => {
 				if (!authToken) throw new Error('Missing auth token');
 
 				localStorage.setItem(localStorageAuthKey, authToken);
-				navigate(formatRedirectUrl(redirectUri), {
+				setLocation(formatRedirectUrl(redirectUri), {
 					replace: true,
 				});
 			} catch (error) {
@@ -67,7 +67,7 @@ export const OTPChallenge = () => {
 				setError(error instanceof Error ? error : new Error(String(error)));
 			}
 		},
-		[verifyOTP, navigate]
+		[verifyOTP, setLocation]
 	);
 
 	return (

--- a/src/packages/auth-ui-components/src/components/passkey/challenge/component.tsx
+++ b/src/packages/auth-ui-components/src/components/passkey/challenge/component.tsx
@@ -13,7 +13,7 @@ import {
 	PublicKeyCredentialRequestOptionsJSON,
 } from '@simplewebauthn/types';
 import { Form, Formik } from 'formik';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'wouter';
 
 import {
 	GENERATE_AUTHENTICATION_OPTIONS,
@@ -104,7 +104,7 @@ const AuthenticateButton = ({
 }) => {
 	const [loading, setLoading] = useState(false);
 	const [searchParams] = useSearchParams();
-	const navigate = useNavigate();
+	const [, setLocation] = useLocation();
 
 	const redirectUri = searchParams.get('redirect_uri');
 	if (!redirectUri) throw new Error('Missing redirect URL');
@@ -135,7 +135,7 @@ const AuthenticateButton = ({
 
 			localStorage.setItem(localStorageAuthKey, authToken);
 
-			navigate(formatRedirectUrl(redirectUri), { replace: true });
+			setLocation(formatRedirectUrl(redirectUri), { replace: true });
 		} catch (error: any) {
 			setError(error);
 			setLoading(false);

--- a/src/packages/auth-ui-components/src/components/password/challenge/component.tsx
+++ b/src/packages/auth-ui-components/src/components/password/challenge/component.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'wouter';
 import { Field, Form, Formik, FormikHelpers } from 'formik';
 import { useMutation } from '@apollo/client';
 import {

--- a/src/packages/auth-ui-components/src/components/password/forgotten-password/component.tsx
+++ b/src/packages/auth-ui-components/src/components/password/forgotten-password/component.tsx
@@ -55,6 +55,7 @@ export const ForgottenPassword = () => {
 						placeholder="Username"
 						id="username"
 						name="username"
+						autofocus
 						className={styles.textInputField}
 					/>
 

--- a/src/packages/auth-ui-components/src/components/password/login/component.tsx
+++ b/src/packages/auth-ui-components/src/components/password/login/component.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useLocation, useSearchParams } from 'wouter';
 import { Field, Form, Formik, FormikHelpers } from 'formik';
 import { useMutation } from '@apollo/client';
 import {
@@ -24,7 +24,7 @@ export const PasswordLogin = ({ canResetPassword = true }: { canResetPassword?: 
 	const [login] = useMutation<{ result: { authToken: string } }>(LOGIN_MUTATION);
 	const [error, setError] = useState<Error | undefined>();
 	const [searchParams] = useSearchParams();
-	const navigate = useNavigate();
+	const [, setLocation] = useLocation();
 
 	const redirectUri = searchParams.get('redirect_uri');
 	if (!redirectUri) throw new Error('Missing redirect URL');
@@ -45,7 +45,7 @@ export const PasswordLogin = ({ canResetPassword = true }: { canResetPassword?: 
 			if (!token) throw new Error('Missing token');
 
 			localStorage.setItem(localStorageAuthKey, token);
-			navigate(formatRedirectUrl(redirectUri), { replace: true });
+			setLocation(formatRedirectUrl(redirectUri), { replace: true });
 		} catch (error) {
 			resetForm();
 			setError(error instanceof Error ? error : new Error(String(error)));

--- a/src/packages/auth-ui-components/src/components/password/login/component.tsx
+++ b/src/packages/auth-ui-components/src/components/password/login/component.tsx
@@ -63,6 +63,7 @@ export const PasswordLogin = ({ canResetPassword = true }: { canResetPassword?: 
 							placeholder="Username"
 							id="username"
 							name="username"
+							autofocus
 							className={styles.textInputField}
 						/>
 						<PasswordFieldComponent />

--- a/src/packages/auth-ui-components/src/components/password/password/component.tsx
+++ b/src/packages/auth-ui-components/src/components/password/password/component.tsx
@@ -1,15 +1,18 @@
-import { Field } from 'formik';
+import { Field, FieldAttributes } from 'formik';
 
 import styles from './styles.module.css';
 
-export const PasswordFieldComponent = () => {
+export const PasswordFieldComponent = (props: FieldAttributes<any>) => {
 	return (
 		<Field
-			type="password"
+			// These can be overridden
+			className={styles.textInputField}
 			placeholder="Password"
+			{...props}
+			// But we really want these to not be overridden
+			type="password"
 			id="password"
 			name="password"
-			className={styles.textInputField}
 		/>
 	);
 };
@@ -26,13 +29,13 @@ export const ConfirmFieldComponent = () => {
 	);
 };
 
-export const PasswordComponent = () => {
+export const PasswordComponent = (props: FieldAttributes<any>) => {
 	return (
 		<>
 			<label htmlFor="password" className={styles.fieldLabel}>
 				password
 			</label>
-			<PasswordFieldComponent />
+			<PasswordFieldComponent {...props} />
 		</>
 	);
 };

--- a/src/packages/auth-ui-components/src/components/password/reset-password/component.tsx
+++ b/src/packages/auth-ui-components/src/components/password/reset-password/component.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'wouter';
 import { Form, Formik, FormikHelpers } from 'formik';
 import { useMutation } from '@apollo/client';
 import { GraphweaverLogo, Alert, Button } from '@exogee/graphweaver-admin-ui-components';
@@ -21,7 +21,7 @@ export const ResetPassword = () => {
 	const [resetPassword] = useMutation<{ result: boolean }>(RESET_PASSWORD);
 	const [error, setError] = useState<Error | undefined>();
 	const [searchParams] = useSearchParams();
-	const navigate = useNavigate();
+	const [, setLocation] = useLocation();
 
 	const token = searchParams.get('token');
 	const redirectUri = searchParams.get('redirect_uri');
@@ -43,7 +43,7 @@ export const ResetPassword = () => {
 			});
 
 			const redirectUrl = redirectUri ?? new URL('/');
-			navigate(`${authPath}${loginPath}?redirect_uri=${redirectUrl}`, {
+			setLocation(`${authPath}${loginPath}?redirect_uri=${redirectUrl}`, {
 				replace: true,
 			});
 		} catch (error) {

--- a/src/packages/auth-ui-components/src/components/password/reset-password/component.tsx
+++ b/src/packages/auth-ui-components/src/components/password/reset-password/component.tsx
@@ -62,7 +62,7 @@ export const ResetPassword = () => {
 					{!!error && <Alert>{error.message}</Alert>}
 
 					<div className={styles.inputContainer}>
-						<PasswordComponent />
+						<PasswordComponent autofocus />
 						<ConfirmComponent />
 					</div>
 

--- a/src/packages/auth-ui-components/src/components/web3/challenge/component.tsx
+++ b/src/packages/auth-ui-components/src/components/web3/challenge/component.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams, useLocation } from 'wouter';
 import { useMutation, useQuery } from '@apollo/client';
 import {
 	GraphweaverLogo,
@@ -72,7 +72,7 @@ const VerifyButton = () => {
 	const [verifySignature] = useMutation<{ result: { authToken: string } }>(VERIFY_WEB3_MUTATION);
 	const [error, setError] = useState<Error | undefined>();
 	const [searchParams] = useSearchParams();
-	const navigate = useNavigate();
+	const [, setLocation] = useLocation();
 
 	const redirectUri = searchParams.get('redirect_uri');
 	if (!redirectUri) throw new Error('Missing redirect URL');
@@ -100,12 +100,12 @@ const VerifyButton = () => {
 
 				localStorage.setItem(localStorageAuthKey, authToken);
 
-				navigate(formatRedirectUrl(redirectUri), { replace: true });
+				setLocation(formatRedirectUrl(redirectUri), { replace: true });
 			}
 		} catch (error) {
 			setError(error instanceof Error ? error : new Error(String(error)));
 		}
-	}, [library, verifySignature, navigate, account]);
+	}, [library, verifySignature, setLocation, account]);
 
 	// 'account' undefined means that we are not connected.
 	if (!account) return null;

--- a/src/packages/auth-ui-components/src/pages/auth/component.tsx
+++ b/src/packages/auth-ui-components/src/pages/auth/component.tsx
@@ -1,14 +1,11 @@
 import { Spacer } from '@exogee/graphweaver-admin-ui-components';
-import { Outlet } from 'react-router-dom';
 
 import styles from './styles.module.css';
 
-export const Auth = () => {
+export const Auth = ({ children }: { children: React.ReactNode }) => {
 	return (
 		<div className={styles.wrapper}>
-			<div className={styles.container}>
-				<Outlet />
-			</div>
+			<div className={styles.container}>{children}</div>
 			<Spacer height={30} />
 
 			<div className={styles.footer}>

--- a/src/packages/auth-ui-components/src/pages/challenge/component.tsx
+++ b/src/packages/auth-ui-components/src/pages/challenge/component.tsx
@@ -1,4 +1,4 @@
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'wouter';
 import {
 	MagicLinkChallenge,
 	OTPChallenge,

--- a/src/packages/auth-ui-components/src/routes.tsx
+++ b/src/packages/auth-ui-components/src/routes.tsx
@@ -37,17 +37,21 @@ export const loadRoutes = () => {
 
 	for (const method of primaryMethods) {
 		const formattedMethodName = method.toLowerCase().replace('_', '-') + '-';
-		const path = `${primaryMethods.length > 1 ? formattedMethodName : ''}login`;
+		const path = `auth/${primaryMethods.length > 1 ? formattedMethodName : ''}login`;
 		routes.push({
 			path,
-			element: mapComponent(method),
+			element: <Auth>{mapComponent(method)}</Auth>,
 		});
 	}
 
 	if (secondaryMethods) {
 		routes.push({
-			path: 'challenge',
-			element: <Challenge />,
+			path: 'auth/challenge',
+			element: (
+				<Auth>
+					<Challenge />
+				</Auth>
+			),
 		});
 	}
 
@@ -55,30 +59,25 @@ export const loadRoutes = () => {
 
 	if (hasPassword && password?.enableForgottenPassword) {
 		routes.push({
-			path: 'forgot-password',
-			element: <ForgottenPassword />,
+			path: 'auth/forgot-password',
+			element: (
+				<Auth>
+					<ForgottenPassword />
+				</Auth>
+			),
 		});
 	}
 
 	if (hasPassword && password?.enableResetPassword) {
 		routes.push({
-			path: 'reset-password',
-			element: <ResetPassword />,
+			path: 'auth/reset-password',
+			element: (
+				<Auth>
+					<ResetPassword />
+				</Auth>
+			),
 		});
 	}
 
-	return [
-		{
-			path: '/auth',
-			element: (
-				<Auth>
-					{routes.map((route) => (
-						<Route key={route.path} path={route.path}>
-							{route.element}
-						</Route>
-					))}
-				</Auth>
-			),
-		},
-	];
+	return routes;
 };

--- a/src/packages/auth-ui-components/src/routes.tsx
+++ b/src/packages/auth-ui-components/src/routes.tsx
@@ -1,3 +1,4 @@
+import { Route } from 'wouter';
 import {
 	Auth0,
 	ForgottenPassword,
@@ -31,20 +32,20 @@ export const loadRoutes = () => {
 	const config = import.meta.env.VITE_GRAPHWEAVER_CONFIG;
 	if (!config.auth) return [];
 
-	const routes = new Set();
+	const routes: { path: string; element: React.ReactNode }[] = [];
 	const { primaryMethods, secondaryMethods, password } = config.auth;
 
 	for (const method of primaryMethods) {
 		const formattedMethodName = method.toLowerCase().replace('_', '-') + '-';
 		const path = `${primaryMethods.length > 1 ? formattedMethodName : ''}login`;
-		routes.add({
+		routes.push({
 			path,
 			element: mapComponent(method),
 		});
 	}
 
 	if (secondaryMethods) {
-		routes.add({
+		routes.push({
 			path: 'challenge',
 			element: <Challenge />,
 		});
@@ -53,14 +54,14 @@ export const loadRoutes = () => {
 	const hasPassword = primaryMethods.includes(PrimaryAuthMethod.PASSWORD);
 
 	if (hasPassword && password?.enableForgottenPassword) {
-		routes.add({
+		routes.push({
 			path: 'forgot-password',
 			element: <ForgottenPassword />,
 		});
 	}
 
 	if (hasPassword && password?.enableResetPassword) {
-		routes.add({
+		routes.push({
 			path: 'reset-password',
 			element: <ResetPassword />,
 		});
@@ -69,8 +70,15 @@ export const loadRoutes = () => {
 	return [
 		{
 			path: '/auth',
-			element: <Auth />,
-			children: Array.from(routes),
+			element: (
+				<Auth>
+					{routes.map((route) => (
+						<Route key={route.path} path={route.path}>
+							{route.element}
+						</Route>
+					))}
+				</Auth>
+			),
 		},
 	];
 };

--- a/src/packages/auth-ui-components/src/routes.tsx
+++ b/src/packages/auth-ui-components/src/routes.tsx
@@ -1,4 +1,3 @@
-import { Route } from 'wouter';
 import {
 	Auth0,
 	ForgottenPassword,

--- a/src/packages/builder/src/vite-config.ts
+++ b/src/packages/builder/src/vite-config.ts
@@ -85,7 +85,6 @@ export const viteConfig = async ({
 				'react-dom/client',
 				'react-fast-compare',
 				'react-is',
-				'react-router-dom',
 				'rehackt',
 				'set-value',
 			],

--- a/src/packages/xero/package.json
+++ b/src/packages/xero/package.json
@@ -39,7 +39,6 @@
 		"prettier": "3.4.2",
 		"react": "19.0.0",
 		"react-dom": "19.0.0",
-		"react-router-dom": "6.28.0",
 		"typescript": "5.7.2"
 	},
 	"keywords": [

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -85,10 +85,10 @@ importers:
         version: 6.4.6
       '@mikro-orm/knex':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.1)(sqlite3@5.1.7)
       '@mikro-orm/sqlite':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.1)
       graphql:
         specifier: 16.10.0
         version: 16.10.0
@@ -284,10 +284,10 @@ importers:
         version: 6.4.6
       '@mikro-orm/knex':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.1)(sqlite3@5.1.7)
       '@mikro-orm/sqlite':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.1)
       graphql:
         specifier: 16.10.0
         version: 16.10.0
@@ -339,10 +339,10 @@ importers:
         version: 6.4.6
       '@mikro-orm/knex':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.1)(sqlite3@5.1.7)
       '@mikro-orm/sqlite':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.1)
       '@okta/okta-auth-js':
         specifier: 7.9.0
         version: 7.9.0(encoding@0.1.13)
@@ -382,10 +382,10 @@ importers:
         version: 6.4.6
       '@mikro-orm/knex':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.1)(sqlite3@5.1.7)
       '@mikro-orm/mysql':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.2)
       dotenv:
         specifier: 16.4.7
         version: 16.4.7
@@ -434,7 +434,7 @@ importers:
         version: 6.4.6
       '@mikro-orm/mysql':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.2)
       dotenv:
         specifier: 16.4.7
         version: 16.4.7
@@ -501,10 +501,10 @@ importers:
         version: 6.4.6
       '@mikro-orm/knex':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.1)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.1)(sqlite3@5.1.7)
       '@mikro-orm/postgresql':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(mysql2@3.12.0)
       graphql:
         specifier: 16.10.0
         version: 16.10.0
@@ -559,10 +559,10 @@ importers:
         version: 6.4.6
       '@mikro-orm/knex':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.1)(sqlite3@5.1.7)
       '@mikro-orm/sqlite':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.1)
       graphql:
         specifier: 16.10.0
         version: 16.10.0
@@ -654,9 +654,9 @@ importers:
       react-dom:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
-      react-router-dom:
-        specifier: 6.28.0
-        version: 6.28.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      wouter:
+        specifier: 3.6.0
+        version: 3.6.0(react@19.0.0)
       xero-node:
         specifier: 10.0.0
         version: 10.0.0
@@ -700,12 +700,15 @@ importers:
       react-dom:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
+      react-error-boundary:
+        specifier: 5.0.0
+        version: 5.0.0(react@19.0.0)
       react-modal:
         specifier: 3.16.1
         version: 3.16.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      react-router-dom:
-        specifier: 6.28.0
-        version: 6.28.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      wouter:
+        specifier: 3.6.0
+        version: 3.6.0(react@19.0.0)
     devDependencies:
       '@chialab/esbuild-plugin-html':
         specifier: 0.18.2
@@ -776,6 +779,9 @@ importers:
       react-day-picker:
         specifier: 9.4.1
         version: 9.4.1(react@19.0.0)
+      react-error-boundary:
+        specifier: 5.0.0
+        version: 5.0.0(react@19.0.0)
       react-hot-toast:
         specifier: 2.4.1
         version: 2.4.1(csstype@3.1.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -785,6 +791,9 @@ importers:
       react-syntax-highlighter:
         specifier: 15.6.1
         version: 15.6.1(react@19.0.0)
+      wouter:
+        specifier: 3.6.0
+        version: 3.6.0(react@19.0.0)
     devDependencies:
       '@types/graphql-deduplicator':
         specifier: 2.0.2
@@ -822,9 +831,6 @@ importers:
       react-dom:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
-      react-router-dom:
-        specifier: 6.28.0
-        version: 6.28.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       typescript:
         specifier: 5.7.2
         version: 5.7.2
@@ -946,12 +952,12 @@ importers:
       graphql:
         specifier: '16'
         version: 16.10.0
-      react-router-dom:
-        specifier: ^6.23.1
-        version: 6.26.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       web3-token:
         specifier: 1.0.6
         version: 1.0.6(react@19.0.0)
+      wouter:
+        specifier: 3.6.0
+        version: 3.6.0(react@19.0.0)
     devDependencies:
       '@auth0/auth0-spa-js':
         specifier: 2.1.3
@@ -1338,7 +1344,7 @@ importers:
         version: 6.4.6
       '@mikro-orm/postgresql':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(mysql2@3.12.0)
       '@mikro-orm/sqlite':
         specifier: 6.4.6
         version: 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.1)
@@ -1443,10 +1449,10 @@ importers:
     dependencies:
       '@mikro-orm/knex':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.1)(sqlite3@5.1.7)
       '@mikro-orm/sqlite':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.1)
       node-sqlite3-wasm:
         specifier: 0.8.28
         version: 0.8.28
@@ -1502,16 +1508,16 @@ importers:
     optionalDependencies:
       '@mikro-orm/knex':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(mysql2@3.12.0)(pg@8.13.2)
       '@mikro-orm/mysql':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.2)
       '@mikro-orm/postgresql':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(mysql2@3.12.0)
       '@mikro-orm/sqlite':
         specifier: 6.4.6
-        version: 6.4.6(@mikro-orm/core@6.4.6)
+        version: 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.2)
     devDependencies:
       '@mikro-orm/core':
         specifier: 6.4.6
@@ -1805,9 +1811,6 @@ importers:
       react-dom:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
-      react-router-dom:
-        specifier: 6.28.0
-        version: 6.28.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       typescript:
         specifier: 5.7.2
         version: 5.7.2
@@ -4863,14 +4866,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-
-  '@remix-run/router@1.19.2':
-    resolution: {integrity: sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA==}
-    engines: {node: '>=14.0.0'}
-
-  '@remix-run/router@1.21.0':
-    resolution: {integrity: sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==}
-    engines: {node: '>=14.0.0'}
 
   '@repeaterjs/repeater@3.0.6':
     resolution: {integrity: sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==}
@@ -8618,6 +8613,9 @@ packages:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -9337,6 +9335,11 @@ packages:
     peerDependencies:
       react: ^19.0.0
 
+  react-error-boundary@5.0.0:
+    resolution: {integrity: sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==}
+    peerDependencies:
+      react: '>=16.13.1'
+
   react-fast-compare@2.0.4:
     resolution: {integrity: sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==}
 
@@ -9396,32 +9399,6 @@ packages:
       react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
-  react-router-dom@6.26.2:
-    resolution: {integrity: sha512-z7YkaEW0Dy35T3/QKPYB1LjMK2R1fxnHO8kWpUMTBdfVzZrWOiY9a7CtN8HqdWtDUWd5FY6Dl8HFsqVwH4uOtQ==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-
-  react-router-dom@6.28.0:
-    resolution: {integrity: sha512-kQ7Unsl5YdyOltsPGl31zOjLrDv+m2VcIEcIHqYYD3Lp0UppLjrzcfJqDJwXxFw3TH/yvapbnUvPlAj7Kx5nbg==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-
-  react-router@6.26.2:
-    resolution: {integrity: sha512-tvN1iuT03kHgOFnLPfLJ8V95eijteveqdOSk+srqfePtQvqCExB8eHOYnlilbOcyJyKnYkr1vJvf7YqotAJu1A==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
-
-  react-router@6.28.0:
-    resolution: {integrity: sha512-HrYdIFqdrnhDw0PqG/AKjAqEqM7AvxCz0DQ4h2W8k6nqmc5uRBYDag0SBxx9iYz5G8gnuNVLzUe13wl9eAsXXg==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
-
   react-style-singleton@2.2.1:
     resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
     engines: {node: '>=10'}
@@ -9476,6 +9453,10 @@ packages:
 
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+
+  regexparam@3.0.0:
+    resolution: {integrity: sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==}
+    engines: {node: '>=8'}
 
   rehackt@0.1.0:
     resolution: {integrity: sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==}
@@ -10588,6 +10569,11 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wouter@3.6.0:
+    resolution: {integrity: sha512-l11eR4urCc+CbY8+pV8HKFHxEqMgffss9aVB1XwiSkLDtH3cI6XpCa50cOzREzL0KwQqrwCVE5dCyeNcCgFpPg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -14019,36 +14005,6 @@ snapshots:
       mikro-orm: 6.4.6
       reflect-metadata: 0.2.2
 
-  '@mikro-orm/knex@6.4.6(@mikro-orm/core@6.4.6)':
-    dependencies:
-      '@mikro-orm/core': 6.4.6
-      fs-extra: 11.3.0
-      knex: 3.1.0
-      sqlstring: 2.3.3
-    transitivePeerDependencies:
-      - mysql
-      - mysql2
-      - pg
-      - pg-native
-      - sqlite3
-      - supports-color
-      - tedious
-
-  '@mikro-orm/knex@6.4.6(@mikro-orm/core@6.4.6)(mysql2@3.12.0)':
-    dependencies:
-      '@mikro-orm/core': 6.4.6
-      fs-extra: 11.3.0
-      knex: 3.1.0(mysql2@3.12.0)
-      sqlstring: 2.3.3
-    transitivePeerDependencies:
-      - mysql
-      - mysql2
-      - pg
-      - pg-native
-      - sqlite3
-      - supports-color
-      - tedious
-
   '@mikro-orm/knex@6.4.6(@mikro-orm/core@6.4.6)(mysql2@3.12.0)(pg@8.13.1)':
     dependencies:
       '@mikro-orm/core': 6.4.6
@@ -14079,21 +14035,6 @@ snapshots:
       - supports-color
       - tedious
 
-  '@mikro-orm/knex@6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.1)':
-    dependencies:
-      '@mikro-orm/core': 6.4.6
-      fs-extra: 11.3.0
-      knex: 3.1.0(pg@8.13.1)
-      sqlstring: 2.3.3
-    transitivePeerDependencies:
-      - mysql
-      - mysql2
-      - pg
-      - pg-native
-      - sqlite3
-      - supports-color
-      - tedious
-
   '@mikro-orm/knex@6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.1)(sqlite3@5.1.7)':
     dependencies:
       '@mikro-orm/core': 6.4.6
@@ -14109,11 +14050,11 @@ snapshots:
       - supports-color
       - tedious
 
-  '@mikro-orm/knex@6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.2)':
+  '@mikro-orm/knex@6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.2)(sqlite3@5.1.7)':
     dependencies:
       '@mikro-orm/core': 6.4.6
       fs-extra: 11.3.0
-      knex: 3.1.0(pg@8.13.2)
+      knex: 3.1.0(pg@8.13.2)(sqlite3@5.1.7)
       sqlstring: 2.3.3
     transitivePeerDependencies:
       - mysql
@@ -14123,37 +14064,7 @@ snapshots:
       - sqlite3
       - supports-color
       - tedious
-
-  '@mikro-orm/knex@6.4.6(@mikro-orm/core@6.4.6)(sqlite3@5.1.7)':
-    dependencies:
-      '@mikro-orm/core': 6.4.6
-      fs-extra: 11.3.0
-      knex: 3.1.0(sqlite3@5.1.7)
-      sqlstring: 2.3.3
-    transitivePeerDependencies:
-      - mysql
-      - mysql2
-      - pg
-      - pg-native
-      - sqlite3
-      - supports-color
-      - tedious
-
-  '@mikro-orm/mysql@6.4.6(@mikro-orm/core@6.4.6)':
-    dependencies:
-      '@mikro-orm/core': 6.4.6
-      '@mikro-orm/knex': 6.4.6(@mikro-orm/core@6.4.6)(mysql2@3.12.0)
-      mysql2: 3.12.0
-    transitivePeerDependencies:
-      - better-sqlite3
-      - libsql
-      - mariadb
-      - mysql
-      - pg
-      - pg-native
-      - sqlite3
-      - supports-color
-      - tedious
+    optional: true
 
   '@mikro-orm/mysql@6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.1)':
     dependencies:
@@ -14171,20 +14082,17 @@ snapshots:
       - supports-color
       - tedious
 
-  '@mikro-orm/postgresql@6.4.6(@mikro-orm/core@6.4.6)':
+  '@mikro-orm/mysql@6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.2)':
     dependencies:
       '@mikro-orm/core': 6.4.6
-      '@mikro-orm/knex': 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.2)
-      pg: 8.13.2
-      postgres-array: 3.0.2
-      postgres-date: 2.1.0
-      postgres-interval: 4.0.2
+      '@mikro-orm/knex': 6.4.6(@mikro-orm/core@6.4.6)(mysql2@3.12.0)(pg@8.13.2)
+      mysql2: 3.12.0
     transitivePeerDependencies:
       - better-sqlite3
       - libsql
       - mariadb
       - mysql
-      - mysql2
+      - pg
       - pg-native
       - sqlite3
       - supports-color
@@ -14209,25 +14117,6 @@ snapshots:
       - supports-color
       - tedious
 
-  '@mikro-orm/sqlite@6.4.6(@mikro-orm/core@6.4.6)':
-    dependencies:
-      '@mikro-orm/core': 6.4.6
-      '@mikro-orm/knex': 6.4.6(@mikro-orm/core@6.4.6)(sqlite3@5.1.7)
-      fs-extra: 11.3.0
-      sqlite3: 5.1.7
-      sqlstring-sqlite: 0.1.1
-    transitivePeerDependencies:
-      - better-sqlite3
-      - bluebird
-      - libsql
-      - mariadb
-      - mysql
-      - mysql2
-      - pg
-      - pg-native
-      - supports-color
-      - tedious
-
   '@mikro-orm/sqlite@6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.1)':
     dependencies:
       '@mikro-orm/core': 6.4.6
@@ -14246,6 +14135,26 @@ snapshots:
       - pg-native
       - supports-color
       - tedious
+
+  '@mikro-orm/sqlite@6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.2)':
+    dependencies:
+      '@mikro-orm/core': 6.4.6
+      '@mikro-orm/knex': 6.4.6(@mikro-orm/core@6.4.6)(pg@8.13.2)(sqlite3@5.1.7)
+      fs-extra: 11.3.0
+      sqlite3: 5.1.7
+      sqlstring-sqlite: 0.1.1
+    transitivePeerDependencies:
+      - better-sqlite3
+      - bluebird
+      - libsql
+      - mariadb
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - supports-color
+      - tedious
+    optional: true
 
   '@motionone/animation@10.18.0':
     dependencies:
@@ -15105,10 +15014,6 @@ snapshots:
       '@react-spring/types': 9.7.4
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-
-  '@remix-run/router@1.19.2': {}
-
-  '@remix-run/router@1.21.0': {}
 
   '@repeaterjs/repeater@3.0.6': {}
 
@@ -19297,46 +19202,6 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  knex@3.1.0:
-    dependencies:
-      colorette: 2.0.19
-      commander: 10.0.1
-      debug: 4.3.4
-      escalade: 3.2.0
-      esm: 3.2.25
-      get-package-type: 0.1.0
-      getopts: 2.3.0
-      interpret: 2.2.0
-      lodash: 4.17.21
-      pg-connection-string: 2.6.2
-      rechoir: 0.8.0
-      resolve-from: 5.0.0
-      tarn: 3.0.2
-      tildify: 2.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  knex@3.1.0(mysql2@3.12.0):
-    dependencies:
-      colorette: 2.0.19
-      commander: 10.0.1
-      debug: 4.3.4
-      escalade: 3.2.0
-      esm: 3.2.25
-      get-package-type: 0.1.0
-      getopts: 2.3.0
-      interpret: 2.2.0
-      lodash: 4.17.21
-      pg-connection-string: 2.6.2
-      rechoir: 0.8.0
-      resolve-from: 5.0.0
-      tarn: 3.0.2
-      tildify: 2.0.0
-    optionalDependencies:
-      mysql2: 3.12.0
-    transitivePeerDependencies:
-      - supports-color
-
   knex@3.1.0(mysql2@3.12.0)(pg@8.13.1):
     dependencies:
       colorette: 2.0.19
@@ -19381,27 +19246,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  knex@3.1.0(pg@8.13.1):
-    dependencies:
-      colorette: 2.0.19
-      commander: 10.0.1
-      debug: 4.3.4
-      escalade: 3.2.0
-      esm: 3.2.25
-      get-package-type: 0.1.0
-      getopts: 2.3.0
-      interpret: 2.2.0
-      lodash: 4.17.21
-      pg-connection-string: 2.6.2
-      rechoir: 0.8.0
-      resolve-from: 5.0.0
-      tarn: 3.0.2
-      tildify: 2.0.0
-    optionalDependencies:
-      pg: 8.13.1
-    transitivePeerDependencies:
-      - supports-color
-
   knex@3.1.0(pg@8.13.1)(sqlite3@5.1.7):
     dependencies:
       colorette: 2.0.19
@@ -19424,7 +19268,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  knex@3.1.0(pg@8.13.2):
+  knex@3.1.0(pg@8.13.2)(sqlite3@5.1.7):
     dependencies:
       colorette: 2.0.19
       commander: 10.0.1
@@ -19442,29 +19286,10 @@ snapshots:
       tildify: 2.0.0
     optionalDependencies:
       pg: 8.13.2
-    transitivePeerDependencies:
-      - supports-color
-
-  knex@3.1.0(sqlite3@5.1.7):
-    dependencies:
-      colorette: 2.0.19
-      commander: 10.0.1
-      debug: 4.3.4
-      escalade: 3.2.0
-      esm: 3.2.25
-      get-package-type: 0.1.0
-      getopts: 2.3.0
-      interpret: 2.2.0
-      lodash: 4.17.21
-      pg-connection-string: 2.6.2
-      rechoir: 0.8.0
-      resolve-from: 5.0.0
-      tarn: 3.0.2
-      tildify: 2.0.0
-    optionalDependencies:
       sqlite3: 5.1.7
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   leven@3.1.0: {}
 
@@ -19872,6 +19697,8 @@ snapshots:
     dependencies:
       minipass: 3.3.6
       yallist: 4.0.0
+
+  mitt@3.0.1: {}
 
   mkdirp-classic@0.5.3: {}
 
@@ -20596,6 +20423,11 @@ snapshots:
       react: 19.0.0
       scheduler: 0.25.0
 
+  react-error-boundary@5.0.0(react@19.0.0):
+    dependencies:
+      '@babel/runtime': 7.26.7
+      react: 19.0.0
+
   react-fast-compare@2.0.4: {}
 
   react-hot-toast@2.4.1(csstype@3.1.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
@@ -20648,30 +20480,6 @@ snapshots:
     dependencies:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-
-  react-router-dom@6.26.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
-    dependencies:
-      '@remix-run/router': 1.19.2
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
-      react-router: 6.26.2(react@19.0.0)
-
-  react-router-dom@6.28.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
-    dependencies:
-      '@remix-run/router': 1.21.0
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
-      react-router: 6.28.0(react@19.0.0)
-
-  react-router@6.26.2(react@19.0.0):
-    dependencies:
-      '@remix-run/router': 1.19.2
-      react: 19.0.0
-
-  react-router@6.28.0(react@19.0.0):
-    dependencies:
-      '@remix-run/router': 1.21.0
-      react: 19.0.0
 
   react-style-singleton@2.2.1(@types/react@19.0.10)(react@19.0.0):
     dependencies:
@@ -20735,6 +20543,8 @@ snapshots:
       prismjs: 1.27.0
 
   regenerator-runtime@0.14.1: {}
+
+  regexparam@3.0.0: {}
 
   rehackt@0.1.0(@types/react@19.0.10)(react@19.0.0):
     optionalDependencies:
@@ -21937,6 +21747,13 @@ snapshots:
       string-width: 5.1.2
 
   word-wrap@1.2.5: {}
+
+  wouter@3.6.0(react@19.0.0):
+    dependencies:
+      mitt: 3.0.1
+      react: 19.0.0
+      regexparam: 3.0.0
+      use-sync-external-store: 1.2.0(react@19.0.0)
 
   wrap-ansi@6.2.0:
     dependencies:

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -453,6 +453,9 @@ importers:
       react:
         specifier: 19.0.0
         version: 19.0.0
+      wouter:
+        specifier: 3.6.0
+        version: 3.6.0(react@19.0.0)
     devDependencies:
       '@types/node':
         specifier: 22.10.1


### PR DESCRIPTION
I'm sick of breaking API changes. This PR moves the Admin UI to using Wouter.

The only reason this will affect you is if you're using our Admin UI Components library directly. If so, see our upgrade notes in the release notes.