### PR TITLE
Fix / Misleading error message

### DIFF
--- a/src/packages/core/src/metadata.ts
+++ b/src/packages/core/src/metadata.ts
@@ -460,7 +460,7 @@ class Metadata {
 		if (args.primaryKeyField) {
 			if (existingMetadata.primaryKeyField && existingMetadata.primaryKeyField !== args.name) {
 				throw new Error(
-					`Entities can only declare one primary key field. An attempt was made to set ${args.name} as the primary key for ${entity.name} while ${entity.primaryKeyField} is already set.`
+					`Entities can only declare one primary key field. An attempt was made to set ${args.name} as the primary key for ${entity.name} while ${String(existingMetadata.primaryKeyField)} is already set.`
 				);
 			}
 


### PR DESCRIPTION
When this would trigger you'd see:

```
Error: Entities can only declare one primary key field. An attempt was made to set [field name] as the primary key for [Entity] while undefined is already set.
```

This is not helpful, the `undefined` should show the name of the property that's currently set.