### PR TITLE
Feature / Multiple Version Protection

### DIFF
--- a/src/packages/core/tsconfig.json
+++ b/src/packages/core/tsconfig.json
@@ -3,7 +3,8 @@
 	"include": ["./src"],
 	"compilerOptions": {
 		"rootDir": "./src",
-		"outDir": "./lib"
+		"outDir": "./lib",
+		"resolveJsonModule": true
 	},
 	"references": [{ "path": "../logger" }, { "path": "../scalars" }]
 }

--- a/src/packages/end-to-end/scripts/import-auth.ts
+++ b/src/packages/end-to-end/scripts/import-auth.ts
@@ -19,6 +19,11 @@ async function execAsync(command: string) {
 	return child;
 }
 
+const getDependencyVersion = async (dependency: string) => {
+	const packageJson = JSON.parse(await fs.promises.readFile('package.json', 'utf-8'));
+	return packageJson.dependencies[dependency];
+};
+
 async function main() {
 	try {
 		await execAsync('pwd');
@@ -52,7 +57,7 @@ async function main() {
 
 		await fs.promises.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
-		await execAsync("pnpm add '@mikro-orm/sqlite'")
+		await execAsync(`pnpm add '@mikro-orm/sqlite@${getDependencyVersion('@mikro-orm/sqlite')}'`);
 		fs.mkdirSync('./databases');
 		await execAsync('pwd');
 		await execAsync('pnpm i --ignore-workspace --no-lockfile');

--- a/src/packages/end-to-end/scripts/import-auth.ts
+++ b/src/packages/end-to-end/scripts/import-auth.ts
@@ -57,7 +57,9 @@ async function main() {
 
 		await fs.promises.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
-		await execAsync(`pnpm add '@mikro-orm/sqlite@${getDependencyVersion('@mikro-orm/sqlite')}'`);
+		await execAsync(
+			`pnpm add '@mikro-orm/sqlite@${await getDependencyVersion('@mikro-orm/sqlite')}'`
+		);
 		fs.mkdirSync('./databases');
 		await execAsync('pwd');
 		await execAsync('pnpm i --ignore-workspace --no-lockfile');

--- a/src/packages/end-to-end/scripts/import-auth.ts
+++ b/src/packages/end-to-end/scripts/import-auth.ts
@@ -20,7 +20,14 @@ async function execAsync(command: string) {
 }
 
 const getDependencyVersion = async (dependency: string) => {
-	const packageJson = JSON.parse(await fs.promises.readFile('package.json', 'utf-8'));
+	const packageJson = JSON.parse(
+		await fs.promises.readFile(path.join(__dirname, '..', 'package.json'), 'utf-8')
+	);
+
+	if (!packageJson.dependencies?.[dependency]) {
+		throw new Error(`Dependency ${dependency} not found in package.json`);
+	}
+
 	return packageJson.dependencies[dependency];
 };
 


### PR DESCRIPTION
Add singleton protection by tagging our version on `global` when the metadata file loads. This should prevent people from installing multiple versions of Graphweaver by accident and not realising.