### PR TITLE
Fix / Let windows catch its breath in CI / Test Process

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -25,7 +25,7 @@
 		"format": "pnpm prettier",
 		"lint:fix": "eslint . --fix",
 		"lint": "eslint .",
-		"pack:all": "rm -rf .packs && mkdir -p .packs && pnpm build:packages && pnpm packages:pack",
+		"pack:all": "rm -rf .packs && mkdir -p .packs && pnpm build:packages && sleep 0.5 && pnpm packages:pack",
 		"packages:pack": "turbo --filter \"!./examples/**\" package:pack -- --pack-destination ../../.packs",
 		"prettier": "prettier --write .",
 		"publish:dry": "pnpm build && pnpm -r publish --no-git-checks --access public --dry-run",

--- a/src/packages/end-to-end/scripts/import-auth.ts
+++ b/src/packages/end-to-end/scripts/import-auth.ts
@@ -71,6 +71,13 @@ async function main() {
 		await execAsync('pwd');
 		await execAsync('pnpm i --ignore-workspace --no-lockfile');
 
+		// On Windows, add a small delay to allow filesystem operations to complete
+		// This prevents race conditions with pnpm symlink creation
+		if (process.platform === 'win32') {
+			console.log('Waiting for filesystem operations to complete on Windows...');
+			await new Promise((resolve) => setTimeout(resolve, 500));
+		}
+
 		const tsJson = JSON.parse(await fs.promises.readFile('tsconfig.json', 'utf-8'));
 		delete tsJson.references;
 		await fs.promises.writeFile('tsconfig.json', JSON.stringify(tsJson, null, 2));

--- a/src/packages/end-to-end/scripts/import-rest.ts
+++ b/src/packages/end-to-end/scripts/import-rest.ts
@@ -55,6 +55,13 @@ async function main() {
 		await execAsync('pwd');
 		await execAsync('pnpm i --ignore-workspace --no-lockfile');
 
+		// On Windows, add a small delay to allow filesystem operations to complete
+		// This prevents race conditions with pnpm symlink creation
+		if (process.platform === 'win32') {
+			console.log('Waiting for filesystem operations to complete on Windows...');
+			await new Promise((resolve) => setTimeout(resolve, 500));
+		}
+
 		const tsJson = JSON.parse(await fs.promises.readFile('tsconfig.json', 'utf-8'));
 		delete tsJson.references;
 		await fs.promises.writeFile('tsconfig.json', JSON.stringify(tsJson, null, 2));

--- a/src/packages/end-to-end/scripts/import-sqlite.ts
+++ b/src/packages/end-to-end/scripts/import-sqlite.ts
@@ -43,6 +43,13 @@ async function main() {
 		await execAsync('pwd');
 		await execAsync('pnpm i --ignore-workspace --no-lockfile');
 
+		// On Windows, add a small delay to allow filesystem operations to complete
+		// This prevents race conditions with pnpm symlink creation
+		if (process.platform === 'win32') {
+			console.log('Waiting for filesystem operations to complete on Windows...');
+			await new Promise((resolve) => setTimeout(resolve, 500));
+		}
+
 		// Copy the database
 		await fs.promises.mkdir('databases');
 		await copyFile('../databases/database.sqlite', 'databases/database.sqlite');

--- a/src/packages/end-to-end/scripts/import-storage-provider.ts
+++ b/src/packages/end-to-end/scripts/import-storage-provider.ts
@@ -53,6 +53,13 @@ async function main() {
 		await execAsync('pwd');
 		await execAsync('pnpm i --ignore-workspace --no-lockfile');
 
+		// On Windows, add a small delay to allow filesystem operations to complete
+		// This prevents race conditions with pnpm symlink creation
+		if (process.platform === 'win32') {
+			console.log('Waiting for filesystem operations to complete on Windows...');
+			await new Promise((resolve) => setTimeout(resolve, 500));
+		}
+
 		const tsJson = JSON.parse(await fs.promises.readFile('tsconfig.json', 'utf-8'));
 		delete tsJson.references;
 		await fs.promises.writeFile('tsconfig.json', JSON.stringify(tsJson, null, 2));


### PR DESCRIPTION
We've had really flaky builds on Windows recently. This attempts to fix that by adding a small pause on Windows to make sure the pnpm process has completed before the build starts.