### PR TITLE
Fix / Logout loop with Okta.

### DIFF
--- a/src/packages/auth-ui-components/src/components/logout/component.tsx
+++ b/src/packages/auth-ui-components/src/components/logout/component.tsx
@@ -19,12 +19,22 @@ export const Logout = ({ onLogout }: LogoutProps) => {
 	const handleOnLogout = async () => {
 		try {
 			localStorage.removeItem(localStorageAuthKey);
-			await apolloClient.resetStore();
+
+			// We do NOT want to call apolloClient.resetStore() here.
+			// This refetches all active queries, which causes calls to the backend, which causes the user to be redirected
+			// back to the login page while being half logged out. The onLogout function MUST be called before calling apolloClient.resetStore()
+			// so Okta and the like can be logged out before the queries are refetched.
+			await apolloClient.clearStore();
+
 			if (onLogout) {
 				await onLogout();
 			} else {
 				setLocation('/');
 			}
+
+			// In many cases the code down here won't even run, but if we did make it down here, then now's the time to tell Apollo to fully clear
+			// the store and refetch all active queries.
+			await apolloClient.resetStore();
 		} catch (error: any) {
 			const message = error?.message || 'Unknown error.';
 			toast.error(`Failed to logout. Please try again. Error: ${message}`, {


### PR DESCRIPTION
When clicking logout, the `resetStore()` call was happening before the call to get Okta to log out. While this is officially correct according to the Apollo docs, it causes a refetch in the middle of the logout process, so suddenly that triggers a redirect to go log in before the Okta logout can happen. We then end up in a state where Okta thinks we're logged in and Graphweaver knows we're not, redirect loop ensues.

This ensures that we just clear the store, then if our auth provider does a full redirect in `onLogout()` that's fine. But if they don't then we'll go ahead and call `resetStore()` anyway after the provider has a chance to do what they need to do.