### PR TITLE
Exogw 444 GitHub 1725 custom query with string return type generates string return type instead

### DIFF
--- a/src/packages/core/src/metadata.test.ts
+++ b/src/packages/core/src/metadata.test.ts
@@ -62,10 +62,9 @@ describe('Metadata', () => {
 
 	it('should correctly identify the field for a filter key where the field has a list return type', () => {
 		expect(
-			graphweaverMetadata.fieldMetadataForFilterKey(
-				stubEntityMetadata,
-				'field_with_list_return_type_in'
-			)?.getType()
+			graphweaverMetadata
+				.fieldMetadataForFilterKey(stubEntityMetadata, 'field_with_list_return_type_in')
+				?.getType()
 		).toStrictEqual([String]);
 	});
 

--- a/src/packages/core/src/metadata.test.ts
+++ b/src/packages/core/src/metadata.test.ts
@@ -30,6 +30,11 @@ const stubEntityMetadata: EntityMetadata<any> = {
 			target: TestEntity,
 			getType: () => String,
 		},
+		field_with_list_return_type: {
+			name: 'field_with_list_return_type',
+			target: TestEntity,
+			getType: () => [String],
+		},
 	},
 };
 
@@ -53,6 +58,15 @@ describe('Metadata', () => {
 				'field_with_lots_of_underscores_gt'
 			)?.name
 		).toBe('field_with_lots_of_underscores');
+	});
+
+	it('should correctly identify the field for a filter key where the field has a list return type', () => {
+		expect(
+			graphweaverMetadata.fieldMetadataForFilterKey(
+				stubEntityMetadata,
+				'field_with_list_return_type_in'
+			)?.getType()
+		).toStrictEqual([String]);
 	});
 
 	it('should ignore a filter key that does not specify a valid filter operator as the last portion of the key', () => {

--- a/src/packages/core/src/schema-builder.ts
+++ b/src/packages/core/src/schema-builder.ts
@@ -976,6 +976,8 @@ class SchemaBuilderImplementation {
 					const { fieldType, isList, metadata } = getFieldTypeWithMetadata(customQuery.getType);
 					const customArgs = this.graphQLTypeForArgs(entityFilter, customQuery.args);
 
+					
+
 					if (isEntityMetadata(metadata)) {
 						// If the entity filter says no, we will ignore their custom query because it references
 						// an entity that is filtered out of this schema.
@@ -1004,7 +1006,7 @@ class SchemaBuilderImplementation {
 						fields[customQuery.name] = {
 							...customQuery,
 							args: customArgs,
-							type,
+							type: isList ? new GraphQLList(type) : type,
 							resolve: trace(resolvers.baseResolver(customQuery.resolver)),
 							extensions: {
 								directives: customQuery.directives ?? {},

--- a/src/packages/core/src/schema-builder.ts
+++ b/src/packages/core/src/schema-builder.ts
@@ -976,8 +976,6 @@ class SchemaBuilderImplementation {
 					const { fieldType, isList, metadata } = getFieldTypeWithMetadata(customQuery.getType);
 					const customArgs = this.graphQLTypeForArgs(entityFilter, customQuery.args);
 
-					
-
 					if (isEntityMetadata(metadata)) {
 						// If the entity filter says no, we will ignore their custom query because it references
 						// an entity that is filtered out of this schema.

--- a/src/packages/end-to-end/src/__tests__/api/metadata/custom-queries.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/metadata/custom-queries.test.ts
@@ -1,0 +1,30 @@
+import gql from 'graphql-tag';
+import assert from 'assert';
+import Graphweaver from '@exogee/graphweaver-server';
+import { graphweaverMetadata } from '@exogee/graphweaver';
+
+
+test('should correctly handle non entity list return type.', async () => {
+    graphweaverMetadata.addQuery({
+        name: 'test',
+        getType: () => [String],
+        resolver: () => Promise.resolve(['a', 'b']),
+    });
+
+    const graphweaver = new Graphweaver();
+
+    const response = await graphweaver.executeOperation<{
+        test: string[];
+    }>({
+        query: gql`
+			query {
+				test
+			}
+		`,
+    });
+    assert(response.body.kind === "single");
+    expect(response.body.singleResult.errors).toBeUndefined();
+    expect(response.body.singleResult.data).toMatchObject({
+        test: ['a', 'b']
+    });
+});

--- a/src/packages/end-to-end/src/__tests__/api/metadata/custom-queries.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/metadata/custom-queries.test.ts
@@ -3,28 +3,27 @@ import assert from 'assert';
 import Graphweaver from '@exogee/graphweaver-server';
 import { graphweaverMetadata } from '@exogee/graphweaver';
 
-
 test('should correctly handle non entity list return type.', async () => {
-    graphweaverMetadata.addQuery({
-        name: 'test',
-        getType: () => [String],
-        resolver: () => Promise.resolve(['a', 'b']),
-    });
+	graphweaverMetadata.addQuery({
+		name: 'test',
+		getType: () => [String],
+		resolver: () => Promise.resolve(['a', 'b']),
+	});
 
-    const graphweaver = new Graphweaver();
+	const graphweaver = new Graphweaver();
 
-    const response = await graphweaver.executeOperation<{
-        test: string[];
-    }>({
-        query: gql`
+	const response = await graphweaver.executeOperation<{
+		test: string[];
+	}>({
+		query: gql`
 			query {
 				test
 			}
 		`,
-    });
-    assert(response.body.kind === "single");
-    expect(response.body.singleResult.errors).toBeUndefined();
-    expect(response.body.singleResult.data).toMatchObject({
-        test: ['a', 'b']
-    });
+	});
+	assert(response.body.kind === 'single');
+	expect(response.body.singleResult.errors).toBeUndefined();
+	expect(response.body.singleResult.data).toMatchObject({
+		test: ['a', 'b'],
+	});
 });

--- a/📦 @exogee/graphweaver/src/metadata.test.ts
+++ b/📦 @exogee/graphweaver/src/metadata.test.ts
@@ -1,0 +1,8 @@
+it('should correctly identify the field for a filter key where the field has multiple underscores in the name', () => {
+	expect(
+		graphweaverMetadata.fieldMetadataForFilterKey(
+			stubEntityMetadata,
+			'field_with_lots_of_underscores_gt'
+		)?.getType()
+	).toBe(String[]);
+}); 


### PR DESCRIPTION
This pull request introduces support for handling fields and queries with list return types in the Graphweaver framework. Key changes include updates to metadata handling, schema building, and the addition of new tests to ensure correctness.

### Metadata and Schema Enhancements:
* Updated the schema builder to correctly handle list return types by wrapping the type in `GraphQLList` when `isList` is true. (`src/packages/core/src/schema-builder.ts`, [src/packages/core/src/schema-builder.tsL1007-R1009](diffhunk://#diff-92502d1cf2ae0c4ce8fdc5f77cf8c2d53ad0516e7e9626da099204ce2bb5302bL1007-R1009))

### Testing Improvements:
* Added a unit test to verify that fields with list return types are correctly identified and handled in metadata. (`src/packages/core/src/metadata.test.ts`, [src/packages/core/src/metadata.test.tsR63-R71](diffhunk://#diff-25596ccbf0db5689bf32ff855191b8b9f2005939ee3ec3997d3f82aba4bd51f3R63-R71))
* Added an end-to-end test to validate the behavior of a custom query returning a non-entity list type (`[String]`). (`src/packages/end-to-end/src/__tests__/api/metadata/custom-queries.test.ts`, [src/packages/end-to-end/src/__tests__/api/metadata/custom-queries.test.tsR1-R30](diffhunk://#diff-6e3560558631f9d42edb9cee6f9a2b8d7cbd1c500c427b3ee3e4dc52d8219874R1-R30))