### PR TITLE
Fix / Make drivers optional peer dependencies instead of optional dependencies

### DIFF
--- a/src/packages/mikroorm/package.json
+++ b/src/packages/mikroorm/package.json
@@ -38,7 +38,25 @@
 	"peerDependencies": {
 		"@mikro-orm/core": "6",
 		"@mikro-orm/knex": "6",
+		"@mikro-orm/mssql": "6",
+		"@mikro-orm/mysql": "6",
+		"@mikro-orm/postgresql": "6",
+		"@mikro-orm/sqlite": "6",
 		"graphql": "16"
+	},
+	"peerDependenciesMeta": {
+		"@mikro-orm/mssql": {
+			"optional": true
+		},
+		"@mikro-orm/mysql": {
+			"optional": true
+		},
+		"@mikro-orm/postgresql": {
+			"optional": true
+		},
+		"@mikro-orm/sqlite": {
+			"optional": true
+		}
 	},
 	"devDependencies": {
 		"@mikro-orm/core": "6.4.16",
@@ -55,13 +73,6 @@
 		"tsx": "4.19.3",
 		"typescript": "5.8.3",
 		"vitest": "3.0.9"
-	},
-	"optionalDependencies": {
-		"@mikro-orm/knex": "^6.4.16",
-		"@mikro-orm/mssql": "^6.4.16",
-		"@mikro-orm/mysql": "^6.4.16",
-		"@mikro-orm/postgresql": "^6.4.16",
-		"@mikro-orm/sqlite": "^6.4.16"
 	},
 	"keywords": [
 		"graphql",

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -1659,12 +1659,15 @@ importers:
       reflect-metadata:
         specifier: 0.2.2
         version: 0.2.2
-    optionalDependencies:
+    devDependencies:
+      '@mikro-orm/core':
+        specifier: 6.4.16
+        version: 6.4.16
       '@mikro-orm/knex':
         specifier: 6.4.16
         version: 6.4.16(@mikro-orm/core@6.4.16)(mysql2@3.14.0)(pg@8.16.0)
       '@mikro-orm/mssql':
-        specifier: ^6.4.16
+        specifier: 6.4.16
         version: 6.4.16(@mikro-orm/core@6.4.16)(pg@8.16.0)
       '@mikro-orm/mysql':
         specifier: 6.4.16
@@ -1675,10 +1678,6 @@ importers:
       '@mikro-orm/sqlite':
         specifier: 6.4.16
         version: 6.4.16(@mikro-orm/core@6.4.16)(pg@8.16.0)
-    devDependencies:
-      '@mikro-orm/core':
-        specifier: 6.4.16
-        version: 6.4.16
       '@types/node':
         specifier: 22.13.14
         version: 22.13.14
@@ -2973,8 +2972,8 @@ packages:
   '@codemirror/state@6.5.2':
     resolution: {integrity: sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==}
 
-  '@codemirror/view@6.38.0':
-    resolution: {integrity: sha512-yvSchUwHOdupXkd7xJ0ob36jdsSR/I+/C+VbY0ffBiL5NiSTEBDfB1ZGWbbIlDd5xgdUkody+lukAdOxYrOBeg==}
+  '@codemirror/view@6.38.1':
+    resolution: {integrity: sha512-RmTOkE7hRU3OVREqFVITWHz6ocgBjv08GoePscAakgVQfciA3SGCEk7mb9IzwW61cKKmlTpHXG6DUE5Ubx+MGQ==}
 
   '@date-fns/tz@1.2.0':
     resolution: {integrity: sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==}
@@ -7936,6 +7935,10 @@ packages:
 
   form-data@4.0.3:
     resolution: {integrity: sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==}
+    engines: {node: '>= 6'}
+
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
   format@0.2.2:
@@ -13825,7 +13828,7 @@ snapshots:
   '@codemirror/language@6.0.0':
     dependencies:
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.0
+      '@codemirror/view': 6.38.1
       '@lezer/common': 1.2.3
       '@lezer/highlight': 1.2.1
       '@lezer/lr': 1.4.2
@@ -13835,7 +13838,7 @@ snapshots:
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
 
-  '@codemirror/view@6.38.0':
+  '@codemirror/view@6.38.1':
     dependencies:
       '@codemirror/state': 6.5.2
       crelt: 1.0.6
@@ -16210,7 +16213,6 @@ snapshots:
       - sqlite3
       - supports-color
       - tedious
-    optional: true
 
   '@mikro-orm/knex@6.4.16(@mikro-orm/core@6.4.16)(mysql2@3.14.1)(tedious@18.6.1)':
     dependencies:
@@ -16271,7 +16273,6 @@ snapshots:
       - sqlite3
       - supports-color
       - tedious
-    optional: true
 
   '@mikro-orm/knex@6.4.16(@mikro-orm/core@6.4.16)(pg@8.16.0)(tedious@18.6.1)':
     dependencies:
@@ -16303,7 +16304,6 @@ snapshots:
       - sqlite3
       - supports-color
       - tedious
-    optional: true
 
   '@mikro-orm/knex@6.4.16(@mikro-orm/core@6.4.16)(sqlite3@5.1.7)':
     dependencies:
@@ -16400,7 +16400,6 @@ snapshots:
       - pg-native
       - sqlite3
       - supports-color
-    optional: true
 
   '@mikro-orm/mysql@6.4.16(@mikro-orm/core@6.4.16)':
     dependencies:
@@ -16449,7 +16448,6 @@ snapshots:
       - sqlite3
       - supports-color
       - tedious
-    optional: true
 
   '@mikro-orm/mysql@6.4.16(@mikro-orm/core@6.4.16)(tedious@18.6.1)':
     dependencies:
@@ -16582,7 +16580,6 @@ snapshots:
       - pg-native
       - supports-color
       - tedious
-    optional: true
 
   '@mikro-orm/sqlite@6.4.16(@mikro-orm/core@6.4.16)(tedious@18.6.1)':
     dependencies:
@@ -19257,7 +19254,7 @@ snapshots:
   axios@1.10.0:
     dependencies:
       follow-redirects: 1.15.9
-      form-data: 4.0.3
+      form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -21005,6 +21002,14 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   format@0.2.2: {}
 
   formdata-polyfill@4.0.10:
@@ -22512,7 +22517,6 @@ snapshots:
       pg: 8.16.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   knex@3.1.0(mysql2@3.14.1)(tedious@18.6.1):
     dependencies:
@@ -22579,7 +22583,6 @@ snapshots:
       sqlite3: 5.1.7
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   knex@3.1.0(pg@8.16.0)(tedious@18.6.1):
     dependencies:


### PR DESCRIPTION
Turns out optional dependencies are automatically installed. This is not what we want. We want to tell users they should install a driver, but we want to stop short of pulling them all in automatically. This is because the bundling includes anything that's on disk.