### PR TITLE
EXOGW-426-Write-operations-broken-by-combination-of-tracing-and-certain-auth-controls

### DIFF
--- a/src/packages/core/src/open-telemetry/tracing.ts
+++ b/src/packages/core/src/open-telemetry/tracing.ts
@@ -89,6 +89,7 @@ export const trace =
 				});
 				return result;
 			} catch (error: any) {
+				logger.error(error);
 				const errorMessage = String(error);
 				span.setStatus({ code: SpanStatusCode.ERROR, message: errorMessage });
 				span.recordException(error);

--- a/src/packages/server/src/trace.ts
+++ b/src/packages/server/src/trace.ts
@@ -4,6 +4,7 @@ import {
 	setEnableTracingForRequest,
 	trace,
 } from '@exogee/graphweaver';
+import { logger } from '@exogee/logger';
 import { OperationDefinitionNode, parse } from 'graphql';
 
 export const enableTracing = <TContext extends BaseContext>(server: ApolloServer<TContext>) => {
@@ -16,17 +17,22 @@ export const enableTracing = <TContext extends BaseContext>(server: ApolloServer
 			| undefined;
 		const operationName = body?.operationName ?? 'Graphweaver Request';
 
-		const gql = parse(body?.query ?? '');
-		const type = (gql.definitions[0] as OperationDefinitionNode)?.operation ?? '';
+		// This gets called as a GET when first visiting the playground. In that case body?.query is undefined and if we try to parse it, it will throw an error
+		if (body?.query) {
+			const gql = parse(body.query);
+			const type = (gql.definitions[0] as OperationDefinitionNode)?.operation ?? '';
 
-		trace?.span.updateName(operationName);
-		trace?.span.setAttributes({
-			'X-Amzn-RequestId': request.httpGraphQLRequest.headers.get('x-amzn-requestid'),
-			'X-Amzn-Trace-Id': request.httpGraphQLRequest.headers.get('x-amzn-trace-id'),
-			body: JSON.stringify(request.httpGraphQLRequest.body),
-			method: request.httpGraphQLRequest.method,
-			type,
-		});
+			trace?.span.updateName(operationName);
+			trace?.span.setAttributes({
+				'X-Amzn-RequestId': request.httpGraphQLRequest.headers.get('x-amzn-requestid'),
+				'X-Amzn-Trace-Id': request.httpGraphQLRequest.headers.get('x-amzn-trace-id'),
+				body: JSON.stringify(request.httpGraphQLRequest.body),
+				method: request.httpGraphQLRequest.method,
+				type,
+			});
+		} else {
+			logger.trace('enableTracing - No query found in request body');
+		}
 
 		const suppressTracing = request.httpGraphQLRequest.headers.get(
 			'x-graphweaver-suppress-tracing'


### PR DESCRIPTION
https://exogee.atlassian.net/browse/EXOGW-426

`enableTracing` was throwing an error when trying to `parse(body?.query)` on a GET request.