### PR TITLE
Fixed sorting by non unique field

### DIFF
--- a/src/examples/auth-zero/package.json
+++ b/src/examples/auth-zero/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-auth-zero",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"license": "Apache-2.0",
 	"private": true,
 	"description": "Example of connecting a SQLite database with Auth0.",

--- a/src/examples/aws-cognito/package.json
+++ b/src/examples/aws-cognito/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@exogee/graphweaver-example-aws-cognito",
 	"private": true,
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"license": "Apache-2.0",
 	"description": "Example of connecting to AWS Cognito",
 	"main": "lib/index.js",

--- a/src/examples/databases/package.json
+++ b/src/examples/databases/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-databases",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"license": "Apache-2.0",
 	"private": true,
 	"description": "Example of connecting a MySQL and PostgreSQL database together.",

--- a/src/examples/federation/package.json
+++ b/src/examples/federation/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@exogee/graphweaver-example-federation",
 	"private": true,
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"license": "Apache-2.0",
 	"description": "Example app used to test federation compatibility",
 	"main": "lib/index.js",

--- a/src/examples/microsoft-entra/package.json
+++ b/src/examples/microsoft-entra/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-microsoft-entra",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"license": "Apache-2.0",
 	"private": true,
 	"description": "Example of connecting a SQLite database with Microsoft Entra.",

--- a/src/examples/okta/package.json
+++ b/src/examples/okta/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-okta",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"license": "Apache-2.0",
 	"private": true,
 	"description": "Example of connecting a SQLite database with Okta.",

--- a/src/examples/rest-with-auth/package.json
+++ b/src/examples/rest-with-auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-rest-with-auth",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"license": "Apache-2.0",
 	"private": true,
 	"description": "Example of connecting a Rest API with a MySQL database and complex auth.",

--- a/src/examples/rest/package.json
+++ b/src/examples/rest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-rest",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"license": "Apache-2.0",
 	"description": "Simple example of connecting to a Rest API.",
 	"private": true,

--- a/src/examples/s3-storage/package.json
+++ b/src/examples/s3-storage/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-s3-storage",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"license": "Apache-2.0",
 	"private": true,
 	"description": "Example of connecting Graphweaver to an AWS S3 bucket.",

--- a/src/examples/sqlite/package.json
+++ b/src/examples/sqlite/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-sqlite",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"license": "Apache-2.0",
 	"private": true,
 	"description": "Example of connecting a SQLite database.",

--- a/src/examples/xero/package.json
+++ b/src/examples/xero/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-example-xero",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"license": "Apache-2.0",
 	"private": true,
 	"description": "Example of using @exogee/graphweaver to connect two Xero instances",

--- a/src/packages/admin-ui-components/package.json
+++ b/src/packages/admin-ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-admin-ui-components",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "Components from Graphweaver's admin UI which you can use in your projects as you like",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/src/packages/admin-ui-components/src/entity-list/component.tsx
+++ b/src/packages/admin-ui-components/src/entity-list/component.tsx
@@ -110,8 +110,11 @@ export const EntityList = <TData extends object>({ children }: { children: React
 
 		let filter = variables.filter ?? {};
 		let offset = 0;
-		if (supportsPseudoCursorPagination && Object.keys(sort).find((k) => k === entity.primaryKeyField)) {
-			filter = addStabilizationToFilter(filter, sort, lastElement, entity);
+		const sortedByPrimaryKeyOnly = Object.keys(sort).length === 1 && Object.keys(sort)[0] === entity.primaryKeyField;
+		if (supportsPseudoCursorPagination && sortedByPrimaryKeyOnly) {
+			// We don't yet have a way to define sort order, so for now we
+			// can only page this way in this case.
+			filter = addStabilizationToFilter(filter, sort, lastElement);
 		} else {
 			const nextPage = Math.ceil((data?.result.length ?? 0) / PAGE_SIZE);
 			offset = nextPage * PAGE_SIZE;

--- a/src/packages/admin-ui-components/src/entity-list/component.tsx
+++ b/src/packages/admin-ui-components/src/entity-list/component.tsx
@@ -106,13 +106,17 @@ export const EntityList = <TData extends object>({ children }: { children: React
 	};
 
 	const handleFetchNextPage = async () => {
-		const nextPage = Math.ceil((data?.result.length ?? 0) / PAGE_SIZE);
-		const offset = supportsPseudoCursorPagination ? 0 : nextPage * PAGE_SIZE;
+		const lastElement = data?.result?.[data.result.length - 1];
 
-		const filterVar = variables.filter ?? {};
-		const filter = supportsPseudoCursorPagination
-			? addStabilizationToFilter(filterVar, sort, data?.result?.[data.result.length - 1])
-			: filterVar;
+		let filter = variables.filter ?? {};
+		let offset = 0;
+		if (supportsPseudoCursorPagination && Object.keys(sort).find((k) => k === entity.primaryKeyField)) {
+			filter = addStabilizationToFilter(filter, sort, lastElement, entity);
+		} else {
+			const nextPage = Math.ceil((data?.result.length ?? 0) / PAGE_SIZE);
+			offset = nextPage * PAGE_SIZE;
+		}
+
 		fetchMore({
 			variables: {
 				...variables,

--- a/src/packages/admin-ui-components/src/title-bar/component.tsx
+++ b/src/packages/admin-ui-components/src/title-bar/component.tsx
@@ -29,18 +29,29 @@ export const TitleBar = ({ title, subtitle, onExportToCSV }: Props) => {
 			</div>
 
 			<div className={styles.toolsWrapper}>
-				<a
-					href="/playground"
-					// If we are in an iframe then open in the same window otherwise open in a new tab
-					target={window === window.parent ? '_blank' : '_self'}
-					rel="noopener noreferrer"
-					aria-label="Open Playground"
-				>
-					<Button>
-						Open Playground
-						<OpenExternalIcon />
-					</Button>
-				</a>
+				{/* By default we want to open in a new window. <Link /> doesn't do that for us.
+				    But when we're in an iframe, we can't open a new window, so we just clobber. */}
+				{!window.parent ? (
+					<a
+						href="/playground"
+						target="_blank"
+						rel="noopener noreferrer"
+						aria-label="Open Playground"
+					>
+						<Button>
+							Open Playground
+							<OpenExternalIcon />
+						</Button>
+					</a>
+				) : (
+					<Link to="/playground" aria-label="Open Playground">
+						<Button>
+							Open Playground
+							<OpenExternalIcon />
+						</Button>
+					</Link>
+				)}
+
 				{onExportToCSV && (
 					<Button className={styles.toolBarTrailingButton} onClick={onExportToCSV}>
 						Export to CSV

--- a/src/packages/admin-ui-components/src/title-bar/component.tsx
+++ b/src/packages/admin-ui-components/src/title-bar/component.tsx
@@ -31,7 +31,7 @@ export const TitleBar = ({ title, subtitle, onExportToCSV }: Props) => {
 			<div className={styles.toolsWrapper}>
 				{/* By default we want to open in a new window. <Link /> doesn't do that for us.
 				    But when we're in an iframe, we can't open a new window, so we just clobber. */}
-				{!window.parent ? (
+				{window.self === window.top ? (
 					<a
 						href="/playground"
 						target="_blank"

--- a/src/packages/admin-ui/package.json
+++ b/src/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-admin-ui",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"type": "module",
 	"main": "dist/main.js",
 	"types": "src/main.tsx",

--- a/src/packages/apollo-client/package.json
+++ b/src/packages/apollo-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-apollo-client",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "Useful helpers for working with Apollo Client and Graphweaver",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/src/packages/apollo-client/src/index.ts
+++ b/src/packages/apollo-client/src/index.ts
@@ -85,7 +85,8 @@ export const generateTypePolicies = (entities: Entity[]) => {
 export const addStabilizationToFilter = <TData>(
 	filter: Record<string, unknown>,
 	sort: SortEntity,
-	lastElement: TData
+	lastElement: TData,
+	entity: Entity
 ) => {
 	const filters = {
 		...filter,
@@ -93,6 +94,7 @@ export const addStabilizationToFilter = <TData>(
 
 	const keys = Object.keys(sort);
 	for (const key of keys) {
+		if (key !== entity.primaryKeyField) continue;
 		const isDesc = sort[key] === Sort.DESC;
 		const operationKey = isDesc ? 'lte' : 'gte';
 

--- a/src/packages/apollo-client/src/index.ts
+++ b/src/packages/apollo-client/src/index.ts
@@ -85,8 +85,7 @@ export const generateTypePolicies = (entities: Entity[]) => {
 export const addStabilizationToFilter = <TData>(
 	filter: Record<string, unknown>,
 	sort: SortEntity,
-	lastElement: TData,
-	entity: Entity
+	lastElement: TData
 ) => {
 	const filters = {
 		...filter,
@@ -94,7 +93,6 @@ export const addStabilizationToFilter = <TData>(
 
 	const keys = Object.keys(sort);
 	for (const key of keys) {
-		if (key !== entity.primaryKeyField) continue;
 		const isDesc = sort[key] === Sort.DESC;
 		const operationKey = isDesc ? 'lte' : 'gte';
 

--- a/src/packages/auth-ui-components/package.json
+++ b/src/packages/auth-ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-auth-ui-components",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "Components from Graphweaver's Auth UI which you can use in your projects as you like",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/src/packages/auth/package.json
+++ b/src/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-auth",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "Row-Level Security support for @exogee/graphweaver",
 	"license": "Apache-2.0",
 	"scripts": {

--- a/src/packages/aws-cognito/package.json
+++ b/src/packages/aws-cognito/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-aws",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"main": "lib/index.js",
 	"source": "src/index.ts",
 	"directories": {

--- a/src/packages/builder/package.json
+++ b/src/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-builder",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "A tool for building and running Graphweaver projects",
 	"license": "Apache-2.0",
 	"scripts": {

--- a/src/packages/cdk/package.json
+++ b/src/packages/cdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-cdk",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "Deploy Graphweaver to AWS",
 	"license": "Apache-2.0",
 	"directories": {

--- a/src/packages/cli/package.json
+++ b/src/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "graphweaver",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "A tool for managing, running, debugging and building Graphweaver projects",
 	"license": "Apache-2.0",
 	"scripts": {

--- a/src/packages/config/package.json
+++ b/src/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-config",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "Retrieve and parse Graphweaver configurations",
 	"license": "Apache-2.0",
 	"scripts": {

--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "Graphweaver Core Package",
 	"license": "Apache-2.0",
 	"scripts": {

--- a/src/packages/core/tsconfig.json
+++ b/src/packages/core/tsconfig.json
@@ -3,7 +3,8 @@
 	"include": ["./src"],
 	"compilerOptions": {
 		"rootDir": "./src",
-		"outDir": "./lib"
+		"outDir": "./lib",
+		"resolveJsonModule": true
 	},
 	"references": [{ "path": "../logger" }, { "path": "../scalars" }]
 }

--- a/src/packages/end-to-end/package.json
+++ b/src/packages/end-to-end/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-end-to-end",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "Graphweaver Test Suite",
 	"license": "Apache-2.0",
 	"scripts": {

--- a/src/packages/end-to-end/scripts/import-auth.ts
+++ b/src/packages/end-to-end/scripts/import-auth.ts
@@ -19,6 +19,11 @@ async function execAsync(command: string) {
 	return child;
 }
 
+const getDependencyVersion = async (dependency: string) => {
+	const packageJson = JSON.parse(await fs.promises.readFile('package.json', 'utf-8'));
+	return packageJson.dependencies[dependency];
+};
+
 async function main() {
 	try {
 		await execAsync('pwd');
@@ -52,7 +57,7 @@ async function main() {
 
 		await fs.promises.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
-		await execAsync("pnpm add '@mikro-orm/sqlite'")
+		await execAsync(`pnpm add '@mikro-orm/sqlite@${getDependencyVersion('@mikro-orm/sqlite')}'`);
 		fs.mkdirSync('./databases');
 		await execAsync('pwd');
 		await execAsync('pnpm i --ignore-workspace --no-lockfile');

--- a/src/packages/end-to-end/scripts/import-auth.ts
+++ b/src/packages/end-to-end/scripts/import-auth.ts
@@ -57,7 +57,9 @@ async function main() {
 
 		await fs.promises.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
-		await execAsync(`pnpm add '@mikro-orm/sqlite@${getDependencyVersion('@mikro-orm/sqlite')}'`);
+		await execAsync(
+			`pnpm add '@mikro-orm/sqlite@${await getDependencyVersion('@mikro-orm/sqlite')}'`
+		);
 		fs.mkdirSync('./databases');
 		await execAsync('pwd');
 		await execAsync('pnpm i --ignore-workspace --no-lockfile');

--- a/src/packages/end-to-end/scripts/import-auth.ts
+++ b/src/packages/end-to-end/scripts/import-auth.ts
@@ -20,7 +20,14 @@ async function execAsync(command: string) {
 }
 
 const getDependencyVersion = async (dependency: string) => {
-	const packageJson = JSON.parse(await fs.promises.readFile('package.json', 'utf-8'));
+	const packageJson = JSON.parse(
+		await fs.promises.readFile(path.join(__dirname, '..', 'package.json'), 'utf-8')
+	);
+
+	if (!packageJson.dependencies?.[dependency]) {
+		throw new Error(`Dependency ${dependency} not found in package.json`);
+	}
+
 	return packageJson.dependencies[dependency];
 };
 

--- a/src/packages/load-testing/package.json
+++ b/src/packages/load-testing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-load-testing",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"private": true,
 	"description": "Graphweaver Load Testing Suite",
 	"license": "Apache-2.0",

--- a/src/packages/logger/package.json
+++ b/src/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/logger",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "Common logging output for Exogee projects",
 	"license": "Apache-2.0",
 	"directories": {

--- a/src/packages/mikro-orm-sqlite-wasm/package.json
+++ b/src/packages/mikro-orm-sqlite-wasm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mikro-orm-sqlite-wasm",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "MikroORM SQLite Driver Wasm",
 	"license": "Apache-2.0",
 	"scripts": {

--- a/src/packages/mikroorm/package.json
+++ b/src/packages/mikroorm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-mikroorm",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "MikroORM backend for @exogee/graphweaver",
 	"license": "Apache-2.0",
 	"scripts": {

--- a/src/packages/rest-legacy/package.json
+++ b/src/packages/rest-legacy/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-rest-legacy",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "Legacy RESTful backend adapter for @exogee/graphweaver",
 	"license": "Apache-2.0",
 	"scripts": {

--- a/src/packages/rest/package.json
+++ b/src/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-rest",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "RESTful backend adapter for @exogee/graphweaver",
 	"license": "Apache-2.0",
 	"scripts": {

--- a/src/packages/scalars/package.json
+++ b/src/packages/scalars/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-scalars",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "Common scalar types for use with @exogee/graphweaver",
 	"license": "Apache-2.0",
 	"main": "lib/index.js",

--- a/src/packages/server/package.json
+++ b/src/packages/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-server",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "Server support for @exogee/graphweaver",
 	"license": "Apache-2.0",
 	"scripts": {

--- a/src/packages/storage-provider/package.json
+++ b/src/packages/storage-provider/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-storage-provider",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "Graphweaver Storage Provider Package",
 	"license": "Apache-2.0",
 	"scripts": {

--- a/src/packages/vite-plugin-graphweaver/package.json
+++ b/src/packages/vite-plugin-graphweaver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vite-plugin-graphweaver",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "A vite plugin for use with @exogee/graphweaver's admin UI",
 	"license": "Apache-2.0",
 	"main": "lib/index.js",

--- a/src/packages/xero/package.json
+++ b/src/packages/xero/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exogee/graphweaver-xero",
-	"version": "2.12.0",
+	"version": "2.12.1",
 	"description": "Xero backend for @exogee/graphweaver",
 	"license": "Apache-2.0",
 	"scripts": {


### PR DESCRIPTION
The pagination fix in https://github.com/exogee-technology/graphweaver/pull/1582 didn't handle when the Admin UI is sorted by a non-unique field. The pseudo-cursor pagination is now only used on supporting providers if only sorting by the entity's primary key field, as right now that's the only field the metadata exposes as unique.