### PR TITLE
Date, timezone and currency support added to field decorators

### DIFF
--- a/src/examples/auth-zero/src/frontend/types.generated.ts
+++ b/src/examples/auth-zero/src/frontend/types.generated.ts
@@ -71,12 +71,21 @@ export type AdminUiFieldExtensionsMetadata = {
   key?: Maybe<Scalars['String']['output']>;
 };
 
+export type AdminUiFieldFormatMetadata = {
+  __typename?: 'AdminUiFieldFormatMetadata';
+  format?: Maybe<Scalars['String']['output']>;
+  timezone?: Maybe<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
+  variant?: Maybe<Scalars['String']['output']>;
+};
+
 export type AdminUiFieldMetadata = {
   __typename?: 'AdminUiFieldMetadata';
   attributes?: Maybe<AdminUiFieldAttributeMetadata>;
   detailPanelInputComponent?: Maybe<DetailPanelInputComponent>;
   extensions?: Maybe<AdminUiFieldExtensionsMetadata>;
   filter?: Maybe<AdminUiFilterMetadata>;
+  format?: Maybe<AdminUiFieldFormatMetadata>;
   hideInDetailForm?: Maybe<Scalars['Boolean']['output']>;
   hideInFilterBar?: Maybe<Scalars['Boolean']['output']>;
   hideInTable?: Maybe<Scalars['Boolean']['output']>;

--- a/src/examples/auth-zero/src/types.generated.ts
+++ b/src/examples/auth-zero/src/types.generated.ts
@@ -71,12 +71,21 @@ export type AdminUiFieldExtensionsMetadata = {
   key?: Maybe<Scalars['String']['output']>;
 };
 
+export type AdminUiFieldFormatMetadata = {
+  __typename?: 'AdminUiFieldFormatMetadata';
+  format?: Maybe<Scalars['String']['output']>;
+  timezone?: Maybe<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
+  variant?: Maybe<Scalars['String']['output']>;
+};
+
 export type AdminUiFieldMetadata = {
   __typename?: 'AdminUiFieldMetadata';
   attributes?: Maybe<AdminUiFieldAttributeMetadata>;
   detailPanelInputComponent?: Maybe<DetailPanelInputComponent>;
   extensions?: Maybe<AdminUiFieldExtensionsMetadata>;
   filter?: Maybe<AdminUiFilterMetadata>;
+  format?: Maybe<AdminUiFieldFormatMetadata>;
   hideInDetailForm?: Maybe<Scalars['Boolean']['output']>;
   hideInFilterBar?: Maybe<Scalars['Boolean']['output']>;
   hideInTable?: Maybe<Scalars['Boolean']['output']>;

--- a/src/examples/aws-cognito/src/frontend/types.generated.ts
+++ b/src/examples/aws-cognito/src/frontend/types.generated.ts
@@ -69,12 +69,21 @@ export type AdminUiFieldExtensionsMetadata = {
   key?: Maybe<Scalars['String']['output']>;
 };
 
+export type AdminUiFieldFormatMetadata = {
+  __typename?: 'AdminUiFieldFormatMetadata';
+  format?: Maybe<Scalars['String']['output']>;
+  timezone?: Maybe<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
+  variant?: Maybe<Scalars['String']['output']>;
+};
+
 export type AdminUiFieldMetadata = {
   __typename?: 'AdminUiFieldMetadata';
   attributes?: Maybe<AdminUiFieldAttributeMetadata>;
   detailPanelInputComponent?: Maybe<DetailPanelInputComponent>;
   extensions?: Maybe<AdminUiFieldExtensionsMetadata>;
   filter?: Maybe<AdminUiFilterMetadata>;
+  format?: Maybe<AdminUiFieldFormatMetadata>;
   hideInDetailForm?: Maybe<Scalars['Boolean']['output']>;
   hideInFilterBar?: Maybe<Scalars['Boolean']['output']>;
   hideInTable?: Maybe<Scalars['Boolean']['output']>;

--- a/src/examples/aws-cognito/src/types.generated.ts
+++ b/src/examples/aws-cognito/src/types.generated.ts
@@ -69,12 +69,21 @@ export type AdminUiFieldExtensionsMetadata = {
   key?: Maybe<Scalars['String']['output']>;
 };
 
+export type AdminUiFieldFormatMetadata = {
+  __typename?: 'AdminUiFieldFormatMetadata';
+  format?: Maybe<Scalars['String']['output']>;
+  timezone?: Maybe<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
+  variant?: Maybe<Scalars['String']['output']>;
+};
+
 export type AdminUiFieldMetadata = {
   __typename?: 'AdminUiFieldMetadata';
   attributes?: Maybe<AdminUiFieldAttributeMetadata>;
   detailPanelInputComponent?: Maybe<DetailPanelInputComponent>;
   extensions?: Maybe<AdminUiFieldExtensionsMetadata>;
   filter?: Maybe<AdminUiFilterMetadata>;
+  format?: Maybe<AdminUiFieldFormatMetadata>;
   hideInDetailForm?: Maybe<Scalars['Boolean']['output']>;
   hideInFilterBar?: Maybe<Scalars['Boolean']['output']>;
   hideInTable?: Maybe<Scalars['Boolean']['output']>;

--- a/src/examples/federation/src/frontend/types.generated.ts
+++ b/src/examples/federation/src/frontend/types.generated.ts
@@ -72,12 +72,21 @@ export type AdminUiFieldExtensionsMetadata = {
   key?: Maybe<Scalars['String']['output']>;
 };
 
+export type AdminUiFieldFormatMetadata = {
+  __typename?: 'AdminUiFieldFormatMetadata';
+  format?: Maybe<Scalars['String']['output']>;
+  timezone?: Maybe<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
+  variant?: Maybe<Scalars['String']['output']>;
+};
+
 export type AdminUiFieldMetadata = {
   __typename?: 'AdminUiFieldMetadata';
   attributes?: Maybe<AdminUiFieldAttributeMetadata>;
   detailPanelInputComponent?: Maybe<DetailPanelInputComponent>;
   extensions?: Maybe<AdminUiFieldExtensionsMetadata>;
   filter?: Maybe<AdminUiFilterMetadata>;
+  format?: Maybe<AdminUiFieldFormatMetadata>;
   hideInDetailForm?: Maybe<Scalars['Boolean']['output']>;
   hideInFilterBar?: Maybe<Scalars['Boolean']['output']>;
   hideInTable?: Maybe<Scalars['Boolean']['output']>;

--- a/src/examples/federation/src/types.generated.ts
+++ b/src/examples/federation/src/types.generated.ts
@@ -72,12 +72,21 @@ export type AdminUiFieldExtensionsMetadata = {
   key?: Maybe<Scalars['String']['output']>;
 };
 
+export type AdminUiFieldFormatMetadata = {
+  __typename?: 'AdminUiFieldFormatMetadata';
+  format?: Maybe<Scalars['String']['output']>;
+  timezone?: Maybe<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
+  variant?: Maybe<Scalars['String']['output']>;
+};
+
 export type AdminUiFieldMetadata = {
   __typename?: 'AdminUiFieldMetadata';
   attributes?: Maybe<AdminUiFieldAttributeMetadata>;
   detailPanelInputComponent?: Maybe<DetailPanelInputComponent>;
   extensions?: Maybe<AdminUiFieldExtensionsMetadata>;
   filter?: Maybe<AdminUiFilterMetadata>;
+  format?: Maybe<AdminUiFieldFormatMetadata>;
   hideInDetailForm?: Maybe<Scalars['Boolean']['output']>;
   hideInFilterBar?: Maybe<Scalars['Boolean']['output']>;
   hideInTable?: Maybe<Scalars['Boolean']['output']>;

--- a/src/examples/microsoft-entra/src/frontend/types.generated.ts
+++ b/src/examples/microsoft-entra/src/frontend/types.generated.ts
@@ -71,12 +71,21 @@ export type AdminUiFieldExtensionsMetadata = {
   key?: Maybe<Scalars['String']['output']>;
 };
 
+export type AdminUiFieldFormatMetadata = {
+  __typename?: 'AdminUiFieldFormatMetadata';
+  format?: Maybe<Scalars['String']['output']>;
+  timezone?: Maybe<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
+  variant?: Maybe<Scalars['String']['output']>;
+};
+
 export type AdminUiFieldMetadata = {
   __typename?: 'AdminUiFieldMetadata';
   attributes?: Maybe<AdminUiFieldAttributeMetadata>;
   detailPanelInputComponent?: Maybe<DetailPanelInputComponent>;
   extensions?: Maybe<AdminUiFieldExtensionsMetadata>;
   filter?: Maybe<AdminUiFilterMetadata>;
+  format?: Maybe<AdminUiFieldFormatMetadata>;
   hideInDetailForm?: Maybe<Scalars['Boolean']['output']>;
   hideInFilterBar?: Maybe<Scalars['Boolean']['output']>;
   hideInTable?: Maybe<Scalars['Boolean']['output']>;

--- a/src/examples/microsoft-entra/src/types.generated.ts
+++ b/src/examples/microsoft-entra/src/types.generated.ts
@@ -71,12 +71,21 @@ export type AdminUiFieldExtensionsMetadata = {
   key?: Maybe<Scalars['String']['output']>;
 };
 
+export type AdminUiFieldFormatMetadata = {
+  __typename?: 'AdminUiFieldFormatMetadata';
+  format?: Maybe<Scalars['String']['output']>;
+  timezone?: Maybe<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
+  variant?: Maybe<Scalars['String']['output']>;
+};
+
 export type AdminUiFieldMetadata = {
   __typename?: 'AdminUiFieldMetadata';
   attributes?: Maybe<AdminUiFieldAttributeMetadata>;
   detailPanelInputComponent?: Maybe<DetailPanelInputComponent>;
   extensions?: Maybe<AdminUiFieldExtensionsMetadata>;
   filter?: Maybe<AdminUiFilterMetadata>;
+  format?: Maybe<AdminUiFieldFormatMetadata>;
   hideInDetailForm?: Maybe<Scalars['Boolean']['output']>;
   hideInFilterBar?: Maybe<Scalars['Boolean']['output']>;
   hideInTable?: Maybe<Scalars['Boolean']['output']>;

--- a/src/examples/okta/src/frontend/types.generated.ts
+++ b/src/examples/okta/src/frontend/types.generated.ts
@@ -71,12 +71,21 @@ export type AdminUiFieldExtensionsMetadata = {
   key?: Maybe<Scalars['String']['output']>;
 };
 
+export type AdminUiFieldFormatMetadata = {
+  __typename?: 'AdminUiFieldFormatMetadata';
+  format?: Maybe<Scalars['String']['output']>;
+  timezone?: Maybe<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
+  variant?: Maybe<Scalars['String']['output']>;
+};
+
 export type AdminUiFieldMetadata = {
   __typename?: 'AdminUiFieldMetadata';
   attributes?: Maybe<AdminUiFieldAttributeMetadata>;
   detailPanelInputComponent?: Maybe<DetailPanelInputComponent>;
   extensions?: Maybe<AdminUiFieldExtensionsMetadata>;
   filter?: Maybe<AdminUiFilterMetadata>;
+  format?: Maybe<AdminUiFieldFormatMetadata>;
   hideInDetailForm?: Maybe<Scalars['Boolean']['output']>;
   hideInFilterBar?: Maybe<Scalars['Boolean']['output']>;
   hideInTable?: Maybe<Scalars['Boolean']['output']>;

--- a/src/examples/okta/src/types.generated.ts
+++ b/src/examples/okta/src/types.generated.ts
@@ -71,12 +71,21 @@ export type AdminUiFieldExtensionsMetadata = {
   key?: Maybe<Scalars['String']['output']>;
 };
 
+export type AdminUiFieldFormatMetadata = {
+  __typename?: 'AdminUiFieldFormatMetadata';
+  format?: Maybe<Scalars['String']['output']>;
+  timezone?: Maybe<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
+  variant?: Maybe<Scalars['String']['output']>;
+};
+
 export type AdminUiFieldMetadata = {
   __typename?: 'AdminUiFieldMetadata';
   attributes?: Maybe<AdminUiFieldAttributeMetadata>;
   detailPanelInputComponent?: Maybe<DetailPanelInputComponent>;
   extensions?: Maybe<AdminUiFieldExtensionsMetadata>;
   filter?: Maybe<AdminUiFilterMetadata>;
+  format?: Maybe<AdminUiFieldFormatMetadata>;
   hideInDetailForm?: Maybe<Scalars['Boolean']['output']>;
   hideInFilterBar?: Maybe<Scalars['Boolean']['output']>;
   hideInTable?: Maybe<Scalars['Boolean']['output']>;

--- a/src/examples/rest-with-auth/src/frontend/types.generated.ts
+++ b/src/examples/rest-with-auth/src/frontend/types.generated.ts
@@ -73,12 +73,21 @@ export type AdminUiFieldExtensionsMetadata = {
   key?: Maybe<Scalars['String']['output']>;
 };
 
+export type AdminUiFieldFormatMetadata = {
+  __typename?: 'AdminUiFieldFormatMetadata';
+  format?: Maybe<Scalars['String']['output']>;
+  timezone?: Maybe<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
+  variant?: Maybe<Scalars['String']['output']>;
+};
+
 export type AdminUiFieldMetadata = {
   __typename?: 'AdminUiFieldMetadata';
   attributes?: Maybe<AdminUiFieldAttributeMetadata>;
   detailPanelInputComponent?: Maybe<DetailPanelInputComponent>;
   extensions?: Maybe<AdminUiFieldExtensionsMetadata>;
   filter?: Maybe<AdminUiFilterMetadata>;
+  format?: Maybe<AdminUiFieldFormatMetadata>;
   hideInDetailForm?: Maybe<Scalars['Boolean']['output']>;
   hideInFilterBar?: Maybe<Scalars['Boolean']['output']>;
   hideInTable?: Maybe<Scalars['Boolean']['output']>;

--- a/src/examples/rest-with-auth/src/types.generated.ts
+++ b/src/examples/rest-with-auth/src/types.generated.ts
@@ -73,12 +73,21 @@ export type AdminUiFieldExtensionsMetadata = {
   key?: Maybe<Scalars['String']['output']>;
 };
 
+export type AdminUiFieldFormatMetadata = {
+  __typename?: 'AdminUiFieldFormatMetadata';
+  format?: Maybe<Scalars['String']['output']>;
+  timezone?: Maybe<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
+  variant?: Maybe<Scalars['String']['output']>;
+};
+
 export type AdminUiFieldMetadata = {
   __typename?: 'AdminUiFieldMetadata';
   attributes?: Maybe<AdminUiFieldAttributeMetadata>;
   detailPanelInputComponent?: Maybe<DetailPanelInputComponent>;
   extensions?: Maybe<AdminUiFieldExtensionsMetadata>;
   filter?: Maybe<AdminUiFilterMetadata>;
+  format?: Maybe<AdminUiFieldFormatMetadata>;
   hideInDetailForm?: Maybe<Scalars['Boolean']['output']>;
   hideInFilterBar?: Maybe<Scalars['Boolean']['output']>;
   hideInTable?: Maybe<Scalars['Boolean']['output']>;

--- a/src/examples/rest-with-auth/types.generated.ts
+++ b/src/examples/rest-with-auth/types.generated.ts
@@ -73,12 +73,21 @@ export type AdminUiFieldExtensionsMetadata = {
   key?: Maybe<Scalars['String']['output']>;
 };
 
+export type AdminUiFieldFormatMetadata = {
+  __typename?: 'AdminUiFieldFormatMetadata';
+  format?: Maybe<Scalars['String']['output']>;
+  timezone?: Maybe<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
+  variant?: Maybe<Scalars['String']['output']>;
+};
+
 export type AdminUiFieldMetadata = {
   __typename?: 'AdminUiFieldMetadata';
   attributes?: Maybe<AdminUiFieldAttributeMetadata>;
   detailPanelInputComponent?: Maybe<DetailPanelInputComponent>;
   extensions?: Maybe<AdminUiFieldExtensionsMetadata>;
   filter?: Maybe<AdminUiFilterMetadata>;
+  format?: Maybe<AdminUiFieldFormatMetadata>;
   hideInDetailForm?: Maybe<Scalars['Boolean']['output']>;
   hideInFilterBar?: Maybe<Scalars['Boolean']['output']>;
   hideInTable?: Maybe<Scalars['Boolean']['output']>;

--- a/src/examples/rest/src/frontend/types.generated.ts
+++ b/src/examples/rest/src/frontend/types.generated.ts
@@ -69,12 +69,21 @@ export type AdminUiFieldExtensionsMetadata = {
   key?: Maybe<Scalars['String']['output']>;
 };
 
+export type AdminUiFieldFormatMetadata = {
+  __typename?: 'AdminUiFieldFormatMetadata';
+  format?: Maybe<Scalars['String']['output']>;
+  timezone?: Maybe<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
+  variant?: Maybe<Scalars['String']['output']>;
+};
+
 export type AdminUiFieldMetadata = {
   __typename?: 'AdminUiFieldMetadata';
   attributes?: Maybe<AdminUiFieldAttributeMetadata>;
   detailPanelInputComponent?: Maybe<DetailPanelInputComponent>;
   extensions?: Maybe<AdminUiFieldExtensionsMetadata>;
   filter?: Maybe<AdminUiFilterMetadata>;
+  format?: Maybe<AdminUiFieldFormatMetadata>;
   hideInDetailForm?: Maybe<Scalars['Boolean']['output']>;
   hideInFilterBar?: Maybe<Scalars['Boolean']['output']>;
   hideInTable?: Maybe<Scalars['Boolean']['output']>;

--- a/src/examples/rest/src/types.generated.ts
+++ b/src/examples/rest/src/types.generated.ts
@@ -69,12 +69,21 @@ export type AdminUiFieldExtensionsMetadata = {
   key?: Maybe<Scalars['String']['output']>;
 };
 
+export type AdminUiFieldFormatMetadata = {
+  __typename?: 'AdminUiFieldFormatMetadata';
+  format?: Maybe<Scalars['String']['output']>;
+  timezone?: Maybe<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
+  variant?: Maybe<Scalars['String']['output']>;
+};
+
 export type AdminUiFieldMetadata = {
   __typename?: 'AdminUiFieldMetadata';
   attributes?: Maybe<AdminUiFieldAttributeMetadata>;
   detailPanelInputComponent?: Maybe<DetailPanelInputComponent>;
   extensions?: Maybe<AdminUiFieldExtensionsMetadata>;
   filter?: Maybe<AdminUiFilterMetadata>;
+  format?: Maybe<AdminUiFieldFormatMetadata>;
   hideInDetailForm?: Maybe<Scalars['Boolean']['output']>;
   hideInFilterBar?: Maybe<Scalars['Boolean']['output']>;
   hideInTable?: Maybe<Scalars['Boolean']['output']>;

--- a/src/examples/sqlite/src/backend/schema/employee.ts
+++ b/src/examples/sqlite/src/backend/schema/employee.ts
@@ -27,10 +27,20 @@ export class Employee {
 	})
 	employee?: Employee;
 
-	@Field(() => ISODateStringScalar, { nullable: true })
+	@Field(() => ISODateStringScalar, {
+		nullable: true,
+		adminUIOptions: {
+			format: { type: 'date', timezone: 'Australia/Sydney', format: 'DATE_MED' },
+		},
+	})
 	birthDate?: Date;
 
-	@Field(() => ISODateStringScalar, { nullable: true })
+	@Field(() => ISODateStringScalar, {
+		nullable: true,
+		adminUIOptions: {
+			format: { type: 'date', timezone: 'Australia/Sydney', format: 'DATE_MED_WITH_WEEKDAY' },
+		},
+	})
 	hireDate?: Date;
 
 	@Field(() => String, { nullable: true })

--- a/src/examples/sqlite/src/backend/schema/invoice-line.ts
+++ b/src/examples/sqlite/src/backend/schema/invoice-line.ts
@@ -20,7 +20,11 @@ export class InvoiceLine {
 	@RelationshipField<InvoiceLine>(() => Track, { id: (entity) => entity.track?.trackId })
 	track!: Track;
 
-	@Field(() => String)
+	@Field(() => String, {
+		adminUIOptions: {
+			format: { type: 'currency', variant: 'AUD' },
+		},
+	})
 	unitPrice!: string;
 
 	@Field(() => Number)

--- a/src/examples/sqlite/src/frontend/types.generated.ts
+++ b/src/examples/sqlite/src/frontend/types.generated.ts
@@ -75,12 +75,21 @@ export type AdminUiFieldExtensionsMetadata = {
   key?: Maybe<Scalars['String']['output']>;
 };
 
+export type AdminUiFieldFormatMetadata = {
+  __typename?: 'AdminUiFieldFormatMetadata';
+  format?: Maybe<Scalars['String']['output']>;
+  timezone?: Maybe<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
+  variant?: Maybe<Scalars['String']['output']>;
+};
+
 export type AdminUiFieldMetadata = {
   __typename?: 'AdminUiFieldMetadata';
   attributes?: Maybe<AdminUiFieldAttributeMetadata>;
   detailPanelInputComponent?: Maybe<DetailPanelInputComponent>;
   extensions?: Maybe<AdminUiFieldExtensionsMetadata>;
   filter?: Maybe<AdminUiFilterMetadata>;
+  format?: Maybe<AdminUiFieldFormatMetadata>;
   hideInDetailForm?: Maybe<Scalars['Boolean']['output']>;
   hideInFilterBar?: Maybe<Scalars['Boolean']['output']>;
   hideInTable?: Maybe<Scalars['Boolean']['output']>;

--- a/src/examples/sqlite/src/types.generated.ts
+++ b/src/examples/sqlite/src/types.generated.ts
@@ -75,12 +75,21 @@ export type AdminUiFieldExtensionsMetadata = {
   key?: Maybe<Scalars['String']['output']>;
 };
 
+export type AdminUiFieldFormatMetadata = {
+  __typename?: 'AdminUiFieldFormatMetadata';
+  format?: Maybe<Scalars['String']['output']>;
+  timezone?: Maybe<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
+  variant?: Maybe<Scalars['String']['output']>;
+};
+
 export type AdminUiFieldMetadata = {
   __typename?: 'AdminUiFieldMetadata';
   attributes?: Maybe<AdminUiFieldAttributeMetadata>;
   detailPanelInputComponent?: Maybe<DetailPanelInputComponent>;
   extensions?: Maybe<AdminUiFieldExtensionsMetadata>;
   filter?: Maybe<AdminUiFilterMetadata>;
+  format?: Maybe<AdminUiFieldFormatMetadata>;
   hideInDetailForm?: Maybe<Scalars['Boolean']['output']>;
   hideInFilterBar?: Maybe<Scalars['Boolean']['output']>;
   hideInTable?: Maybe<Scalars['Boolean']['output']>;

--- a/src/packages/admin-ui-components/src/utils/graphql.ts
+++ b/src/packages/admin-ui-components/src/utils/graphql.ts
@@ -28,6 +28,12 @@ export const SCHEMA_QUERY = gql`
 						type
 						options
 					}
+					format {
+						type
+						timezone
+						format
+						variant
+					}
 					attributes {
 						isReadOnly
 						isRequired

--- a/src/packages/admin-ui-components/src/utils/use-schema.ts
+++ b/src/packages/admin-ui-components/src/utils/use-schema.ts
@@ -90,6 +90,41 @@ export interface DetailPanelInputComponent {
 	options?: Record<string, unknown>;
 }
 
+export type DateTimeFormat =
+	| 'DATETIME_FULL'
+	| 'DATETIME_FULL_WITH_SECONDS'
+	| 'DATETIME_HUGE'
+	| 'DATETIME_HUGE_WITH_SECONDS'
+	| 'DATETIME_MED'
+	| 'DATETIME_MED_WITH_SECONDS'
+	| 'DATETIME_MED_WITH_WEEKDAY'
+	| 'DATETIME_SHORT'
+	| 'DATETIME_SHORT_WITH_SECONDS'
+	| 'DATE_FULL'
+	| 'DATE_HUGE'
+	| 'DATE_MED'
+	| 'DATE_MED_WITH_WEEKDAY'
+	| 'DATE_SHORT'
+	| 'TIME_24_SIMPLE'
+	| 'TIME_24_WITH_LONG_OFFSET'
+	| 'TIME_24_WITH_SHORT_OFFSET'
+	| 'TIME_24_WITH_SECONDS'
+	| 'TIME_WITH_LONG_OFFSET'
+	| 'TIME_WITH_SHORT_OFFSET'
+	| 'TIME_SIMPLE'
+	| 'TIME_WITH_SECONDS';
+
+export type CellFormatOptions =
+	| {
+			type: 'date';
+			timezone?: 'UTC' | 'local' | string;
+			format?: DateTimeFormat;
+	  }
+	| {
+			type: 'currency';
+			variant: 'AUD' | 'GBP' | 'USD' | 'JPY' | 'EUR' | 'CHF' | 'THB' | 'IDR' | string;
+	  };
+
 export interface EntityField {
 	name: string;
 	type: EntityFieldType;
@@ -101,6 +136,7 @@ export interface EntityField {
 	};
 	attributes?: EntityFieldAttributes;
 	initialValue?: string | number | boolean;
+	format?: CellFormatOptions;
 	extensions?: {
 		key: string;
 	};

--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -31,6 +31,7 @@
 		"@opentelemetry/resources": "1.30.1",
 		"@opentelemetry/sdk-node": "0.57.2",
 		"@opentelemetry/sdk-trace-base": "1.30.1",
+		"@types/luxon": "3.6.2",
 		"async-mutex": "0.5.0",
 		"class-validator": "0.14.1",
 		"dataloader": "2.2.3",

--- a/src/packages/core/src/decorators/field.ts
+++ b/src/packages/core/src/decorators/field.ts
@@ -86,6 +86,41 @@ export interface DetailPanelInputComponent {
 	};
 }
 
+export type DateTimeFormat =
+	| 'DATETIME_FULL'
+	| 'DATETIME_FULL_WITH_SECONDS'
+	| 'DATETIME_HUGE'
+	| 'DATETIME_HUGE_WITH_SECONDS'
+	| 'DATETIME_MED'
+	| 'DATETIME_MED_WITH_SECONDS'
+	| 'DATETIME_MED_WITH_WEEKDAY'
+	| 'DATETIME_SHORT'
+	| 'DATETIME_SHORT_WITH_SECONDS'
+	| 'DATE_FULL'
+	| 'DATE_HUGE'
+	| 'DATE_MED'
+	| 'DATE_MED_WITH_WEEKDAY'
+	| 'DATE_SHORT'
+	| 'TIME_24_SIMPLE'
+	| 'TIME_24_WITH_LONG_OFFSET'
+	| 'TIME_24_WITH_SHORT_OFFSET'
+	| 'TIME_24_WITH_SECONDS'
+	| 'TIME_WITH_LONG_OFFSET'
+	| 'TIME_WITH_SHORT_OFFSET'
+	| 'TIME_SIMPLE'
+	| 'TIME_WITH_SECONDS';
+
+export type CellFormatOptions =
+	| {
+			type: 'date';
+			timezone?: 'UTC' | 'local' | string;
+			format?: DateTimeFormat;
+	  }
+	| {
+			type: 'currency';
+			variant: 'AUD' | 'GBP' | 'USD' | 'JPY' | 'EUR' | 'CHF' | 'THB' | 'IDR' | string;
+	  };
+
 export interface FieldOptions {
 	description?: string;
 	deprecationReason?: string;
@@ -107,6 +142,7 @@ export interface FieldOptions {
 		readonly?: boolean;
 		summaryField?: boolean;
 		fieldForDetailPanelNavigationId?: boolean;
+		format?: CellFormatOptions;
 
 		/**
 		 * Specifies a component to be utilized as input in the detail panel for this field.

--- a/src/packages/core/src/metadata-service/field-format.ts
+++ b/src/packages/core/src/metadata-service/field-format.ts
@@ -1,0 +1,18 @@
+import { DateTimeFormat, Entity, Field } from '../decorators';
+
+@Entity('AdminUiFieldFormatMetadata', {
+	apiOptions: { excludeFromBuiltInOperations: true, excludeFromFederation: true },
+})
+export class AdminUiFieldFormatMetadata {
+	@Field(() => String, { nullable: false })
+	type!: 'date' | 'currency';
+
+	@Field(() => String, { nullable: true })
+	timezone?: string;
+
+	@Field(() => String, { nullable: true })
+	format?: DateTimeFormat;
+
+	@Field(() => String, { nullable: true })
+	variant?: string;
+}

--- a/src/packages/core/src/metadata-service/field.ts
+++ b/src/packages/core/src/metadata-service/field.ts
@@ -1,9 +1,10 @@
+import { GraphQLJSON } from '@exogee/graphweaver-scalars';
 import { DetailPanelInputComponentOption, Entity, Field } from '../decorators';
-import { AdminUiFilterMetadata } from './filter';
+import { graphweaverMetadata } from '../metadata';
 import { AdminUiFieldAttributeMetadata } from './field-attribute';
 import { AdminUiFieldExtensionsMetadata } from './field-extensions';
-import { graphweaverMetadata } from '../metadata';
-import { GraphQLJSON } from '@exogee/graphweaver-scalars';
+import { AdminUiFieldFormatMetadata } from './field-format';
+import { AdminUiFilterMetadata } from './filter';
 
 graphweaverMetadata.collectEnumInformation({
 	name: 'DetailPanelInputComponentOption',
@@ -39,6 +40,9 @@ export class AdminUiFieldMetadata {
 
 	@Field(() => AdminUiFilterMetadata, { nullable: true })
 	filter?: AdminUiFilterMetadata;
+
+	@Field(() => AdminUiFieldFormatMetadata, { nullable: true })
+	format?: AdminUiFieldFormatMetadata;
 
 	@Field(() => AdminUiFieldAttributeMetadata, { nullable: true })
 	attributes?: AdminUiFieldAttributeMetadata;

--- a/src/packages/core/src/metadata-service/resolver.ts
+++ b/src/packages/core/src/metadata-service/resolver.ts
@@ -116,6 +116,7 @@ export const resolveAdminUiMetadata = (hooks?: Hooks) => {
 						isReadOnly,
 						isRequired,
 					},
+					format: field.adminUIOptions?.format,
 					hideInTable: field.adminUIOptions?.hideInTable,
 					hideInFilterBar: field.adminUIOptions?.hideInFilterBar,
 					hideInDetailForm: field.adminUIOptions?.hideInDetailForm,

--- a/src/packages/core/src/types.ts
+++ b/src/packages/core/src/types.ts
@@ -4,7 +4,11 @@ import { GraphQLID, GraphQLResolveInfo, GraphQLScalarType, Source } from 'graphq
 import { ResolveTree } from 'graphql-parse-resolve-info';
 import { ComplexityEstimator } from 'graphql-query-complexity';
 import { EntityMetadata } from './metadata';
-import { DetailPanelInputComponent, DetailPanelInputComponentOption } from './decorators';
+import {
+	CellFormatOptions,
+	DetailPanelInputComponent,
+	DetailPanelInputComponentOption,
+} from './decorators';
 
 export type { Instrumentation } from '@opentelemetry/instrumentation';
 export type { GraphQLResolveInfo } from 'graphql';
@@ -255,6 +259,7 @@ export interface FieldMetadata<G = unknown, D = unknown> {
 		filterType?: AdminUIFilterType;
 		filterOptions?: Record<string, unknown>;
 		detailPanelInputComponent?: DetailPanelInputComponentOption | DetailPanelInputComponent;
+		format?: CellFormatOptions;
 	};
 	apiOptions?: {
 		excludeFromBuiltInWriteOperations?: boolean;

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -1329,6 +1329,9 @@ importers:
       '@opentelemetry/sdk-trace-base':
         specifier: 1.30.1
         version: 1.30.1(@opentelemetry/api@1.9.0)
+      '@types/luxon':
+        specifier: 3.6.2
+        version: 3.6.2
       async-mutex:
         specifier: 0.5.0
         version: 0.5.0


### PR DESCRIPTION
This pull request introduces the `AdminUiFieldFormatMetadata` type to enhance field formatting options across multiple examples and updates the `AdminUiFieldMetadata` type to include a new `format` property. Additionally, it modifies the admin UI components to support formatting for dates and currencies. Below is a breakdown of the most important changes:

### Type Enhancements
* Added `AdminUiFieldFormatMetadata` type with properties for `format`, `timezone`, `type`, and `variant` across various `types.generated.ts` files in multiple examples, including `auth-zero`, `aws-cognito`, `federation`, `microsoft-entra`, `okta`, `rest-with-auth`, and `rest`. This type enables more granular control over field formatting. [[1]](diffhunk://#diff-28038da5dba8a8164b172b50bf670c35c2f41f5b75961e0619bb48c5c406d8d4R74-R88) [[2]](diffhunk://#diff-bbdc3ad2640803547d5b6d264fd10550203d35ef8c27c2b3c369ee65e6b99871R72-R86) [[3]](diffhunk://#diff-e7c5182ea60de952adfcc6f098c67f5614f8a1bdde9cad5e6fa308ca94cead34R75-R89) [[4]](diffhunk://#diff-895b6ab61567fbbdb219631145c4c179b8c8f1a2cb1a84536cc0d4b3c53c4978R76-R90) [[5]](diffhunk://#diff-9cf08fa3c8f7305f4e3802c20b028185c0a7796a421f92be2e5df531af18f1edR72-R86) [[6]](diffhunk://#diff-549982c4c2832c951d2d3a9c1bc71a85c47de2cd79a7c600a30e1097a75f058fR78-R92)

### Admin UI Updates
* Updated the `AdminUiFieldMetadata` type to include a new `format` property, linking it to the `AdminUiFieldFormatMetadata` type. This change ensures fields can specify formatting metadata for display purposes. [[1]](diffhunk://#diff-28038da5dba8a8164b172b50bf670c35c2f41f5b75961e0619bb48c5c406d8d4R74-R88) [[2]](diffhunk://#diff-bbdc3ad2640803547d5b6d264fd10550203d35ef8c27c2b3c369ee65e6b99871R72-R86) [[3]](diffhunk://#diff-e7c5182ea60de952adfcc6f098c67f5614f8a1bdde9cad5e6fa308ca94cead34R75-R89) [[4]](diffhunk://#diff-895b6ab61567fbbdb219631145c4c179b8c8f1a2cb1a84536cc0d4b3c53c4978R76-R90) [[5]](diffhunk://#diff-9cf08fa3c8f7305f4e3802c20b028185c0a7796a421f92be2e5df531af18f1edR72-R86) [[6]](diffhunk://#diff-549982c4c2832c951d2d3a9c1bc71a85c47de2cd79a7c600a30e1097a75f058fR78-R92)

### Backend Schema Changes
* Enhanced the `Employee` class in `sqlite` schema to include `adminUIOptions` for `birthDate` and `hireDate` fields, specifying date formats and timezones.
* Updated the `InvoiceLine` class in `sqlite` schema to include `adminUIOptions` for the `unitPrice` field, enabling currency formatting.

### Admin UI Component Enhancements
* Introduced the `formatValue` function in `src/packages/admin-ui-components/src/entity-list/columns.tsx` to handle field formatting for dates and currencies using the `luxon` library.
* Modified `cellForType` function to apply formatting for array values and simple values using the `formatValue` function. [[1]](diffhunk://#diff-1a20a99aa4c25a34158ce3194326584269e01f49c1f66697dac548030ea09c7fL47-R74) [[2]](diffhunk://#diff-1a20a99aa4c25a34158ce3194326584269e01f49c1f66697dac548030ea09c7fL62-R89)