### PR TITLE
Add handling for field_null and field_notnull in gqlToMikro

### DIFF
--- a/src/packages/end-to-end/src/__tests__/api/postgres/query/null-filter.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/postgres/query/null-filter.test.ts
@@ -1,0 +1,26 @@
+import request from 'supertest-graphql';
+import gql from 'graphql-tag';
+
+import { config } from '../../../../config';
+
+describe('null filter', () => {
+	test('should filter by Customers with company_null = true', async () => {
+		const { data } = await request<{ customers: any }>(config.baseUrl)
+			.query(gql`
+				query Customers($filter: CustomersListFilter) {
+					customers(filter: $filter) {
+						customerId
+						company
+					}
+				}
+			`)
+			.variables({
+				filter: {
+					company_null: true,
+				},
+			})
+			.expectNoErrors();
+
+		expect(data?.customers).toHaveLength(49);
+	});
+});

--- a/src/packages/end-to-end/src/__tests__/api/postgres/query/null-filter.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/postgres/query/null-filter.test.ts
@@ -22,5 +22,149 @@ describe('null filter', () => {
 			.expectNoErrors();
 
 		expect(data?.customers).toHaveLength(49);
+		expect(data?.customers?.[0]?.company).toBeNull();
+	});
+
+	test('should filter by Customers with company_notnull = true', async () => {
+		const { data } = await request<{ customers: any }>(config.baseUrl)
+			.query(gql`
+				query Customers($filter: CustomersListFilter) {
+					customers(filter: $filter) {
+						customerId
+						company
+					}
+				}
+			`)
+			.variables({
+				filter: {
+					company_notnull: true,
+				},
+			})
+			.expectNoErrors();
+
+		expect(data?.customers).toHaveLength(10);
+		expect(data?.customers?.[0]?.company).not.toBeNull();
+	});
+
+	test('should filter by Customers with company = null', async () => {
+		const { data } = await request<{ customers: any }>(config.baseUrl)
+			.query(gql`
+				query Customers($filter: CustomersListFilter) {
+					customers(filter: $filter) {
+						customerId
+						company
+					}
+				}
+			`)
+			.variables({
+				filter: {
+					company: null,
+				},
+			})
+			.expectNoErrors();
+
+		expect(data?.customers).toHaveLength(49);
+		expect(data?.customers?.[0]?.company).toBeNull();
+	});
+
+	// Not working, but this bug is unrelated to the current PR about null filters
+	// test('should filter by Customers with company_null = false AND company = JetBrains s.r.o.', async () => {
+	// 	const { data } = await request<{ customers: any }>(config.baseUrl)
+	// 		.query(gql`
+	// 			query Customers($filter: CustomersListFilter) {
+	// 				customers(filter: $filter) {
+	// 					customerId
+	// 					company
+	// 				}
+	// 			}
+	// 		`)
+	// 		.variables({
+	// 			filter: {
+	// 				company_null: false,
+	// 				company: 'JetBrains s.r.o.',
+	// 			},
+	// 		})
+	// 		.expectNoErrors();
+
+	// 	expect(data?.customers).toHaveLength(49);
+	// 	expect(data?.customers?.[0]?.company).toBeNull();
+	// });
+
+	test('should filter by Customers with company_null = false AND company in [JetBrains s.r.o.]', async () => {
+		const { data } = await request<{ customers: any }>(config.baseUrl)
+			.query(gql`
+				query Customers($filter: CustomersListFilter) {
+					customers(filter: $filter) {
+						customerId
+						company
+					}
+				}
+			`)
+			.variables({
+				filter: {
+					company_null: false,
+					company_in: ['JetBrains s.r.o.'],
+				},
+			})
+			.expectNoErrors();
+
+		expect(data?.customers).toHaveLength(1);
+		expect(data?.customers?.[0]?.company).toBe('JetBrains s.r.o.');
+	});
+
+	test('should get all employees who dont have customers', async () => {
+		const { data } = await request<{ employees: any }>(config.baseUrl)
+			.query(gql`
+				query Employees($filter: EmployeesListFilter) {
+					employees(filter: $filter) {
+						employeeId
+						customers {
+							customerId
+						}
+					}
+				}
+			`)
+			.variables({
+				filter: {
+					customers: {
+						customerId_null: true,
+					},
+				},
+			})
+			.expectNoErrors();
+
+		expect(data?.employees).toHaveLength(5);
+		data?.employees.forEach((employee: any) => {
+			expect(employee.customers).toHaveLength(0);
+		});
+	});
+
+	test('Should get all employees who have at least one customer with a fax', async () => {
+		const { data } = await request<{ employees: any }>(config.baseUrl)
+			.query(gql`
+				query Employees($filter: EmployeesListFilter) {
+					employees(filter: $filter) {
+						employeeId
+						customers {
+							customerId
+							fax
+						}
+					}
+				}
+			`)
+			.variables({
+				filter: {
+					customers: {
+						fax_null: false,
+					},
+				},
+			})
+			.expectNoErrors();
+
+		expect(data?.employees).toHaveLength(3);
+		data?.employees.forEach((employee: any) => {
+			const hasFax = employee.customers.some((customer: any) => customer.fax !== null);
+			expect(hasFax).toBe(true);
+		});
 	});
 });

--- a/src/packages/mikroorm/src/provider/provider.ts
+++ b/src/packages/mikroorm/src/provider/provider.ts
@@ -43,6 +43,7 @@ type PostgresError = {
 
 const objectOperations = new Set(['_and', '_or', '_not']);
 const mikroObjectOperations = new Set(['$and', '$or', '$not']);
+const nullBooleanOperations = new Set(['null', 'notnull']);
 
 const appendPath = (path: string, newPath: string) =>
 	path.length ? `${path}.${newPath}` : newPath;
@@ -63,12 +64,21 @@ export const gqlToMikro: (filter: any) => any = (filter: any) => {
 				// Recurse over nested filters only (arrays are an argument to a filter, not a nested filter)
 				filter[key] = gqlToMikro(filter[key]);
 			} else if (key.indexOf('_') >= 0) {
-				// { firstName_in: ['k', 'b'] } => { firstName: { $in: ['k', 'b'] } }
 				const [newKey, operator] = key.split('_');
-				const newValue = { [`$${operator}`]: gqlToMikro(filter[key]) };
-
-				// They can construct multiple filters for the same key. In that case we need
-				// to append them all into an object.
+				let newValue;
+				if (nullBooleanOperations.has(operator) && typeof filter[key] === 'boolean') {
+					// { firstName_null: true } => { firstName: { $eq: null } } or { firstName_null: false } => { firstName: { $ne: null } }
+					// { firstName_notnull: true } => { firstName: { $ne: null } } or { firstName_notnull: false } => { firstName: { $eq: null } }
+					newValue =
+						(filter[key] && operator === 'null') || (!filter[key] && operator === 'notnull')
+							? { $eq: null }
+							: { $ne: null };
+				} else {
+					// { firstName_in: ['k', 'b'] } => { firstName: { $in: ['k', 'b'] } }
+					newValue = { [`$${operator}`]: gqlToMikro(filter[key]) };
+					// They can construct multiple filters for the same key. In that case we need
+					// to append them all into an object.
+				}
 				if (typeof filter[newKey] !== 'undefined') {
 					filter[newKey] = { ...filter[newKey], ...newValue };
 				} else {


### PR DESCRIPTION
Introduce support for null and notnull filters in the gqlToMikro function, allowing for more flexible querying of data based on nullability. Add corresponding tests to validate the new functionality.