### PR TITLE
Fix / Secrets Manager SDK is required even when not using the secret ARN feature.

### DIFF
--- a/src/packages/mikroorm/src/database.ts
+++ b/src/packages/mikroorm/src/database.ts
@@ -10,7 +10,6 @@ import {
 	ReflectMetadataProvider,
 } from '@mikro-orm/core';
 import { logger } from '@exogee/logger';
-import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
 
 import type { EntityManager as PgEntityManager, PostgreSqlDriver } from '@mikro-orm/postgresql';
 import type { EntityManager as MyEntityManager, MySqlDriver } from '@mikro-orm/mysql';
@@ -144,6 +143,16 @@ class DatabaseImplementation {
 		logger.trace('Database::getEnvironmentOverrides() - Enter');
 		const secret = secretArn ?? process.env.DATABASE_SECRET_ARN;
 		if (secret) {
+			const { SecretsManagerClient, GetSecretValueCommand } = await import(
+				'@aws-sdk/client-secrets-manager'
+			);
+
+			if (!SecretsManagerClient || !GetSecretValueCommand) {
+				throw new Error(
+					'SecretsManagerClient or GetSecretValueCommand not found but a secret ARN was provided. Is @aws-sdk/client-secrets-manager available?'
+				);
+			}
+
 			const client = new SecretsManagerClient({
 				region: process.env.AWS_REGION,
 			});


### PR DESCRIPTION
Moved to async load of secrets manager SDK so that it's only loaded if the developer actually configures the secret ARN.