### PR TITLE
`EXOGW-419` and `EXOGW-416`

### DIFF
--- a/src/examples/rest-with-auth/src/backend/database.ts
+++ b/src/examples/rest-with-auth/src/backend/database.ts
@@ -15,5 +15,6 @@ export const myConnection = {
 		user: process.env.DATABASE_USERNAME,
 		password: process.env.DATABASE_PASSWORD,
 		port: 3306,
+		debug: true,
 	},
 };

--- a/src/examples/rest-with-auth/src/backend/database.ts
+++ b/src/examples/rest-with-auth/src/backend/database.ts
@@ -15,6 +15,5 @@ export const myConnection = {
 		user: process.env.DATABASE_USERNAME,
 		password: process.env.DATABASE_PASSWORD,
 		port: 3306,
-		debug: true,
 	},
 };

--- a/src/packages/core/src/base-loader.ts
+++ b/src/packages/core/src/base-loader.ts
@@ -50,7 +50,8 @@ const getBaseLoadOneLoader = <G = unknown, D = unknown>({
 	filter?: Filter<G>;
 }) => {
 	const gqlTypeName = getGqlEntityName(gqlEntityType);
-	if (!keyStore[gqlTypeName]) {
+	const loaderKey = `${gqlTypeName}-${JSON.stringify(filter)}`;
+	if (!keyStore[loaderKey]) {
 		const entity = graphweaverMetadata.getEntityByName<G, D>(gqlTypeName);
 		if (!entity?.provider) {
 			throw new Error(`Unable to locate provider for type '${gqlTypeName}'`);
@@ -114,12 +115,12 @@ const getBaseLoadOneLoader = <G = unknown, D = unknown>({
 			return keys.map((key) => lookup[key]);
 		};
 
-		keyStore[gqlTypeName] = new DataLoader(fetchRecordsById, {
+		keyStore[loaderKey] = new DataLoader(fetchRecordsById, {
 			maxBatchSize: entity.provider.maxDataLoaderBatchSize,
 		});
 	}
 
-	return keyStore[gqlTypeName] as DataLoader<string, D>;
+	return keyStore[loaderKey] as DataLoader<string, D>;
 };
 
 export const getBaseRelatedIdLoader = <G = unknown, D = unknown>({

--- a/src/packages/core/src/metadata-service/resolver.utils.ts
+++ b/src/packages/core/src/metadata-service/resolver.utils.ts
@@ -1,0 +1,220 @@
+import { BaseContext } from '@apollo/server';
+import { dataEntityForGraphQLEntity } from '../default-from-backend-entity';
+import { Filter, ReadHookParams, ResolverOptions, TraceOptions } from '../types';
+import { EntityMetadata, MetadataType } from '../metadata';
+import { isScalarType } from 'graphql';
+import { getFieldType } from '../schema-builder';
+import { logger } from '@exogee/logger';
+import { BaseLoaders } from '../base-loader';
+import { isDefined } from '../utils';
+
+export type ID = string | number | bigint;
+
+/**
+ * Retrieves the ID value from the source data.
+ * If the id is a function then it calls it to get the ID value.
+ * If the id is a string then it tries to get the value from the source data.
+ */
+export const getIdValue = <G, D, R, C extends BaseContext>(
+	id: string | bigint | ((dataEntity: unknown) => string | number | bigint | undefined) | undefined,
+	source: G
+) => {
+	let idValue: ID | ID[] | undefined = undefined;
+	if (id && typeof id === 'function') {
+		// If the id is a function, we'll call it with the source data to get the id value.
+		idValue = id(dataEntityForGraphQLEntity<G, D>(source as any));
+	} else if (id) {
+		// else if the id is a string, we'll try to get the value from the source data.
+		const valueOfForeignKey = dataEntityForGraphQLEntity<G, D>(source as any)?.[id as keyof D];
+
+		// If the value is a string or number, we'll use it as the id value.
+		if (
+			typeof valueOfForeignKey === 'string' ||
+			typeof valueOfForeignKey === 'number' ||
+			typeof valueOfForeignKey === 'bigint' ||
+			Array.isArray(valueOfForeignKey)
+		) {
+			idValue = valueOfForeignKey;
+		} else if (!isDefined(valueOfForeignKey)) {
+			// If the value is null, we'll use it as the id value.
+			idValue = undefined;
+		} else {
+			// The ID value must be a string or a number otherwise we'll throw an error.
+			throw new Error(
+				'Could not determine ID value for relationship field. Only strings, numbers or arrays of strings or numbers are supported.'
+			);
+		}
+	}
+
+	return idValue;
+};
+
+interface ConstructFilterForRelatedEntityParams<G, D, R, C extends BaseContext> {
+	resolverOptions: ResolverOptions<{ filter: Filter<R> }, C, G>;
+	idValue: ID | ID[] | undefined;
+	relatedPrimaryKeyField: string;
+	relatedField: string | undefined;
+	relatedEntityMetadata: EntityMetadata;
+	sourcePrimaryKeyField: keyof G;
+}
+
+/**
+ * For this entity we may get a filter, this is the filter passed by the client for this entity,
+ * we then get this filter and _and it with the filter for the relationship.
+ * Both the resulting filter and the relationship filter are returned so that later we can remove the relationship filter from the filter.
+ */
+export const constructFilterForRelatedEntity = <G, D, R, C extends BaseContext>(
+	params: ConstructFilterForRelatedEntityParams<G, D, R, C>
+) => {
+	const {
+		resolverOptions: {
+			source,
+			args: { filter },
+		},
+		idValue,
+		relatedPrimaryKeyField,
+		relatedField,
+		relatedEntityMetadata,
+		sourcePrimaryKeyField,
+	} = params;
+	const _and: Filter<R>[] = [];
+
+	// If we have a user supplied filter, add it to the _and array.
+	if (filter) _and.push(filter);
+
+	// Lets check the relationship type and add the appropriate filter.
+	let relationshipFilterChunk: Filter<R> | undefined = undefined;
+
+	if (idValue) {
+		if (Array.isArray(idValue)) {
+			relationshipFilterChunk = { [`${relatedPrimaryKeyField}_in`]: idValue } as Filter<R>;
+		} else {
+			relationshipFilterChunk = { [relatedPrimaryKeyField]: idValue } as Filter<R>;
+		}
+	} else if (
+		relatedField &&
+		isScalarType(getFieldType(relatedEntityMetadata.fields[relatedField]))
+	) {
+		// Scalars should get a simple filter, e.g. if we have Tasks in a DB which have a userId field, and we
+		// have Users in a REST API with their PK called 'key', instead of trying to filter like:
+		// { userId: { key: '1' } }
+		// we should instead filter like:
+		// { userId: '1' }
+		// because the database provider doesn't understand the shape of the user object at all.
+		relationshipFilterChunk = {
+			[relatedField]: source[sourcePrimaryKeyField],
+		} as unknown as Filter<R>;
+	} else if (relatedField) {
+		// While object filters should nest as not all providers understand what { user: '1' } means. It's more
+		// clear to give them { user: { key: '1' } }.
+		relationshipFilterChunk = {
+			[relatedField]: { [sourcePrimaryKeyField]: source[sourcePrimaryKeyField] },
+		} as Filter<R>;
+	} else {
+		throw new Error(
+			'Did not determine how to filter the relationship. Either id or relatedField is required.'
+		);
+	}
+
+	if (relationshipFilterChunk) _and.push(relationshipFilterChunk);
+
+	const relatedEntityFilter = { _and } as Filter<R>;
+
+	return { relatedEntityFilter, relationshipFilterChunk };
+};
+
+/**
+ * To load the entities in bulk, we need a filter that doesn't contain the relationship filter.
+ * This function will remove the relationship filter from the filter.
+ */
+export const getLoaderFilter = <R>(
+	hookParams: ReadHookParams<R, object>,
+	relationshipFilterChunk: Filter<R>
+) => {
+	let relationshipFilterChunkFound = !relationshipFilterChunk;
+	/**
+	 * Look for `relationshipFilterChunk` and remove it from the filter.
+	 * This is necessary because we are batch loading data and that relationshipFilterChunk makes the filter different for each record, which ends up triggering a SQL query for each record (not batching at all).
+	 * What we want to achieve is having a filter with ACLs into it, but without the relationship chunk.
+	 */
+	const removeRelationshipFilterChunk = (
+		filter: Filter<R> | undefined,
+		relationshipFilterChunk: Filter<R>
+	): Filter<R> | undefined => {
+		if (!filter?._and) return filter;
+		return {
+			_and: filter._and.map((item) => {
+				if (item === relationshipFilterChunk) {
+					relationshipFilterChunkFound = true;
+					return undefined;
+				}
+				if (item._and) {
+					// nested _and, we need to look here too
+					return removeRelationshipFilterChunk(item, relationshipFilterChunk);
+				}
+				return item;
+			}),
+		} as Filter<R>;
+	};
+
+	const loaderFilter = removeRelationshipFilterChunk(
+		hookParams.args?.filter,
+		relationshipFilterChunk
+	);
+
+	if (!relationshipFilterChunkFound) {
+		// If we are getting this error, make sure `removeRelationshipFilterChunk` is working as expected.
+		throw new Error(
+			'No relationship filter found in hook params. This usually means a hook has deep cloned the filter. Please add to the object instead of cloning it if possible. If this limitation is problematic open a GitHub issue so we can understand your use case better.'
+		);
+	}
+
+	return loaderFilter;
+};
+
+interface GetDataEntitiesParams<G, D, R, C extends BaseContext> {
+	source: G;
+	idValue: ID | ID[] | undefined;
+	field: EntityMetadata['fields'][string];
+	sourcePrimaryKeyField: keyof G;
+	loaderFilter: Filter<R> | undefined;
+	gqlEntityType: { new (...args: any[]): R };
+}
+
+/**
+ * Fetches the data entities for the given field.
+ * If the field has a relatedField, it will use the relatedField to load the data entities.
+ * If the field has an id, it will use the id to load the data entities.
+ */
+export const getDataEntities = async <G, D, R, C extends BaseContext>(
+	params: GetDataEntitiesParams<G, D, R, C>
+) => {
+	const { source, idValue, field, gqlEntityType, sourcePrimaryKeyField, loaderFilter } = params;
+	let dataEntities: D[] | undefined = undefined;
+	if (field.relationshipInfo?.relatedField) {
+		logger.trace('Loading with loadByRelatedId');
+
+		// This should be typed as <gqlEntityType, relatedEntityType>
+		dataEntities = await BaseLoaders.loadByRelatedId<R, D>({
+			gqlEntityType,
+			relatedField: field.relationshipInfo.relatedField as keyof D & string,
+			id: String(source[sourcePrimaryKeyField]),
+			filter: loaderFilter,
+		});
+	} else if (idValue) {
+		logger.trace('Loading with loadOne');
+
+		const idsToLoad = Array.isArray(idValue) ? idValue : [idValue];
+		dataEntities = await Promise.all(
+			idsToLoad.map((id) =>
+				BaseLoaders.loadOne<R, D>({
+					gqlEntityType,
+					id: String(id),
+					filter: loaderFilter,
+				})
+			)
+		);
+	}
+
+	return dataEntities;
+};

--- a/src/packages/core/src/metadata-service/resolver.utils.ts
+++ b/src/packages/core/src/metadata-service/resolver.utils.ts
@@ -136,6 +136,7 @@ export const getLoaderFilter = <R>(
 	 * Look for `relationshipFilterChunk` and remove it from the filter.
 	 * This is necessary because we are batch loading data and that relationshipFilterChunk makes the filter different for each record, which ends up triggering a SQL query for each record (not batching at all).
 	 * What we want to achieve is having a filter with ACLs into it, but without the relationship chunk.
+	 * Note that the relationship chunk is _and-ed with the user supplied filter.
 	 */
 	const removeRelationshipFilterChunk = (
 		filter: Filter<R> | undefined,
@@ -143,6 +144,7 @@ export const getLoaderFilter = <R>(
 	): Filter<R> | undefined => {
 		if (!filter?._and) return filter;
 		return {
+			// We only need to look at the _and because `constructFilterForRelatedEntity` _ands the relationship filter with the user supplied filter. User supplied filter is untouched.
 			_and: filter._and.map((item) => {
 				if (item === relationshipFilterChunk) {
 					relationshipFilterChunkFound = true;

--- a/src/packages/core/src/resolvers.ts
+++ b/src/packages/core/src/resolvers.ts
@@ -661,6 +661,17 @@ const _listRelationshipField = async <G, D, R, C extends BaseContext>(
 		? await hookManager.runHooks(HookRegister.BEFORE_READ, params)
 		: params;
 
+	const testParams: ReadHookParams<R> = {
+		args: { filter },
+		context,
+		fields,
+		transactional: !!entity.provider?.withTransaction,
+	};
+
+	const testHookParams = hookManager
+		? await hookManager.runHooks(HookRegister.BEFORE_READ, testParams)
+		: testParams;
+
 	const transformedFilter =
 		hookParams.args?.filter &&
 		isTransformableGraphQLEntityClass(entity.target) &&
@@ -702,7 +713,9 @@ const _listRelationshipField = async <G, D, R, C extends BaseContext>(
 			gqlEntityType,
 			relatedField: field.relationshipInfo.relatedField as keyof D & string,
 			id: String(source[sourcePrimaryKeyField]),
-			filter: transformedFilter,
+			// filter: transformedFilter,
+			// filter,
+			filter: testHookParams.args?.filter,
 		});
 	} else if (idValue) {
 		logger.trace('Loading with loadOne');
@@ -712,7 +725,9 @@ const _listRelationshipField = async <G, D, R, C extends BaseContext>(
 				BaseLoaders.loadOne<R, D>({
 					gqlEntityType,
 					id: String(id),
-					filter: transformedFilter,
+					// filter: transformedFilter,
+					// filter,
+					filter: testHookParams.args?.filter,
 				})
 			)
 		);

--- a/src/packages/core/src/resolvers.ts
+++ b/src/packages/core/src/resolvers.ts
@@ -661,24 +661,6 @@ const _listRelationshipField = async <G, D, R, C extends BaseContext>(
 		? await hookManager.runHooks(HookRegister.BEFORE_READ, params)
 		: params;
 
-	const testParams: ReadHookParams<R> = {
-		args: { filter },
-		context,
-		fields,
-		transactional: !!entity.provider?.withTransaction,
-	};
-
-	const testHookParams = hookManager
-		? await hookManager.runHooks(HookRegister.BEFORE_READ, testParams)
-		: testParams;
-
-	// const transformedFilter =
-	// 	hookParams.args?.filter &&
-	// 	isTransformableGraphQLEntityClass(entity.target) &&
-	// 	entity.target.toBackendEntityFilter
-	// 		? entity.target.toBackendEntityFilter(hookParams.args?.filter)
-	// 		: (hookParams.args?.filter as Filter<D> | undefined);
-
 	// Ok, now we've run our hooks and validated permissions, let's first check if we already have the data.
 	logger.trace('Checking for existing data.');
 
@@ -713,9 +695,7 @@ const _listRelationshipField = async <G, D, R, C extends BaseContext>(
 			gqlEntityType,
 			relatedField: field.relationshipInfo.relatedField as keyof D & string,
 			id: String(source[sourcePrimaryKeyField]),
-			// filter: transformedFilter,
-			// filter,
-			filter: testHookParams.args?.filter,
+			filter: hookParams.args?.filter,
 		});
 	} else if (idValue) {
 		logger.trace('Loading with loadOne');
@@ -725,9 +705,7 @@ const _listRelationshipField = async <G, D, R, C extends BaseContext>(
 				BaseLoaders.loadOne<R, D>({
 					gqlEntityType,
 					id: String(id),
-					// filter: transformedFilter,
-					// filter,
-					filter: testHookParams.args?.filter,
+					filter: hookParams.args?.filter,
 				})
 			)
 		);

--- a/src/packages/core/src/resolvers.ts
+++ b/src/packages/core/src/resolvers.ts
@@ -672,12 +672,12 @@ const _listRelationshipField = async <G, D, R, C extends BaseContext>(
 		? await hookManager.runHooks(HookRegister.BEFORE_READ, testParams)
 		: testParams;
 
-	const transformedFilter =
-		hookParams.args?.filter &&
-		isTransformableGraphQLEntityClass(entity.target) &&
-		entity.target.toBackendEntityFilter
-			? entity.target.toBackendEntityFilter(hookParams.args?.filter)
-			: (hookParams.args?.filter as Filter<D> | undefined);
+	// const transformedFilter =
+	// 	hookParams.args?.filter &&
+	// 	isTransformableGraphQLEntityClass(entity.target) &&
+	// 	entity.target.toBackendEntityFilter
+	// 		? entity.target.toBackendEntityFilter(hookParams.args?.filter)
+	// 		: (hookParams.args?.filter as Filter<D> | undefined);
 
 	// Ok, now we've run our hooks and validated permissions, let's first check if we already have the data.
 	logger.trace('Checking for existing data.');

--- a/src/packages/core/src/resolvers.ts
+++ b/src/packages/core/src/resolvers.ts
@@ -1,4 +1,4 @@
-import { GraphQLResolveInfo, Source, isListType, isObjectType, isScalarType } from 'graphql';
+import { GraphQLResolveInfo, Source, isListType, isObjectType } from 'graphql';
 import { logger } from '@exogee/logger';
 import { ResolveTree, parseResolveInfo } from 'graphql-parse-resolve-info';
 
@@ -6,7 +6,6 @@ import { BaseContext, TraceOptions } from './types';
 import {
 	AggregationResult,
 	AggregationType,
-	BaseLoaders,
 	CreateOrUpdateHookParams,
 	DeleteHookParams,
 	DeleteManyHookParams,
@@ -19,7 +18,6 @@ import {
 	Resolver,
 	ResolverOptions,
 	createOrUpdateEntities,
-	getFieldType,
 	getFieldTypeWithMetadata,
 	graphweaverMetadata,
 	hookManagerMap,
@@ -560,7 +558,7 @@ const _listRelationshipField = async <G, D, R, C extends BaseContext>(
 	if (!info.path.typename)
 		throw new Error(`No typename found in path for ${info.path}, this should not happen.`);
 
-	const entity = graphweaverMetadata.getEntityByName(info.path.typename);
+	const entity = graphweaverMetadata.getEntityByName<G, D>(info.path.typename);
 	if (!entity) {
 		throw new Error(`Entity ${info.path.typename} not found in metadata. This should not happen.`);
 	}
@@ -571,7 +569,7 @@ const _listRelationshipField = async <G, D, R, C extends BaseContext>(
 	const field = entity.fields[info.fieldName];
 	const { id, relatedField } = field.relationshipInfo ?? {};
 
-	const idValue = getIdValue(id, source);
+	const idValue = getIdValue<G, D>(id, source);
 
 	if (existingData === undefined && !isDefined(idValue) && !relatedField) {
 		// id is null and we are loading a single instance so let's return null
@@ -637,7 +635,7 @@ const _listRelationshipField = async <G, D, R, C extends BaseContext>(
 
 	const loaderFilter = getLoaderFilter(hookParams, relationshipFilterChunk);
 
-	const dataEntities = await getDataEntities({
+	const dataEntities = await getDataEntities<G, D, R>({
 		source,
 		idValue,
 		field,

--- a/src/packages/core/src/utils/common.ts
+++ b/src/packages/core/src/utils/common.ts
@@ -1,0 +1,2 @@
+export const isDefined = <T>(value: T | undefined | null): value is T =>
+	value !== undefined && value !== null;

--- a/src/packages/core/src/utils/index.ts
+++ b/src/packages/core/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './apply-default-values';
 export * from './has-id';
 export * from './plural';
 export * from './with-transaction';
+export * from './common';

--- a/src/packages/end-to-end/src/__tests__/api/auth/acl/EXOGW-416.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/auth/acl/EXOGW-416.test.ts
@@ -1,0 +1,268 @@
+process.env.PASSWORD_AUTH_REDIRECT_URI = '*';
+process.env.DATABASE = 'sqlite';
+
+import gql from 'graphql-tag';
+import assert from 'assert';
+import Graphweaver from '@exogee/graphweaver-server';
+import {
+	Entity as DataEntity,
+	Collection,
+	PrimaryKey,
+	ManyToMany,
+	Property,
+} from '@mikro-orm/core';
+import { Field, ID, Entity, RelationshipField, BaseDataProvider } from '@exogee/graphweaver';
+import { ConnectionManager, MikroBackendProvider } from '@exogee/graphweaver-mikroorm';
+import { EntityManager, SqliteDriver } from '@mikro-orm/sqlite';
+import {
+	ApplyAccessControlList,
+	CredentialStorage,
+	hashPassword,
+	Password,
+	setAddUserToContext,
+	UserProfile,
+} from '@exogee/graphweaver-auth';
+
+@DataEntity({ tableName: 'Tag' })
+export class OrmTag {
+	@PrimaryKey({ type: 'string' })
+	id!: string;
+
+	@ManyToMany(() => OrmTask, (task) => task.tags)
+	tasks = new Collection<OrmTask>(this);
+
+	constructor(id?: string) {
+		if (id) {
+			this.id = id;
+		}
+	}
+}
+
+@DataEntity({ tableName: 'Task' })
+export class OrmTask {
+	@PrimaryKey({ type: 'string' })
+	id!: string;
+
+	@Property({ type: 'string' })
+	userId!: string;
+
+	@ManyToMany(() => OrmTag, (tag) => tag.tasks, { owner: true })
+	tags: Collection<OrmTask> = new Collection<OrmTask>(this);
+
+	constructor(id?: string, userId?: string) {
+		if (id) {
+			this.id = id;
+		}
+		if (userId) {
+			this.userId = userId;
+		}
+	}
+}
+
+const connection = {
+	connectionManagerId: 'sqlite',
+	mikroOrmConfig: {
+		entities: [OrmTag, OrmTask],
+		driver: SqliteDriver,
+		dbName: 'databases/database.sqlite',
+	},
+};
+
+@ApplyAccessControlList({
+	Everyone: { all: (context) => ({ userId: context.user?.id }) },
+})
+@Entity('Task', {
+	provider: new MikroBackendProvider(OrmTask, connection),
+})
+export class Task {
+	@Field(() => ID)
+	id!: string;
+
+	@Field(() => String)
+	userId!: string;
+
+	@RelationshipField<Tag>(() => [Tag], { relatedField: 'tasks' })
+	tags!: Tag[];
+}
+
+@ApplyAccessControlList({
+	Everyone: { all: true },
+})
+@Entity('Tag', {
+	provider: new MikroBackendProvider(OrmTag, connection),
+})
+export class Tag {
+	@Field(() => ID)
+	id!: string;
+
+	@RelationshipField<Task>(() => [Task], { relatedField: 'tags', nullable: true })
+	tasks?: Task[];
+}
+
+const user = new UserProfile({
+	id: '1',
+	displayName: 'Test User',
+	roles: ['not an admin'],
+});
+
+const cred: CredentialStorage = {
+	id: '1',
+	username: 'test',
+	password: 'test123',
+};
+
+class PasswordBackendProvider extends BaseDataProvider<CredentialStorage> {
+	async findOne() {
+		cred.password = await hashPassword(cred.password ?? '');
+		return cred;
+	}
+}
+
+export const password = new Password({
+	provider: new PasswordBackendProvider('password'),
+	getUserProfile: async () => user,
+});
+
+setAddUserToContext(async () => user);
+
+const graphweaver = new Graphweaver();
+
+let token: string | undefined;
+let em: EntityManager | undefined = undefined;
+
+describe.only('Nested entity queries should not bypass row-level security', () => {
+	beforeAll(async () => {
+		const connectionResult = await ConnectionManager.connect('sqlite', connection);
+		em = connectionResult?.em;
+		assert(em !== undefined);
+
+		// If tables exists then fail, we are assuming that the tables do not exist
+		const tables = await em
+			?.getConnection()
+			.execute('SELECT name FROM sqlite_master WHERE type="table"');
+		const tableNames = tables.map((table: any) => table.name);
+
+		if (
+			tableNames.includes('Task') ||
+			tableNames.includes('Tag') ||
+			tableNames.includes('task_tags')
+		) {
+			throw new Error(
+				'Tables already exist, this test suit assumes that the tables do not exist, the suit throws away the tables at the end of the test'
+			);
+		}
+
+		// create the task, tag, and task_tags tables
+		await em
+			.getConnection()
+			.execute(
+				'CREATE TABLE `Task` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, PRIMARY KEY (`id`))'
+			);
+		await em.getConnection().execute('CREATE TABLE `Tag` (`id` TEXT NOT NULL, PRIMARY KEY (`id`))');
+		await em
+			.getConnection()
+			.execute(
+				'CREATE TABLE `task_tags` (`orm_task_id` TEXT NOT NULL, `orm_tag_id` TEXT NOT NULL, PRIMARY KEY (`orm_task_id`, `orm_tag_id`))'
+			);
+
+		const loginResponse = await graphweaver.executeOperation<{
+			loginPassword: { authToken: string };
+		}>({
+			query: gql`
+				mutation loginPassword($username: String!, $password: String!) {
+					loginPassword(username: $username, password: $password) {
+						authToken
+					}
+				}
+			`,
+			variables: {
+				username: 'test',
+				password: 'test123',
+			},
+		});
+
+		assert(loginResponse.body.kind === 'single');
+		expect(loginResponse.body.singleResult.errors).toBeUndefined();
+
+		token = loginResponse.body.singleResult.data?.loginPassword?.authToken;
+		expect(token).toContain('Bearer ');
+	});
+
+	afterAll(async () => {
+		// delete the task, tag, and task_tags tables
+		await em?.getConnection().execute('DROP `Task`');
+		await em?.getConnection().execute('DROP `Tag`');
+		await em?.getConnection().execute('DROP `task_tags`');
+
+		await em?.getConnection().close();
+	});
+
+	test.only('Should only return tasks that the user has access to when asking for tags', async () => {
+		// create 3 tasks for our user and another 3 for a different user
+		const task1ForAuthenticatedUser = new OrmTask('task1ForAuthenticatedUser', user.id);
+		const task2ForAuthenticatedUser = new OrmTask('task2ForAuthenticatedUser', user.id);
+		const task3ForAuthenticatedUser = new OrmTask('task3ForAuthenticatedUser', user.id);
+		const task1ForOtherUser = new OrmTask('task1ForOtherUser', 'another user');
+		const task2ForOtherUser = new OrmTask('task2ForOtherUser', 'another user');
+		const task3ForOtherUser = new OrmTask('task3ForOtherUser', 'another user');
+
+		// create 3 tags, 1 with a mix of tasks from both users, 1 with tasks from the authenticated user, and 1 with tasks from the other user
+		const mixTag = new OrmTag('mixTag');
+		mixTag.tasks.add(task1ForAuthenticatedUser);
+		mixTag.tasks.add(task2ForOtherUser);
+		const tagForAuthenticatedUser = new OrmTag('tagForAuthenticatedUser');
+		tagForAuthenticatedUser.tasks.add(task1ForAuthenticatedUser);
+		tagForAuthenticatedUser.tasks.add(task2ForAuthenticatedUser);
+		tagForAuthenticatedUser.tasks.add(task3ForAuthenticatedUser);
+		const tagForOtherUser = new OrmTag('tagForOtherUser');
+		tagForOtherUser.tasks.add(task1ForOtherUser);
+		tagForOtherUser.tasks.add(task2ForOtherUser);
+		tagForOtherUser.tasks.add(task3ForOtherUser);
+
+		await em?.persistAndFlush([
+			task1ForAuthenticatedUser,
+			task2ForAuthenticatedUser,
+			task3ForAuthenticatedUser,
+			task1ForOtherUser,
+			task2ForOtherUser,
+			task3ForOtherUser,
+			mixTag,
+			tagForAuthenticatedUser,
+			tagForOtherUser,
+		]);
+
+		const response = await graphweaver.executeOperation({
+			http: { headers: new Headers({ authorization: token ?? '' }) } as any,
+			query: gql`
+				query {
+					tags {
+						id
+						tasks {
+							id
+						}
+					}
+				}
+			`,
+		});
+
+		assert(response.body.kind === 'single');
+		expect(response.body.singleResult.errors?.[0]?.message).toBeUndefined();
+
+		// there should be a tag with id mixTag that has ONE task with id task1ForAuthenticatedUser. The other tasks should not be returned
+		// there should also be a tag with id tagForAuthenticatedUser that has THREE tasks with ids task1ForAuthenticatedUser, task2ForAuthenticatedUser, and task3ForAuthenticatedUser
+		// there should be a tag with id tagForOtherUser and no tasks
+		expect(response.body.singleResult.data?.tags).toHaveLength(3);
+		expect(response.body.singleResult.data?.tags).toContainEqual({
+			id: 'mixTag',
+			tasks: [{ id: 'task1ForAuthenticatedUser' }],
+		});
+		expect(response.body.singleResult.data?.tags).toContainEqual({
+			id: 'tagForAuthenticatedUser',
+			tasks: [
+				{ id: 'task1ForAuthenticatedUser' },
+				{ id: 'task2ForAuthenticatedUser' },
+				{ id: 'task3ForAuthenticatedUser' },
+			],
+		});
+	});
+});

--- a/src/packages/end-to-end/src/__tests__/api/auth/acl/EXOGW-416.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/auth/acl/EXOGW-416.test.ts
@@ -138,7 +138,7 @@ describe('Nested entity queries should not bypass row-level security', () => {
 		em = connectionResult?.em;
 		assert(em !== undefined);
 
-		// If tables exists then fail, we are assuming that the tables do not exist
+		// If tables exist then fail, we are assuming that the tables do not exist
 		const tables = await em
 			?.getConnection()
 			.execute('SELECT name FROM sqlite_master WHERE type="table"');
@@ -150,7 +150,7 @@ describe('Nested entity queries should not bypass row-level security', () => {
 			tableNames.includes('task_tags')
 		) {
 			throw new Error(
-				'Tables already exist, this test suit assumes that the tables do not exist, the suit throws away the tables at the end of the test'
+				'Tables already exist, this test suite assumes that the tables do not exist. The suite throws away the tables at the end of the test'
 			);
 		}
 
@@ -222,7 +222,7 @@ describe('Nested entity queries should not bypass row-level security', () => {
 		tagForOtherUser.tasks.add(task2ForOtherUser);
 		tagForOtherUser.tasks.add(task3ForOtherUser);
 
-		await em?.persistAndFlush([
+		await em!.persistAndFlush([
 			task1ForAuthenticatedUser,
 			task2ForAuthenticatedUser,
 			task3ForAuthenticatedUser,

--- a/src/packages/end-to-end/src/__tests__/api/auth/acl/EXOGW-416.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/auth/acl/EXOGW-416.test.ts
@@ -190,9 +190,9 @@ describe.only('Nested entity queries should not bypass row-level security', () =
 
 	afterAll(async () => {
 		// delete the task, tag, and task_tags tables
-		await em?.getConnection().execute('DROP `Task`');
-		await em?.getConnection().execute('DROP `Tag`');
-		await em?.getConnection().execute('DROP `task_tags`');
+		await em?.getConnection().execute('DROP TABLE `Task`');
+		await em?.getConnection().execute('DROP TABLE `Tag`');
+		await em?.getConnection().execute('DROP TABLE `task_tags`');
 
 		await em?.getConnection().close();
 	});

--- a/src/packages/end-to-end/src/__tests__/api/auth/acl/EXOGW-416.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/auth/acl/EXOGW-416.test.ts
@@ -132,7 +132,7 @@ const graphweaver = new Graphweaver();
 let token: string | undefined;
 let em: EntityManager | undefined = undefined;
 
-describe.only('Nested entity queries should not bypass row-level security', () => {
+describe('Nested entity queries should not bypass row-level security', () => {
 	beforeAll(async () => {
 		const connectionResult = await ConnectionManager.connect('sqlite', connection);
 		em = connectionResult?.em;
@@ -199,7 +199,7 @@ describe.only('Nested entity queries should not bypass row-level security', () =
 		await em?.getConnection().close();
 	});
 
-	test.only('Should only return tasks that the user has access to when asking for tags', async () => {
+	test('Should only return tasks that the user has access to when asking for tags', async () => {
 		const spyOnArtistDataProvider = jest.spyOn(taskProvider, 'findByRelatedId');
 		// create 3 tasks for our user and another 3 for a different user
 		const task1ForAuthenticatedUser = new OrmTask('task1ForAuthenticatedUser', user.id);

--- a/src/packages/mikroorm/src/provider/provider.ts
+++ b/src/packages/mikroorm/src/provider/provider.ts
@@ -462,10 +462,10 @@ export class MikroBackendProvider<D> implements BackendProvider<D> {
 		let queryFilter: any = { [relatedField]: { $in: relatedFieldIds } };
 
 		if (filter) {
+			// JSON.parse(JSON.stringify()) is needed. See https://exogee.atlassian.net/browse/EXOGW-419
+			const gqlToMikroFilter = JSON.parse(JSON.stringify([gqlToMikro(filter, this.getDbType())]));
 			// Since the user has supplied a filter, we need to and it in.
-			queryFilter = {
-				$and: [queryFilter, ...[gqlToMikro(filter, this.getDbType())]],
-			};
+			queryFilter = { $and: [queryFilter, ...gqlToMikroFilter] };
 		}
 
 		const populate = [relatedField as AutoPath<typeof entity, PopulateHint>];

--- a/src/packages/mikroorm/src/provider/provider.ts
+++ b/src/packages/mikroorm/src/provider/provider.ts
@@ -54,7 +54,7 @@ const appendPath = (path: string, newPath: string) =>
 export const gqlToMikro = (filter: any, databaseType?: DatabaseType): any => {
 	if (Array.isArray(filter)) {
 		return filter.map((element) => gqlToMikro(element, databaseType));
-	} else if (typeof filter === 'object') {
+	} else if (typeof filter === 'object' && filter !== null) {
 		for (const key of Object.keys(filter)) {
 			// A null here is a user-specified value and is valid to filter on
 			if (filter[key] === null) continue;


### PR DESCRIPTION
https://exogee.atlassian.net/browse/EXOGW-416
and
https://exogee.atlassian.net/browse/EXOGW-419

- deep copy `filter` in mikroorm provider because that filter is not a POJO and mikroorm doesn't generate the proper SQL query
- use the filter coming from BEFORE_READ hook in the `core` resolver in the `_listRelationshipField` and `aggregateRelationshipField` so we apply ACLs to the resulting SQL query