### PR TITLE
Fix / Clean Filters Before Passing to Providers

### DIFF
--- a/src/packages/core/src/utils/clean-filter.test.ts
+++ b/src/packages/core/src/utils/clean-filter.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { cleanFilter } from './clean-filter';
+
+describe('cleanFilter', () => {
+	it('should remove undefined values', () => {
+		expect(
+			cleanFilter<{ name: string }>({
+				name: undefined,
+			})
+		).toEqual(undefined);
+	});
+
+	it('should remove null values', () => {
+		expect(
+			cleanFilter<{ name: string }>({
+				name: null,
+			} as any)
+		).toEqual(undefined);
+	});
+
+	it('should hoist _and and _or values with one item in them', () => {
+		expect(
+			cleanFilter<{ name: string }>({
+				_and: [
+					{
+						name: 'test',
+					},
+				],
+			})
+		).toEqual({ name: 'test' });
+
+		expect(
+			cleanFilter<{ name: string }>({
+				_or: [
+					{
+						name: 'test',
+					},
+				],
+			})
+		).toEqual({ name: 'test' });
+	});
+
+	it('should remove empties and hoist at the same time', () => {
+		expect(
+			cleanFilter<{ name: string }>({
+				_and: [
+					{
+						name: 'test',
+					},
+					{
+						_and: [null] as any,
+					},
+				],
+			})
+		).toEqual({ name: 'test' });
+		expect(
+			cleanFilter<{ name: string }>({
+				_or: [
+					{
+						name: 'test',
+					},
+					{
+						_or: [null] as any,
+					},
+				],
+			})
+		).toEqual({ name: 'test' });
+	});
+
+	it('should handle a specific case seen in production', () => {
+		expect(
+			cleanFilter<{ users: { _in: string[] } }>({
+				_and: [
+					{
+						users: {
+							_in: ['1', '2'],
+						},
+					},
+					{
+						_and: [null] as any,
+					},
+				],
+			})
+		).toEqual({
+			users: {
+				_in: ['1', '2'],
+			},
+		});
+	});
+
+	it('should recurse into arrays and do the same stuff', () => {
+		expect(
+			cleanFilter<{ users: { _in: string[] } }>({
+				_and: [
+					{
+						users: {
+							_in: [null] as any,
+						},
+					},
+					{
+						_and: [null] as any,
+					},
+				],
+			})
+		).toEqual(undefined);
+	});
+
+	it('should leave complex valid queries alone', () => {
+		const filter = {
+			_and: [
+				{
+					users: {
+						_in: ['1', '2'],
+					},
+				},
+				{
+					_and: [
+						{ users: { name: 'test', email: 'test@test.com' } },
+						{ users: { name: 'test2', email: 'test2@test.com' } },
+					] as any,
+				},
+			],
+		};
+
+		expect(cleanFilter<{ users: { _in: string[] } }>(filter)).toEqual(filter);
+	});
+});

--- a/src/packages/core/src/utils/clean-filter.ts
+++ b/src/packages/core/src/utils/clean-filter.ts
@@ -1,0 +1,65 @@
+import { Filter } from '../types';
+
+export const cleanFilter = <G>(filter: Filter<G> | undefined): Filter<G> | undefined => {
+	if (filter == null) return undefined;
+
+	// If it's not an object, return as is
+	if (typeof filter !== 'object' || Array.isArray(filter)) {
+		return filter;
+	}
+
+	const cleanedFilter: any = {};
+	let hasValidProperty = false;
+
+	for (const [key, value] of Object.entries(filter)) {
+		// Skip null and undefined values
+		if (value == null) continue;
+
+		// Handle _and and _or arrays
+		if ((key === '_and' || key === '_or') && Array.isArray(value)) {
+			// Recursively clean each item in the array
+			const cleanedItems = value.map((item) => cleanFilter(item)).filter((item) => item != null); // Remove null/undefined results
+
+			// If no valid items remain, skip this property
+			if (cleanedItems.length === 0) continue;
+
+			// If only one item remains, hoist it up instead of keeping the array
+			if (cleanedItems.length === 1) {
+				// Merge the single item into the current filter instead of using _and/_or
+				const singleItem = cleanedItems[0];
+				if (typeof singleItem === 'object' && !Array.isArray(singleItem)) {
+					Object.assign(cleanedFilter, singleItem);
+					hasValidProperty = true;
+					continue;
+				}
+			}
+
+			// Multiple items remain, keep the array
+			cleanedFilter[key] = cleanedItems;
+			hasValidProperty = true;
+		} else if (Array.isArray(value)) {
+			// Handle regular arrays (not _and/_or) - clean them by removing null/undefined values
+			const cleanedArray = value.filter((item) => item != null);
+
+			// If the array becomes empty, skip this property
+			if (cleanedArray.length === 0) continue;
+
+			cleanedFilter[key] = cleanedArray;
+			hasValidProperty = true;
+		} else if (typeof value === 'object' && !Array.isArray(value)) {
+			// Recursively clean nested objects
+			const cleanedValue = cleanFilter(value);
+			if (cleanedValue != null) {
+				cleanedFilter[key] = cleanedValue;
+				hasValidProperty = true;
+			}
+		} else {
+			// Keep primitive values as they are
+			cleanedFilter[key] = value;
+			hasValidProperty = true;
+		}
+	}
+
+	// Return undefined if no valid properties remain
+	return hasValidProperty ? cleanedFilter : undefined;
+};

--- a/src/packages/core/src/utils/index.ts
+++ b/src/packages/core/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './apply-default-values';
+export * from './clean-filter';
 export * from './has-id';
 export * from './plural';
 export * from './with-transaction';


### PR DESCRIPTION
Add a cleaner function to filter to remove nonsensical values and simplify the lives of the providers significantly.

They are semantically identical, but there's no reason to make each provider dig through that to understand what we mean. We now simplify filters to just the parts that actually matter.