### PR TITLE
Improvement / Flush Logs

### DIFF
--- a/src/packages/server/src/integrations/fastify.ts
+++ b/src/packages/server/src/integrations/fastify.ts
@@ -48,7 +48,10 @@ export const startStandaloneServer = async <TContext extends BaseContext>(
 	});
 
 	// Always flush the logger on each request so logs get persisted.
-	fastify.addHook('onResponse', async () => logger.flush());
+	fastify.addHook('onResponse', (_, __, done) => {
+		logger.flush();
+		done();
+	});
 
 	fastify.get('/health', async (_, reply) => {
 		reply.statusCode = 200;

--- a/src/packages/server/src/integrations/fastify.ts
+++ b/src/packages/server/src/integrations/fastify.ts
@@ -47,6 +47,9 @@ export const startStandaloneServer = async <TContext extends BaseContext>(
 		onRequestWrapper(plugins, async () => done());
 	});
 
+	// Always flush the logger on each request so logs get persisted.
+	fastify.addHook('onResponse', async () => logger.flush());
+
 	fastify.get('/health', async (_, reply) => {
 		reply.statusCode = 200;
 		reply.send({

--- a/src/packages/server/src/integrations/lambda.ts
+++ b/src/packages/server/src/integrations/lambda.ts
@@ -2,6 +2,7 @@ import { ApolloServer } from '@apollo/server';
 import { handlers, startServerAndCreateLambdaHandler } from '@as-integrations/aws-lambda';
 import { GraphweaverPlugin } from '@exogee/graphweaver';
 import { onRequestWrapper } from './utils';
+import { logger } from '@exogee/logger';
 
 export const startServerless = ({
 	server,
@@ -17,10 +18,15 @@ export const startServerless = ({
 
 	return (event, context) =>
 		onRequestWrapper(graphweaverPlugins, async () => {
-			const res = await handler(event, context, () => {});
-			if (!res) {
-				throw new Error('Handler Response was undefined or null.');
+			try {
+				const res = await handler(event, context, () => {});
+				if (!res) {
+					throw new Error('Handler Response was undefined or null.');
+				}
+				return res;
+			} finally {
+				// Ensure we always flush logs on each request.
+				logger.flush();
 			}
-			return res;
 		});
 };


### PR DESCRIPTION
For both lambda and fastify make sure we flush the logger at the end of every request. In Lambda already we should have been using synchronous logging, but when running in Serverless Offline or in Fastify we wouldn't have been. This forces the logs to flush at the end of every request, which should help ensure errors are captured in the log.