### PR TITLE
`EXOGW418` - Added ability to type in date picker Admin UI component

### DIFF
--- a/src/packages/admin-ui-components/src/date-picker/component.tsx
+++ b/src/packages/admin-ui-components/src/date-picker/component.tsx
@@ -155,7 +155,7 @@ export const DatePicker = ({
 					placeholder={placeholder}
 					value={(dateInputValue)}
 					onChange={handleInputFieldChange}
-					onBlur={() => {setDateInputValue(inputDisplayText(luxonStartDate, luxonEndDate))}} //TODO: Fix
+					onBlur={() => {setDateInputValue(inputDisplayText(luxonStartDate, luxonEndDate))}}
 				/>
 				{startDate && (
 					<div className={styles.indicatorWrapper}>
@@ -190,28 +190,28 @@ export const DatePicker = ({
 
 					{filterType === AdminUIFilterType.DATE_TIME_RANGE && !isRangePicker && (
 						<div className={styles.timeSelector}>
-							Time:
 							<TimeInput
 								value={luxonStartDate}
 								setValue={handleTimeInputChange('start')}
 								defaultTime="00:00:00"
+								label='Time'
 							/>
 						</div>
 					)}
 					{filterType === AdminUIFilterType.DATE_TIME_RANGE && isRangePicker && (
 						<div className={styles.timeSelector}>
-							From:{' '}
 							<TimeInput
 								value={luxonStartDate}
 								setValue={(value) => handleTimeInputChange('start')(value, luxonEndDate)}
 								defaultTime="00:00:00"
+								label='From'
 							/>
 							<div style={{ width: '5px' }}> </div>
-							To:{' '}
 							<TimeInput
 								value={luxonEndDate}
 								setValue={(value) => handleTimeInputChange('end')(luxonStartDate, value)}
 								defaultTime="23:59:59"
+								label='To'
 							/>
 						</div>
 					)}

--- a/src/packages/admin-ui-components/src/date-picker/component.tsx
+++ b/src/packages/admin-ui-components/src/date-picker/component.tsx
@@ -97,7 +97,7 @@ export const DatePicker = ({
 
 		setDateInputValue(e.target.value);
 
-		if (parsedStart.isValid || !parsedEnd) {
+		if (parsedStart.isValid || parsedEnd.isValid) {
 			onChange(
 				parsedStart.isValid 
 					? parsedStart 
@@ -132,7 +132,7 @@ export const DatePicker = ({
 		<div className={styles.container}>
 			<div className={styles.inputSelector}>
 				<input
-					className={clsx(startDate && styles.inputFieldActive, styles.inputField)}
+					className={clsx((startDate || dateInputValue.length) && styles.inputFieldActive, styles.inputField)}
 					onClick={() => setIsOpen((isOpen) => !isOpen)}
 					placeholder={placeholder}
 					value={(dateInputValue)}

--- a/src/packages/admin-ui-components/src/date-picker/component.tsx
+++ b/src/packages/admin-ui-components/src/date-picker/component.tsx
@@ -30,7 +30,7 @@ export const DatePicker = ({
 	filterType,
 	fieldType,
 }: Props) => {
-	const [isDateLocaleFormat, setIsDateLocaleFormat] = useState(true);
+	const [isDateLocalFormat, setIsDateLocalFormat] = useState(true);
 	const luxonStartDate = toLuxonDate(startDate);
 	const luxonEndDate = toLuxonDate(endDate);
 
@@ -38,23 +38,18 @@ export const DatePicker = ({
 
 	const inputDisplayText = (start?: DateTime, end?: DateTime) => {
 		if (start) {
-			const selectedDatesText = isDateLocaleFormat 
-				? [
-					start.toLocaleString(),
-					end?.toLocaleString(),
-				] : [
-					start.toISODate(),
-					end?.toISODate(),
-				];
-			return isRangePicker
-				? `${selectedDatesText.join(' to ')}`
-				: start.toLocaleString();
+			const selectedDatesText = isDateLocalFormat
+				? [start.toLocaleString(), end?.toLocaleString()]
+				: [start.toISODate(), end?.toISODate()];
+			return isRangePicker ? `${selectedDatesText.join(' to ')}` : start.toLocaleString();
 		} else {
 			return '';
 		}
 	};
-	
-	const [dateInputValue, setDateInputValue] = useState(inputDisplayText(luxonStartDate, luxonEndDate));
+
+	const [dateInputValue, setDateInputValue] = useState(
+		inputDisplayText(luxonStartDate, luxonEndDate)
+	);
 	const datePickerRef = useRef<HTMLDivElement>(null);
 
 	const handleDateRangeSelect = (start?: DateTime, end?: DateTime) => {
@@ -84,28 +79,29 @@ export const DatePicker = ({
 		if (mode === 'end') {
 			end = setTime(endDate, end, DateTime.now().endOf('day'));
 		}
-		setDateInputValue(inputDisplayText(start, end))
+		setDateInputValue(inputDisplayText(start, end));
 		onChange(start, end);
 	};
 
 	const handleInputFieldChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		setDateInputValue(e.target.value);
-		const [inputStart, inputEnd] = isRangePicker 
-			? e.target.value.trim().split(/\s+to\s+/) 
+		const [inputStart, inputEnd] = isRangePicker
+			? e.target.value.trim().split(/\s+to\s+/)
 			: [e.target.value, undefined];
 
 		let parsedStart = DateTime.fromISO(inputStart);
-		let parsedEnd = inputEnd === undefined
-			? DateTime.invalid('No end date provided')
-			: DateTime.fromISO(inputEnd).startOf('day');
+		let parsedEnd =
+			inputEnd === undefined
+				? DateTime.invalid('No end date provided')
+				: DateTime.fromISO(inputEnd).startOf('day');
 
 		// If that didn't work, attempt to parse from locale format
 		const { locale } = Intl.DateTimeFormat().resolvedOptions();
 		if (!parsedStart.isValid) {
 			parsedStart = DateTime.fromFormat(inputStart, 'D', { locale });
-			parsedStart.isValid && setIsDateLocaleFormat(true);
+			if (parsedStart.isValid) setIsDateLocalFormat(true);
 		} else {
-			setIsDateLocaleFormat(false);
+			setIsDateLocalFormat(false);
 		}
 		if (!parsedEnd.isValid && inputEnd !== undefined) {
 			parsedEnd = DateTime.fromFormat(inputEnd, 'D', { locale });
@@ -117,12 +113,8 @@ export const DatePicker = ({
 		// Only trigger onChange if the changed input actually formed a valid date
 		if (parsedStart.isValid || parsedEnd.isValid) {
 			onChange(
-				parsedStart.isValid 
-					? parsedStart 
-					: luxonStartDate, 
-				parsedEnd.isValid 
-					? parsedEnd 
-					: luxonEndDate
+				parsedStart.isValid ? parsedStart : luxonStartDate,
+				parsedEnd.isValid ? parsedEnd : luxonEndDate
 			);
 		}
 	};
@@ -150,12 +142,17 @@ export const DatePicker = ({
 		<div className={styles.container}>
 			<div className={styles.inputSelector}>
 				<input
-					className={clsx((startDate || dateInputValue.length) && styles.inputFieldActive, styles.inputField)}
+					className={clsx(
+						(startDate || dateInputValue.length) && styles.inputFieldActive,
+						styles.inputField
+					)}
 					onClick={() => setIsOpen((isOpen) => !isOpen)}
 					placeholder={placeholder}
-					value={(dateInputValue)}
+					value={dateInputValue}
 					onChange={handleInputFieldChange}
-					onBlur={() => {setDateInputValue(inputDisplayText(luxonStartDate, luxonEndDate))}}
+					onBlur={() => {
+						setDateInputValue(inputDisplayText(luxonStartDate, luxonEndDate));
+					}}
 				/>
 				{startDate && (
 					<div className={styles.indicatorWrapper}>
@@ -194,7 +191,7 @@ export const DatePicker = ({
 								value={luxonStartDate}
 								setValue={handleTimeInputChange('start')}
 								defaultTime="00:00:00"
-								label='Time'
+								label="Time"
 							/>
 						</div>
 					)}
@@ -204,14 +201,14 @@ export const DatePicker = ({
 								value={luxonStartDate}
 								setValue={(value) => handleTimeInputChange('start')(value, luxonEndDate)}
 								defaultTime="00:00:00"
-								label='From'
+								label="From"
 							/>
 							<div style={{ width: '5px' }}> </div>
 							<TimeInput
 								value={luxonEndDate}
 								setValue={(value) => handleTimeInputChange('end')(luxonStartDate, value)}
 								defaultTime="23:59:59"
-								label='To'
+								label="To"
 							/>
 						</div>
 					)}

--- a/src/packages/admin-ui-components/src/date-picker/styles.module.css
+++ b/src/packages/admin-ui-components/src/date-picker/styles.module.css
@@ -116,6 +116,7 @@
 /* Styling overrides for react-day-picker */
 :global(.rdp-root) {
 	--rdp-accent-color: var(--primary-color);
+	--rdp-accent-background-color: #382f46;
 }
 
 .timeSelector {

--- a/src/packages/admin-ui-components/src/date-picker/styles.module.css
+++ b/src/packages/admin-ui-components/src/date-picker/styles.module.css
@@ -129,5 +129,5 @@
 	width: 101px;
 	border: 1px solid var(--primary-color);
 	border-radius: 7px;
-	padding: 1px 5px;
+	padding: 3px 5px;
 }

--- a/src/packages/admin-ui-components/src/date-picker/styles.module.css
+++ b/src/packages/admin-ui-components/src/date-picker/styles.module.css
@@ -131,4 +131,5 @@
 	border: 1px solid var(--primary-color);
 	border-radius: 7px;
 	padding: 3px 5px;
+	flex-grow: 1;
 }

--- a/src/packages/admin-ui-components/src/date-picker/styles.module.css
+++ b/src/packages/admin-ui-components/src/date-picker/styles.module.css
@@ -1,5 +1,6 @@
 .container {
-	flex: 1;
+	flex-shrink: 0;
+	flex-grow: 1;
 }
 
 .inputSelector {

--- a/src/packages/admin-ui-components/src/date-picker/time-input.tsx
+++ b/src/packages/admin-ui-components/src/date-picker/time-input.tsx
@@ -19,10 +19,10 @@ export const TimeInput = (props: Props) => {
 				if (!event.target.value) return;
 				const newDate = DateTime.fromISO(event.target.value);
 				setValue(
-					(value ?? DateTime.now())?.startOf('day').plus({
-						hours: newDate.hour,
-						minutes: newDate.minute,
-						seconds: newDate.second,
+					(value ?? DateTime.now()).set({
+						hour: newDate.hour,
+						minute: newDate.minute,
+						second: newDate.second,
 					})
 				);
 			}}

--- a/src/packages/admin-ui-components/src/date-picker/time-input.tsx
+++ b/src/packages/admin-ui-components/src/date-picker/time-input.tsx
@@ -1,12 +1,11 @@
 import { DateTime } from 'luxon';
 import { useId } from 'react';
-import styles from './styles.module.css';
 
 interface Props {
 	value: DateTime | undefined;
 	setValue: (value: DateTime) => void;
 	defaultTime: string;
-	label?: string
+	label?: string;
 }
 
 const timeFormat = 'HH:mm:ss';
@@ -16,11 +15,9 @@ export const TimeInput = (props: Props) => {
 	const id = useId();
 	return (
 		<>
-			{label && <label htmlFor={id}>
-				{label}
-			</label>}
+			{label && <label htmlFor={id}>{label}</label>}
 			<input
-				id={id} 
+				id={id}
 				type="time"
 				step={1}
 				value={value?.toFormat(timeFormat) ?? defaultTime}

--- a/src/packages/admin-ui-components/src/date-picker/time-input.tsx
+++ b/src/packages/admin-ui-components/src/date-picker/time-input.tsx
@@ -1,31 +1,41 @@
 import { DateTime } from 'luxon';
+import { useId } from 'react';
+import styles from './styles.module.css';
 
 interface Props {
 	value: DateTime | undefined;
 	setValue: (value: DateTime) => void;
 	defaultTime: string;
+	label?: string
 }
 
 const timeFormat = 'HH:mm:ss';
 
 export const TimeInput = (props: Props) => {
-	const { value, setValue, defaultTime } = props;
+	const { value, setValue, defaultTime, label } = props;
+	const id = useId();
 	return (
-		<input
-			type="time"
-			step={1}
-			value={value?.toFormat(timeFormat) ?? defaultTime}
-			onChange={(event) => {
-				if (!event.target.value) return;
-				const newDate = DateTime.fromISO(event.target.value);
-				setValue(
-					(value ?? DateTime.now()).set({
-						hour: newDate.hour,
-						minute: newDate.minute,
-						second: newDate.second,
-					})
-				);
-			}}
-		/>
+		<>
+			{label && <label htmlFor={id}>
+				{label}
+			</label>}
+			<input
+				id={id} 
+				type="time"
+				step={1}
+				value={value?.toFormat(timeFormat) ?? defaultTime}
+				onChange={(event) => {
+					if (!event.target.value) return;
+					const newDate = DateTime.fromISO(event.target.value);
+					setValue(
+						(value ?? DateTime.now()).set({
+							hour: newDate.hour,
+							minute: newDate.minute,
+							second: newDate.second,
+						})
+					);
+				}}
+			/>
+		</>
 	);
 };

--- a/src/packages/admin-ui-components/src/date-picker/utils.ts
+++ b/src/packages/admin-ui-components/src/date-picker/utils.ts
@@ -14,11 +14,11 @@ export const setTime = (
 ) => {
 	const dateLuxon = toLuxonDate(date);
 	const timeDateLuxon = toLuxonDate(time) ?? defaultTime;
-	if (!dateLuxon) return dateLuxon;
-	return dateLuxon.startOf('day').plus({
-		hours: timeDateLuxon.hour,
-		minutes: timeDateLuxon.minute,
-		seconds: timeDateLuxon.second,
+	if (!dateLuxon || !dateLuxon.isValid || !timeDateLuxon.isValid) return dateLuxon;
+	return dateLuxon.set({
+		hour: timeDateLuxon.hour,
+		minute: timeDateLuxon.minute,
+		second: timeDateLuxon.second,
 	});
 };
 

--- a/src/packages/admin-ui-components/src/filters/utils.ts
+++ b/src/packages/admin-ui-components/src/filters/utils.ts
@@ -22,6 +22,7 @@ const getValidFilterProperties = (fields: EntityField[]): Set<string> => {
 				supportedKeys.add(field.name);
 				break;
 			case AdminUIFilterType.DATE_RANGE:
+			case AdminUIFilterType.DATE_TIME_RANGE:
 				supportedKeys.add(`${field.name}_gte`);
 				supportedKeys.add(`${field.name}_lte`);
 				break;

--- a/src/packages/end-to-end/src/__tests__/ui/sqlite/components/date-picker.test.ts
+++ b/src/packages/end-to-end/src/__tests__/ui/sqlite/components/date-picker.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from '@playwright/test';
+import { config } from '../../../../config';
+
+const invoiceAdminUrl = `${config.adminUiUrl}/Invoice`;
+
+[
+    { locale: 'en-US', timezoneId: 'America/New_York', expectedCount: 7, expectedFrom: 'Thursday, October 1st, 2009' }, 
+    { locale: 'en-AU', timezoneId: 'Australia/Sydney', expectedCount: 1, expectedFrom: 'Saturday, January 10th, 2009' }
+].forEach(({ locale, timezoneId, expectedCount, expectedFrom }) => {
+    // The describe block stops test.use from affecting the rest of the tests in the file
+    test.describe(`Date picker tests: ${locale}`, () => {
+        test.use({ locale, timezoneId });
+        test(`Local (${locale}) dates interpreted in correct format`, async ({ page }) => {
+            await page.goto(invoiceAdminUrl);
+
+            await page.getByPlaceholder('invoiceDate').click();
+            await page.getByPlaceholder('invoiceDate').fill('10/01/2009 to 11/01/2009');
+            await page.getByRole('button', { name: 'Done' }).click();
+            await page.getByPlaceholder('invoiceId').click();
+
+            // Account for header and footer row
+            const totalRows = expectedCount + 2 
+            await expect(page.getByRole('table').getByRole('row')).toHaveCount(totalRows);
+
+            // Open the modal
+            await page.getByPlaceholder('invoiceDate').click();
+            await expect(page.getByRole('button', { name: `${expectedFrom}, selected` })).toBeVisible();
+        });
+    });
+});
+
+test.describe('Date picker with time', () => {
+    // The date range in this test covers the switch between AEST and AEDT,
+    // which was causing a bug in development
+    test.use({ timezoneId: 'Australia/Sydney', locale: 'en-AU' });
+    test('Values in time inputs get preserved', async ({ page }) => {
+        await page.goto(invoiceAdminUrl);
+
+        await page.getByPlaceholder('invoiceDate').click();
+        await page.getByPlaceholder('invoiceDate').fill('04/04/2025 to 05/04/2025');
+
+        await page.getByLabel('From').fill('08:30:00');
+        await page.getByLabel('To', { exact: true }).fill('22:20:00');
+
+        await page.getByPlaceholder('invoiceDate').fill('04/04/2025 to 06/04/2025');
+
+        await expect(page.getByLabel('From')).toHaveValue('08:30:00');
+        await expect(page.getByLabel('To', { exact: true })).toHaveValue('22:20:00');
+    });
+});
+
+test('Filter with ISO Date strings (YYYY-MM-DD)', async ({ page }) => {
+    await page.goto(invoiceAdminUrl);
+
+    await page.getByPlaceholder('invoiceDate').click();
+    await page.getByPlaceholder('invoiceDate').fill('2009-01-10 to 2009-01-11');
+    await page.getByRole('button', { name: 'Done' }).click();
+
+    // The format should stay in YYYY-MM-DD
+    await expect(page.getByPlaceholder('invoiceDate')).toHaveValue('2009-01-10 to 2009-01-11');
+
+    await page.getByPlaceholder('invoiceDate').click();
+    await expect(page.getByRole('button', { name: 'Saturday, January 10th, 2009, selected' })).toBeVisible();
+});
+
+test('Ignore bad dates', async ({ page }) => {
+    await page.goto(invoiceAdminUrl);
+
+    await page.getByPlaceholder('invoiceDate').click();
+    await page.getByPlaceholder('invoiceDate').fill('13/13/2013 to 42/42/2042');
+    await page.getByRole('button', { name: 'Done' }).click();
+
+    // Invalid input should be cleared
+    await expect(page.getByPlaceholder('invoiceDate')).toBeEmpty();
+});
+

--- a/src/packages/end-to-end/src/__tests__/ui/sqlite/components/date-picker.test.ts
+++ b/src/packages/end-to-end/src/__tests__/ui/sqlite/components/date-picker.test.ts
@@ -4,73 +4,84 @@ import { config } from '../../../../config';
 const invoiceAdminUrl = `${config.adminUiUrl}/Invoice`;
 
 [
-    { locale: 'en-US', timezoneId: 'America/New_York', expectedCount: 7, expectedFrom: 'Thursday, October 1st, 2009' }, 
-    { locale: 'en-AU', timezoneId: 'Australia/Sydney', expectedCount: 1, expectedFrom: 'Saturday, January 10th, 2009' }
+	{
+		locale: 'en-US',
+		timezoneId: 'America/New_York',
+		expectedCount: 7,
+		expectedFrom: 'Thursday, October 1st, 2009',
+	},
+	{
+		locale: 'en-AU',
+		timezoneId: 'Australia/Sydney',
+		expectedCount: 1,
+		expectedFrom: 'Saturday, January 10th, 2009',
+	},
 ].forEach(({ locale, timezoneId, expectedCount, expectedFrom }) => {
-    // The describe block stops test.use from affecting the rest of the tests in the file
-    test.describe(`Date picker tests: ${locale}`, () => {
-        test.use({ locale, timezoneId });
-        test(`Local (${locale}) dates interpreted in correct format`, async ({ page }) => {
-            await page.goto(invoiceAdminUrl);
+	// The describe block stops test.use from affecting the rest of the tests in the file
+	test.describe(`Date picker tests: ${locale}`, () => {
+		test.use({ locale, timezoneId });
+		test(`Local (${locale}) dates interpreted in correct format`, async ({ page }) => {
+			await page.goto(invoiceAdminUrl);
 
-            await page.getByPlaceholder('invoiceDate').click();
-            await page.getByPlaceholder('invoiceDate').fill('10/01/2009 to 11/01/2009');
-            await page.getByRole('button', { name: 'Done' }).click();
-            await page.getByPlaceholder('invoiceId').click();
+			await page.getByPlaceholder('invoiceDate').click();
+			await page.getByPlaceholder('invoiceDate').fill('10/01/2009 to 11/01/2009');
+			await page.getByRole('button', { name: 'Done' }).click();
+			await page.getByPlaceholder('invoiceId').click();
 
-            // Account for header and footer row
-            const totalRows = expectedCount + 2 
-            await expect(page.getByRole('table').getByRole('row')).toHaveCount(totalRows);
+			// Account for header and footer row
+			const totalRows = expectedCount + 2;
+			await expect(page.getByRole('table').getByRole('row')).toHaveCount(totalRows);
 
-            // Open the modal
-            await page.getByPlaceholder('invoiceDate').click();
-            await expect(page.getByRole('button', { name: `${expectedFrom}, selected` })).toBeVisible();
-        });
-    });
+			// Open the modal
+			await page.getByPlaceholder('invoiceDate').click();
+			await expect(page.getByRole('button', { name: `${expectedFrom}, selected` })).toBeVisible();
+		});
+	});
 });
 
 test.describe('Date picker with time', () => {
-    // The date range in this test covers the switch between AEST and AEDT,
-    // which was causing a bug in development
-    test.use({ timezoneId: 'Australia/Sydney', locale: 'en-AU' });
-    test('Values in time inputs get preserved', async ({ page }) => {
-        await page.goto(invoiceAdminUrl);
+	// The date range in this test covers the switch between AEST and AEDT,
+	// which was causing a bug in development
+	test.use({ timezoneId: 'Australia/Sydney', locale: 'en-AU' });
+	test('Values in time inputs get preserved', async ({ page }) => {
+		await page.goto(invoiceAdminUrl);
 
-        await page.getByPlaceholder('invoiceDate').click();
-        await page.getByPlaceholder('invoiceDate').fill('04/04/2025 to 05/04/2025');
+		await page.getByPlaceholder('invoiceDate').click();
+		await page.getByPlaceholder('invoiceDate').fill('04/04/2025 to 05/04/2025');
 
-        await page.getByLabel('From').fill('08:30:00');
-        await page.getByLabel('To', { exact: true }).fill('22:20:00');
+		await page.getByLabel('From').fill('08:30:00');
+		await page.getByLabel('To', { exact: true }).fill('22:20:00');
 
-        await page.getByPlaceholder('invoiceDate').fill('04/04/2025 to 06/04/2025');
+		await page.getByPlaceholder('invoiceDate').fill('04/04/2025 to 06/04/2025');
 
-        await expect(page.getByLabel('From')).toHaveValue('08:30:00');
-        await expect(page.getByLabel('To', { exact: true })).toHaveValue('22:20:00');
-    });
+		await expect(page.getByLabel('From')).toHaveValue('08:30:00');
+		await expect(page.getByLabel('To', { exact: true })).toHaveValue('22:20:00');
+	});
 });
 
 test('Filter with ISO Date strings (YYYY-MM-DD)', async ({ page }) => {
-    await page.goto(invoiceAdminUrl);
+	await page.goto(invoiceAdminUrl);
 
-    await page.getByPlaceholder('invoiceDate').click();
-    await page.getByPlaceholder('invoiceDate').fill('2009-01-10 to 2009-01-11');
-    await page.getByRole('button', { name: 'Done' }).click();
+	await page.getByPlaceholder('invoiceDate').click();
+	await page.getByPlaceholder('invoiceDate').fill('2009-01-10 to 2009-01-11');
+	await page.getByRole('button', { name: 'Done' }).click();
 
-    // The format should stay in YYYY-MM-DD
-    await expect(page.getByPlaceholder('invoiceDate')).toHaveValue('2009-01-10 to 2009-01-11');
+	// The format should stay in YYYY-MM-DD
+	await expect(page.getByPlaceholder('invoiceDate')).toHaveValue('2009-01-10 to 2009-01-11');
 
-    await page.getByPlaceholder('invoiceDate').click();
-    await expect(page.getByRole('button', { name: 'Saturday, January 10th, 2009, selected' })).toBeVisible();
+	await page.getByPlaceholder('invoiceDate').click();
+	await expect(
+		page.getByRole('button', { name: 'Saturday, January 10th, 2009, selected' })
+	).toBeVisible();
 });
 
 test('Ignore bad dates', async ({ page }) => {
-    await page.goto(invoiceAdminUrl);
+	await page.goto(invoiceAdminUrl);
 
-    await page.getByPlaceholder('invoiceDate').click();
-    await page.getByPlaceholder('invoiceDate').fill('13/13/2013 to 42/42/2042');
-    await page.getByRole('button', { name: 'Done' }).click();
+	await page.getByPlaceholder('invoiceDate').click();
+	await page.getByPlaceholder('invoiceDate').fill('13/13/2013 to 42/42/2042');
+	await page.getByRole('button', { name: 'Done' }).click();
 
-    // Invalid input should be cleared
-    await expect(page.getByPlaceholder('invoiceDate')).toBeEmpty();
+	// Invalid input should be cleared
+	await expect(page.getByPlaceholder('invoiceDate')).toBeEmpty();
 });
-


### PR DESCRIPTION
The date picker component now lets you type in it, instead of having to click through the calendar pop-up. Dates can be entered as either a date in local format (according to the user's browser/system settings) or in YYYY-MM-DD format.

I've also added proper labels to the time input component, fixed the styling on some inputs to make them larger/stop them from shrinking, and fixed a bug that caused an error to appear if using a DateTime range filter and refreshing the page.