### PR TITLE
`EXOGW-415` - gqlToMikro -> handle multiple operations on the same filter key

### DIFF
--- a/src/packages/end-to-end/src/__tests__/api/postgres/query/null-filter.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/postgres/query/null-filter.test.ts
@@ -85,8 +85,8 @@ describe('null filter', () => {
 			})
 			.expectNoErrors();
 
-		expect(data?.customers).toHaveLength(49);
-		expect(data?.customers?.[0]?.company).toBeNull();
+		expect(data?.customers).toHaveLength(1);
+		expect(data?.customers?.[0]?.company).toBe('JetBrains s.r.o.');
 	});
 
 	test('should filter by Customers with company_null = false AND company in [JetBrains s.r.o.]', async () => {

--- a/src/packages/end-to-end/src/__tests__/api/postgres/query/null-filter.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/postgres/query/null-filter.test.ts
@@ -67,28 +67,27 @@ describe('null filter', () => {
 		expect(data?.customers?.[0]?.company).toBeNull();
 	});
 
-	// Not working, but this bug is unrelated to the current PR about null filters
-	// test('should filter by Customers with company_null = false AND company = JetBrains s.r.o.', async () => {
-	// 	const { data } = await request<{ customers: any }>(config.baseUrl)
-	// 		.query(gql`
-	// 			query Customers($filter: CustomersListFilter) {
-	// 				customers(filter: $filter) {
-	// 					customerId
-	// 					company
-	// 				}
-	// 			}
-	// 		`)
-	// 		.variables({
-	// 			filter: {
-	// 				company_null: false,
-	// 				company: 'JetBrains s.r.o.',
-	// 			},
-	// 		})
-	// 		.expectNoErrors();
+	test('should filter by Customers with company_null = false AND company = JetBrains s.r.o.', async () => {
+		const { data } = await request<{ customers: any }>(config.baseUrl)
+			.query(gql`
+				query Customers($filter: CustomersListFilter) {
+					customers(filter: $filter) {
+						customerId
+						company
+					}
+				}
+			`)
+			.variables({
+				filter: {
+					company_null: false,
+					company: 'JetBrains s.r.o.',
+				},
+			})
+			.expectNoErrors();
 
-	// 	expect(data?.customers).toHaveLength(49);
-	// 	expect(data?.customers?.[0]?.company).toBeNull();
-	// });
+		expect(data?.customers).toHaveLength(49);
+		expect(data?.customers?.[0]?.company).toBeNull();
+	});
 
 	test('should filter by Customers with company_null = false AND company in [JetBrains s.r.o.]', async () => {
 		const { data } = await request<{ customers: any }>(config.baseUrl)

--- a/src/packages/mikroorm/package.json
+++ b/src/packages/mikroorm/package.json
@@ -10,8 +10,9 @@
 		"generate:schema": "tsx ./src/utils/generate-db-schema.ts",
 		"package:pack": "pnpm pack",
 		"prettier": "prettier --write src/**/*.ts",
-		"test": "tsx scripts/check-mikro-overrides-match-installed-versions.ts",
+		"test": "tsx scripts/check-mikro-overrides-match-installed-versions.ts && pnpm run:unit:tests",
 		"test-introspection": "tsx scripts/test-introspection.ts",
+		"run:unit:tests": "vitest",
 		"version": "npm version --no-git-tag-version"
 	},
 	"main": "lib/index.js",
@@ -51,7 +52,8 @@
 		"glob": "11.0.1",
 		"graphql": "16.10.0",
 		"tsx": "4.19.3",
-		"typescript": "5.7.2"
+		"typescript": "5.7.2",
+		"vitest": "2.1.9"
 	},
 	"optionalDependencies": {
 		"@mikro-orm/knex": "^6.4.7",

--- a/src/packages/mikroorm/src/provider/provider.test.ts
+++ b/src/packages/mikroorm/src/provider/provider.test.ts
@@ -1,23 +1,21 @@
 import { describe, it, expect } from 'vitest';
-
 import { gqlToMikro } from './provider';
 
-const filters = [
-	{
-		key: 'nested -> with numbers',
-		throws: false,
-		test: {
+describe('gqlToMikro', () => {
+	it('transforms filter: nested -> with numbers', () => {
+		const test = {
 			field1_gt: 1,
 			field1_lt: 2,
 			field1_in: [1, 2, 3],
 			nested: {
 				field1: 1,
+
 				field2_gte: 3,
 				field2_lte: 4,
 				field2_in: [1, 2, 3],
 			},
-		},
-		expectedResult: {
+		};
+		const expectedResult = {
 			field1: {
 				$gt: 1,
 				$lt: 2,
@@ -31,50 +29,50 @@ const filters = [
 					$in: [1, 2, 3],
 				},
 			},
-		},
-	},
-	{
-		key: 'numbers -> and null',
-		throws: false,
-		test: {
+		};
+		expect(gqlToMikro(test)).toEqual(expectedResult);
+	});
+
+	it('transforms filter: numbers -> and null', () => {
+		const test = {
 			field1_gt: 1,
 			field1_lt: 2,
 			field1_in: [1, 2, 3],
 			field1_null: false,
 			field1_notnull: true,
-		},
-		expectedResult: {
+		};
+		const expectedResult = {
 			field1: {
 				$gt: 1,
 				$lt: 2,
 				$in: [1, 2, 3],
 				$ne: null,
 			},
-		},
-	},
-	{
-		key: 'numbers -> in and eq',
-		throws: false,
-		test: {
+		};
+		expect(gqlToMikro(test)).toEqual(expectedResult);
+	});
+
+	it('transforms filter: numbers -> in and eq', () => {
+		const test = {
 			field1_in: [1, 2, 3],
 			field1: 4,
-		},
-		expectedResult: {
+		};
+		const expectedResult = {
 			field1: { $in: [1, 2, 3], $eq: 4 },
-		},
-	},
-	{
-		key: 'strings -> nested',
-		throws: false,
-		test: {
+		};
+		expect(gqlToMikro(test)).toEqual(expectedResult);
+	});
+
+	it('transforms filter: strings -> nested', () => {
+		const test = {
 			nested: {
 				field1: { id: 'uno' },
 				field2_gte: 'someValue',
 				field2_lte: 'someValue',
 				field2_nin: ['someValue'],
 			},
-		},
-		expectedResult: {
+		};
+		const expectedResult = {
 			nested: {
 				field1: { id: 'uno' },
 				field2: {
@@ -83,38 +81,35 @@ const filters = [
 					$nin: ['someValue'],
 				},
 			},
-		},
-	},
-	{
-		key: 'should throw error -> ambiguous property',
-		throws: true,
-		test: {
+		};
+		expect(gqlToMikro(test)).toEqual(expectedResult);
+	});
+
+	it('should throw error -> ambiguous property', () => {
+		const test = {
 			_and: [{ field1_in: [1, 2, 3], field1: 4, field1_null: true }, { field1_nin: [1, 2, 3] }],
-		},
-		expectedResult: 'Should error here because is ambiguous, is it 4 or null?',
-	},
-	{
-		key: 'should throw error -> ambiguous property - null then string',
-		throws: true,
-		test: { field1_null: true, field1: 'dos' },
-		expectedResult: 'Should error here because is ambiguous, is it dos or null?',
-	},
-	{
-		key: "should throw error -> ambiguous property - we don't support collapsing same values",
-		throws: true,
-		test: { field1_null: true, field1: null },
-		expectedResult: 'Should error here because is ambiguous, is it null or null?',
-	},
-	{
-		key: 'strings -> in and eq',
-		throws: false,
-		test: { field1_nin: ['one'], field1: 'two' },
-		expectedResult: { field1: { $nin: ['one'], $eq: 'two' } },
-	},
-	{
-		key: 'strings -> or and null',
-		throws: false,
-		test: {
+		};
+		expect(() => gqlToMikro(test)).toThrow();
+	});
+
+	it('should throw error -> ambiguous property - null then string', () => {
+		const test = { field1_null: true, field1: 'dos' };
+		expect(() => gqlToMikro(test)).toThrow();
+	});
+
+	it("should throw error -> ambiguous property - we don't support collapsing same values", () => {
+		const test = { field1_null: true, field1: null };
+		expect(() => gqlToMikro(test)).toThrow();
+	});
+
+	it('transforms filter: strings -> in and eq', () => {
+		const test = { field1_nin: ['one'], field1: 'two' };
+		const expectedResult = { field1: { $nin: ['one'], $eq: 'two' } };
+		expect(gqlToMikro(test)).toEqual(expectedResult);
+	});
+
+	it('transforms filter: strings -> or and null', () => {
+		const test = {
 			_or: [
 				{
 					user: {
@@ -127,8 +122,8 @@ const filters = [
 					},
 				},
 			],
-		},
-		expectedResult: {
+		};
+		const expectedResult = {
 			$or: [
 				{
 					user: {
@@ -141,12 +136,12 @@ const filters = [
 					},
 				},
 			],
-		},
-	},
-	{
-		key: 'complicated filter with nested properties, arrays, nulls, strings, and numbers',
-		throws: false,
-		test: {
+		};
+		expect(gqlToMikro(test)).toEqual(expectedResult);
+	});
+
+	it('transforms filter: complicated filter with nested properties, arrays, nulls, strings, and numbers', () => {
+		const test = {
 			field1_gt: 5,
 			field2_lt: 10,
 			field3_in: ['a', 'b', 'c'],
@@ -170,8 +165,8 @@ const filters = [
 					subsubfield2_gt: 7,
 				},
 			},
-		},
-		expectedResult: {
+		};
+		const expectedResult = {
 			field1: { $gt: 5 },
 			field2: { $lt: 10 },
 			field3: { $in: ['a', 'b', 'c'] },
@@ -195,18 +190,7 @@ const filters = [
 					subsubfield2: { $gt: 7 },
 				},
 			},
-		},
-	},
-];
-
-describe('gqlToMikro', () => {
-	filters.forEach(({ key, test, expectedResult, throws }) => {
-		it(key, () => {
-			if (throws) {
-				expect(() => gqlToMikro(test)).toThrow();
-			} else {
-				expect(gqlToMikro(test)).toEqual(expectedResult);
-			}
-		});
+		};
+		expect(gqlToMikro(test)).toEqual(expectedResult);
 	});
 });

--- a/src/packages/mikroorm/src/provider/provider.test.ts
+++ b/src/packages/mikroorm/src/provider/provider.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest';
+
+import { gqlToMikro } from './provider';
+
+const filters = [
+	{
+		key: 'nested -> with numbers',
+		throws: false,
+		test: {
+			field1_gt: 1,
+			field1_lt: 2,
+			field1_in: [1, 2, 3],
+			nested: {
+				field1: 1,
+				field2_gte: 3,
+				field2_lte: 4,
+				field2_in: [1, 2, 3],
+			},
+		},
+		expectedResult: {
+			field1: {
+				$gt: 1,
+				$lt: 2,
+				$in: [1, 2, 3],
+			},
+			nested: {
+				field1: 1,
+				field2: {
+					$gte: 3,
+					$lte: 4,
+					$in: [1, 2, 3],
+				},
+			},
+		},
+	},
+	{
+		key: 'numbers -> and null',
+		throws: false,
+		test: {
+			field1_gt: 1,
+			field1_lt: 2,
+			field1_in: [1, 2, 3],
+			field1_null: false,
+			field1_notnull: true,
+		},
+		expectedResult: {
+			field1: {
+				$gt: 1,
+				$lt: 2,
+				$in: [1, 2, 3],
+				$ne: null,
+			},
+		},
+	},
+	{
+		key: 'numbers -> in and eq',
+		throws: false,
+		test: {
+			field1_in: [1, 2, 3],
+			field1: 4,
+		},
+		expectedResult: {
+			field1: { $in: [1, 2, 3], $eq: 4 },
+		},
+	},
+	{
+		key: 'strings -> nested',
+		throws: false,
+		test: {
+			nested: {
+				field1: { id: 'uno' },
+				field2_gte: 'someValue',
+				field2_lte: 'someValue',
+				field2_nin: ['someValue'],
+			},
+		},
+		expectedResult: {
+			nested: {
+				field1: { id: 'uno' },
+				field2: {
+					$gte: 'someValue',
+					$lte: 'someValue',
+					$nin: ['someValue'],
+				},
+			},
+		},
+	},
+	{
+		key: 'should throw error -> ambiguous property',
+		throws: true,
+		test: {
+			_and: [{ field1_in: [1, 2, 3], field1: 4, field1_null: true }, { field1_nin: [1, 2, 3] }],
+		},
+		expectedResult: 'Should error here because is ambiguous, is it 4 or null?',
+	},
+	{
+		key: 'should throw error -> ambiguous property - null then string',
+		throws: true,
+		test: { field1_null: true, field1: 'dos' },
+		expectedResult: 'Should error here because is ambiguous, is it dos or null?',
+	},
+	{
+		key: "should throw error -> ambiguous property - we don't support collapsing same values",
+		throws: true,
+		test: { field1_null: true, field1: null },
+		expectedResult: 'Should error here because is ambiguous, is it null or null?',
+	},
+	{
+		key: 'strings -> in and eq',
+		throws: false,
+		test: { field1_nin: ['one'], field1: 'two' },
+		expectedResult: { field1: { $nin: ['one'], $eq: 'two' } },
+	},
+	{
+		key: 'strings -> or and null',
+		throws: false,
+		test: {
+			_or: [
+				{
+					user: {
+						id_null: true,
+					},
+				},
+				{
+					user: {
+						id: 'seis',
+					},
+				},
+			],
+		},
+		expectedResult: {
+			$or: [
+				{
+					user: {
+						id: { $eq: null },
+					},
+				},
+				{
+					user: {
+						id: 'seis',
+					},
+				},
+			],
+		},
+	},
+	{
+		key: 'complicated filter with nested properties, arrays, nulls, strings, and numbers',
+		throws: false,
+		test: {
+			field1_gt: 5,
+			field2_lt: 10,
+			field3_in: ['a', 'b', 'c'],
+			field4_null: true,
+			field5_notnull: true,
+			nested1: {
+				subfield1: 1,
+				subfield2_gte: 2,
+				subfield3_lte: 3,
+				subfield4_in: [4, 5, 6],
+				subnested: {
+					subsubfield1: 'value1',
+					subsubfield2_nin: ['value2', 'value3'],
+					subsubfield3_null: false,
+				},
+			},
+			nested2: {
+				subfield1: 'string1',
+				subfield2: {
+					subsubfield1: 'string2',
+					subsubfield2_gt: 7,
+				},
+			},
+		},
+		expectedResult: {
+			field1: { $gt: 5 },
+			field2: { $lt: 10 },
+			field3: { $in: ['a', 'b', 'c'] },
+			field4: { $eq: null },
+			field5: { $ne: null },
+			nested1: {
+				subfield1: 1,
+				subfield2: { $gte: 2 },
+				subfield3: { $lte: 3 },
+				subfield4: { $in: [4, 5, 6] },
+				subnested: {
+					subsubfield1: 'value1',
+					subsubfield2: { $nin: ['value2', 'value3'] },
+					subsubfield3: { $ne: null },
+				},
+			},
+			nested2: {
+				subfield1: 'string1',
+				subfield2: {
+					subsubfield1: 'string2',
+					subsubfield2: { $gt: 7 },
+				},
+			},
+		},
+	},
+];
+
+describe('gqlToMikro', () => {
+	filters.forEach(({ key, test, expectedResult, throws }) => {
+		it(key, () => {
+			if (throws) {
+				expect(() => gqlToMikro(test)).toThrow();
+			} else {
+				expect(gqlToMikro(test)).toEqual(expectedResult);
+			}
+		});
+	});
+});

--- a/src/packages/mikroorm/src/provider/provider.ts
+++ b/src/packages/mikroorm/src/provider/provider.ts
@@ -48,7 +48,7 @@ const nullBooleanOperations = new Set(['null', 'notnull']);
 const appendPath = (path: string, newPath: string) =>
 	path.length ? `${path}.${newPath}` : newPath;
 
-export const gqlToMikro: (filter: any) => any = (filter: any) => {
+export const gqlToMikro = (filter: any): any => {
 	if (Array.isArray(filter)) {
 		return filter.map((element) => gqlToMikro(element));
 	} else if (typeof filter === 'object') {
@@ -79,8 +79,25 @@ export const gqlToMikro: (filter: any) => any = (filter: any) => {
 					// They can construct multiple filters for the same key. In that case we need
 					// to append them all into an object.
 				}
+
 				if (typeof filter[newKey] !== 'undefined') {
-					filter[newKey] = { ...filter[newKey], ...newValue };
+					if (typeof filter[newKey] !== 'object') {
+						if (typeof newValue === 'object' && '$eq' in newValue) {
+							throw new Error(
+								`property ${newKey} on filter is ambiguous. There are two values for this property: ${filter[newKey]} and ${newValue.$eq}`
+							);
+						}
+						filter[newKey] = { ...{ $eq: filter[newKey] }, ...newValue };
+					} else {
+						if (newValue && typeof newValue === 'object' && '$eq' in newValue) {
+							throw new Error(
+								`property ${newKey} on filter is ambiguous. There are two values for this property: ${JSON.stringify(
+									filter[newKey]
+								)} and ${JSON.stringify(newValue)}`
+							);
+						}
+						filter[newKey] = { ...filter[newKey], ...newValue };
+					}
 				} else {
 					filter[newKey] = newValue;
 				}

--- a/src/packages/mikroorm/vitest.config.ts
+++ b/src/packages/mikroorm/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+	},
+});

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -1558,6 +1558,9 @@ importers:
       typescript:
         specifier: 5.7.2
         version: 5.7.2
+      vitest:
+        specifier: 2.1.9
+        version: 2.1.9(@types/node@22.10.1)(lightningcss@1.29.1)
 
   packages/rest:
     dependencies:


### PR DESCRIPTION
https://exogee.atlassian.net/browse/EXOGW-415

Before this change we were getting

```
{
  "0": "t",
  "1": "e",
  "2": "s",
  "3": "t",
  $nin: [
    "not here",
  ],
}
```

when sending a filter like:
```
users(filter:  {
     notes_nin: ["not here"],
     notes: "test"
  }) {
    id
  }
```

Now we handle this situation and some others as well.
Unit tests were also added highlighting some of the scenarios now handled properly