### PR TITLE
Improve detail-panel form handling for relationships

### DIFF
--- a/src/examples/rest-with-auth/.env.example
+++ b/src/examples/rest-with-auth/.env.example
@@ -1,6 +1,6 @@
 REST_BASE_URL='https://swapi.info/api'
-AUTH_PUBLIC_KEY_PEM_BASE64="base64_encoded_pem_public_key"
 AUTH_PRIVATE_KEY_PEM_BASE64="base64_encoded_pem_private_key"
+AUTH_PUBLIC_KEY_PEM_BASE64="base64_encoded_pem_public_key"
 AUTH_BASE_URI="http://localhost:9000"
 AUTH_WHITELIST_DOMAINS="localhost"
 DATABASE_HOST="localhost"

--- a/src/packages/admin-ui-components/package.json
+++ b/src/packages/admin-ui-components/package.json
@@ -19,6 +19,7 @@
 		"build-storybook": "storybook build"
 	},
 	"main": "lib/index.js",
+	"types": "lib/index.d.ts",
 	"source": "src/index.ts",
 	"directories": {
 		"lib": "lib"
@@ -45,6 +46,7 @@
 		"papaparse": "5.5.2",
 		"react-day-picker": "9.6.4",
 		"react-error-boundary": "5.0.0",
+		"react-fast-compare": "3.2.2",
 		"react-hot-toast": "2.5.2",
 		"react-resizable-panels": "2.1.7",
 		"react-syntax-highlighter": "15.6.1",

--- a/src/packages/admin-ui-components/src/combo-box/component.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/component.tsx
@@ -53,7 +53,6 @@ export const ComboBox = ({
 	['data-testid']: testId,
 }: SelectProps) => {
 	const valueArray = arrayify(value);
-	console.log({ options, valueArray })
 	const inputRef = useAutoFocus<HTMLInputElement>(autoFocus);
 	const selectBoxRef = useRef<HTMLDivElement>(null);
 	const dropdownRef = useRef<HTMLUListElement>(null);

--- a/src/packages/admin-ui-components/src/combo-box/component.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/component.tsx
@@ -125,8 +125,6 @@ export const ComboBox = ({
 	// Store the selected ids in an array for easy lookup
 	const selectedIds = useMemo(() => new Set(valueArray.map((item) => item.value)), [value]);
 
-	// console.log(isOpen, options.length);
-
 	return (
 		<div className={styles.select} data-testid={testId}>
 			<div

--- a/src/packages/admin-ui-components/src/combo-box/component.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/component.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useMemo, useRef } from 'react';
 import clsx from 'clsx';
 import { useCombobox } from 'downshift';
+import { useEffect, useMemo, useRef } from 'react';
 
 import { ChevronDownIcon } from '../assets';
-import { Spinner } from '../spinner';
 import { useAutoFocus } from '../hooks';
+import { Spinner } from '../spinner';
 import styles from './styles.module.css';
 
 export enum SelectMode {
@@ -53,6 +53,7 @@ export const ComboBox = ({
 	['data-testid']: testId,
 }: SelectProps) => {
 	const valueArray = arrayify(value);
+	console.log({ options, valueArray })
 	const inputRef = useAutoFocus<HTMLInputElement>(autoFocus);
 	const selectBoxRef = useRef<HTMLDivElement>(null);
 	const dropdownRef = useRef<HTMLUListElement>(null);
@@ -124,6 +125,8 @@ export const ComboBox = ({
 
 	// Store the selected ids in an array for easy lookup
 	const selectedIds = useMemo(() => new Set(valueArray.map((item) => item.value)), [value]);
+
+	// console.log(isOpen, options.length);
 
 	return (
 		<div className={styles.select} data-testid={testId}>

--- a/src/packages/admin-ui-components/src/combo-box/component.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/component.tsx
@@ -78,8 +78,12 @@ export const ComboBox = ({
 			setInputValue('');
 
 			if (mode === SelectMode.MULTI) {
-				if (change.selectedItem && !selectedIds.has(change.selectedItem.value)) {
-					onChange([...valueArray, change.selectedItem]);
+				if (change.selectedItem) {
+					if (selectedIds.has(change.selectedItem.value)) {
+						onChange(valueArray.filter((item) => item.value !== change.selectedItem?.value));
+					} else {
+						onChange([...valueArray, change.selectedItem]);
+					}
 				}
 			} else {
 				onChange(change.selectedItem ? [change.selectedItem] : []);

--- a/src/packages/admin-ui-components/src/detail-panel/component.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/component.tsx
@@ -86,9 +86,6 @@ const filterFieldsForSubmission = (initialValues: Record<string, any>, values: R
 
 	for (const [key, value] of Object.entries(values)) {
 		const field = entity.fields.find((f) => f.name === key);
-		if (field?.attributes?.isReadOnly) {
-			continue;
-		}
 
 		if (!isEqual(initialValues[key], value) || field?.attributes?.isRequired) {
 			result[key] = value;
@@ -425,7 +422,7 @@ export const DetailPanel = () => {
 		customFields?.get(selectedEntity.name) || authCustomFields?.get(selectedEntity.name) || [];
 
 	const formFields: EntityField[] = selectedEntity.fields.filter((field) => {
-		// We also don't show the related ID field for the same reason
+		// Don't expose control of the primary key field
 		if (field.relationshipType && field.name === selectedEntity.primaryKeyField) return false;
 
 		// And we want to filter out any fields that will be overridden with custom fields.

--- a/src/packages/admin-ui-components/src/detail-panel/component.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/component.tsx
@@ -314,6 +314,8 @@ const DetailForm = ({
 					);
 				}
 
+				// console.log({ transformedValues });
+
 				await onSubmit(transformedValues, actions);
 			} catch (error: any) {
 				console.error(error);
@@ -336,7 +338,9 @@ const DetailForm = ({
 			onSubmit={submit}
 			onReset={onCancel}
 		>
-			{({ isSubmitting }) => (
+			{({ isSubmitting, values }) => { 
+				// console.log({ values });
+				return (
 				<Form className={styles.detailFormContainer}>
 					<div className={styles.detailFieldList}>
 						{detailFields.map((field) => {
@@ -373,7 +377,7 @@ const DetailForm = ({
 					</div>
 					<PersistForm name={persistName} />
 				</Form>
-			)}
+			)}}
 		</Formik>
 	);
 };
@@ -425,10 +429,6 @@ export const DetailPanel = () => {
 		customFields?.get(selectedEntity.name) || authCustomFields?.get(selectedEntity.name) || [];
 
 	const formFields: EntityField[] = selectedEntity.fields.filter((field) => {
-		// We don't show Many to Many relationships in the form yet because we don't have
-		// a good editing interface for them.
-		if (field.relationshipType === 'MANY_TO_MANY') return false;
-
 		// We also don't show the related ID field for the same reason
 		if (field.relationshipType && field.name === selectedEntity.primaryKeyField) return false;
 
@@ -464,9 +464,7 @@ export const DetailPanel = () => {
 		{} as Record<string, any>
 	);
 
-	// if (initialValues?.id) {
-	// 	console.log({ initialValues });
-	// }
+	// console.log({ initialValues });
 
 	const [updateEntity] = useMutation(generateUpdateEntityMutation(selectedEntity, entityByType));
 	const [createEntity] = useMutation(generateCreateEntityMutation(selectedEntity, entityByType));

--- a/src/packages/admin-ui-components/src/detail-panel/component.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/component.tsx
@@ -38,7 +38,7 @@ import {
 import { generateCreateEntityMutation, generateUpdateEntityMutation } from './graphql';
 import styles from './styles.module.css';
 import { dataTransforms } from './use-data-transform';
-import { isValueEmpty, parseValueForForm } from './util';
+import { isValueEmpty, parseValueForForm, transformValueForForm } from './util';
 
 interface ResultBaseType {
 	id: string;
@@ -91,6 +91,7 @@ const filterFieldsForSubmission = (initialValues: Record<string, any>, values: R
 		}
 
 		if (!isEqual(initialValues[key], value) || field?.attributes?.isRequired) {
+			// if (!isEqual(initialValues[key], value) || field?.attributes?.isRequired || field?.apiOptions?.requiredForUpdate) {
 			result[key] = value;
 		}
 	}
@@ -455,12 +456,17 @@ export const DetailPanel = () => {
 	const initialValues = formFields.reduce(
 		(acc, field) => {
 			const result = savedSessionState ?? data?.result;
-			const value = parseValueForForm(field.type, result?.[field.name as keyof typeof result]);
-			acc[field.name] = value ?? field.initialValue ?? undefined;
+			const value = parseValueForForm(field.type, result?.[field.name as keyof typeof result], selectedEntity);
+			const transformedValue = transformValueForForm(field, value, entityByType);
+			acc[field.name] = transformedValue ?? field.initialValue ?? undefined;
 			return acc;
 		},
 		{} as Record<string, any>
 	);
+
+	// if (initialValues?.id) {
+	// 	console.log({ initialValues });
+	// }
 
 	const [updateEntity] = useMutation(generateUpdateEntityMutation(selectedEntity, entityByType));
 	const [createEntity] = useMutation(generateCreateEntityMutation(selectedEntity, entityByType));

--- a/src/packages/admin-ui-components/src/detail-panel/component.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/component.tsx
@@ -335,7 +335,7 @@ const DetailForm = ({
 			onSubmit={submit}
 			onReset={onCancel}
 		>
-			{({ isSubmitting, values }) => { 
+			{({ isSubmitting }) => { 
 				return (
 				<Form className={styles.detailFormContainer}>
 					<div className={styles.detailFieldList}>
@@ -452,15 +452,13 @@ export const DetailPanel = () => {
 	const initialValues = formFields.reduce(
 		(acc, field) => {
 			const result = savedSessionState ?? data?.result;
-			const value = parseValueForForm(field.type, result?.[field.name as keyof typeof result], selectedEntity);
+			const value = parseValueForForm(field.type, result?.[field.name as keyof typeof result]);
 			const transformedValue = transformValueForForm(field, value, entityByType);
 			acc[field.name] = transformedValue ?? field.initialValue ?? undefined;
 			return acc;
 		},
 		{} as Record<string, any>
 	);
-
-	// console.log({ initialValues });
 
 	const [updateEntity] = useMutation(generateUpdateEntityMutation(selectedEntity, entityByType));
 	const [createEntity] = useMutation(generateCreateEntityMutation(selectedEntity, entityByType));

--- a/src/packages/admin-ui-components/src/detail-panel/component.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/component.tsx
@@ -91,7 +91,6 @@ const filterFieldsForSubmission = (initialValues: Record<string, any>, values: R
 		}
 
 		if (!isEqual(initialValues[key], value) || field?.attributes?.isRequired) {
-			// if (!isEqual(initialValues[key], value) || field?.attributes?.isRequired || field?.apiOptions?.requiredForUpdate) {
 			result[key] = value;
 		}
 	}
@@ -314,8 +313,6 @@ const DetailForm = ({
 					);
 				}
 
-				// console.log({ transformedValues });
-
 				await onSubmit(transformedValues, actions);
 			} catch (error: any) {
 				console.error(error);
@@ -339,7 +336,6 @@ const DetailForm = ({
 			onReset={onCancel}
 		>
 			{({ isSubmitting, values }) => { 
-				// console.log({ values });
 				return (
 				<Form className={styles.detailFormContainer}>
 					<div className={styles.detailFieldList}>

--- a/src/packages/admin-ui-components/src/detail-panel/fields/boolean-field.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/fields/boolean-field.tsx
@@ -1,7 +1,6 @@
 import { Field, FieldProps } from 'formik';
-import { SelectOption, ComboBox, SelectMode } from '../../combo-box';
+import { ComboBox, SelectMode, SelectOption } from '../../combo-box';
 import { EntityField } from '../../utils';
-import { useDataTransform } from '../use-data-transform';
 
 export const BooleanField = ({
 	field,
@@ -12,16 +11,6 @@ export const BooleanField = ({
 	autoFocus: boolean;
 	disabled?: boolean;
 }) => {
-	// Before we go up to the server we need to change over to a boolean from an array of options
-	useDataTransform({
-		field,
-		transform: async (value: unknown) => {
-			if (!value || !Array.isArray(value)) return undefined;
-
-			return value[0]?.value;
-		},
-	});
-
 	return (
 		<Field name={field.name}>
 			{({ field, form }: FieldProps) => (

--- a/src/packages/admin-ui-components/src/detail-panel/util.ts
+++ b/src/packages/admin-ui-components/src/detail-panel/util.ts
@@ -1,3 +1,5 @@
+import { Entity, EntityField } from "../utils";
+
 // This is used to validate if a value is empty in the context of a form
 export const isValueEmpty = (value: unknown) =>
 	value === '' || value === null || value === undefined;
@@ -6,14 +8,35 @@ export const isValueEmpty = (value: unknown) =>
  * Value should not be undefined because the input that renders it will switch from uncontrolled to controlled and React will throw an error.
  * Also, if value is a JSON object, we stringify it.
  */
-export const parseValueForForm = (fieldType: string, value: unknown) => {
+export const parseValueForForm = (fieldType: string, value: unknown, entity?: Entity) => {
 	if (value === undefined) {
 		return null;
 	}
 
 	if (fieldType === 'JSON' && value) {
 		return JSON.stringify(value, null, 4);
-	}
+	 }
 
+	return value;
+};
+
+const isObjectWithKeys = <T extends Record<string, unknown>, K extends keyof T, S extends keyof T>(value: unknown, key: K, summaryField: S): value is T & { [P in K | S]: unknown } => {
+	return typeof value === 'object' && value !== null && key in value && summaryField in value;
+};
+
+export const transformValueForForm = (field: EntityField, value: unknown, entityByType: (entityType: string) => Entity) => {
+	console.log({ name: field.name, field, value });
+	if (field.relationshipType === 'MANY_TO_ONE') {
+		const relatedEntity = entityByType(field.type);
+		const relatedEntityPrimaryKeyField = relatedEntity.primaryKeyField;
+		const relatedEntitySummaryField = relatedEntity.summaryField ?? relatedEntityPrimaryKeyField;
+
+		if (isObjectWithKeys(value, relatedEntityPrimaryKeyField, relatedEntitySummaryField)) {
+			return {
+				value: value[relatedEntityPrimaryKeyField],
+				label: value[relatedEntitySummaryField],
+			};
+		}
+	}
 	return value;
 };

--- a/src/packages/admin-ui-components/src/detail-panel/util.ts
+++ b/src/packages/admin-ui-components/src/detail-panel/util.ts
@@ -15,7 +15,7 @@ export const parseValueForForm = (fieldType: string, value: unknown) => {
 
 	if (fieldType === 'JSON' && value) {
 		return JSON.stringify(value, null, 4);
-	 }
+	}
 
 	return value;
 };

--- a/src/packages/admin-ui-components/src/detail-panel/util.ts
+++ b/src/packages/admin-ui-components/src/detail-panel/util.ts
@@ -8,7 +8,7 @@ export const isValueEmpty = (value: unknown) =>
  * Value should not be undefined because the input that renders it will switch from uncontrolled to controlled and React will throw an error.
  * Also, if value is a JSON object, we stringify it.
  */
-export const parseValueForForm = (fieldType: string, value: unknown, entity?: Entity) => {
+export const parseValueForForm = (fieldType: string, value: unknown) => {
 	if (value === undefined) {
 		return null;
 	}

--- a/src/packages/admin-ui-components/src/detail-panel/util.ts
+++ b/src/packages/admin-ui-components/src/detail-panel/util.ts
@@ -37,7 +37,7 @@ export const transformValueForForm = (field: EntityField, value: unknown, entity
 					label: value[relatedEntitySummaryField],
 				};
 			}
-		} else if (field.relationshipType === 'MANY_TO_MANY') {
+		} else if (['MANY_TO_MANY', 'ONE_TO_MANY'].includes(field.relationshipType)) {
 			if (Array.isArray(value)) {
 				return value.map((item) => ({
 					value: item[relatedEntityPrimaryKeyField],

--- a/src/packages/admin-ui-components/src/detail-panel/util.ts
+++ b/src/packages/admin-ui-components/src/detail-panel/util.ts
@@ -25,17 +25,26 @@ const isObjectWithKeys = <T extends Record<string, unknown>, K extends keyof T, 
 };
 
 export const transformValueForForm = (field: EntityField, value: unknown, entityByType: (entityType: string) => Entity) => {
-	console.log({ name: field.name, field, value });
-	if (field.relationshipType === 'MANY_TO_ONE') {
+	if (field.relationshipType) {
 		const relatedEntity = entityByType(field.type);
-		const relatedEntityPrimaryKeyField = relatedEntity.primaryKeyField;
-		const relatedEntitySummaryField = relatedEntity.summaryField ?? relatedEntityPrimaryKeyField;
+		const relatedEntityPrimaryKeyField = relatedEntity?.primaryKeyField;
+		const relatedEntitySummaryField = relatedEntity?.summaryField ?? relatedEntityPrimaryKeyField;
 
-		if (isObjectWithKeys(value, relatedEntityPrimaryKeyField, relatedEntitySummaryField)) {
-			return {
-				value: value[relatedEntityPrimaryKeyField],
-				label: value[relatedEntitySummaryField],
-			};
+		if (field.relationshipType === 'MANY_TO_ONE') {
+			if (isObjectWithKeys(value, relatedEntityPrimaryKeyField, relatedEntitySummaryField)) {
+				return {
+					value: value[relatedEntityPrimaryKeyField],
+					label: value[relatedEntitySummaryField],
+				};
+			}
+		} else if (field.relationshipType === 'MANY_TO_MANY') {
+			if (Array.isArray(value)) {
+				return value.map((item) => ({
+					value: item[relatedEntityPrimaryKeyField],
+					label: item[relatedEntitySummaryField],
+				}));
+			}
+			return value;
 		}
 	}
 	return value;

--- a/src/packages/admin-ui-components/src/entity-list/columns.tsx
+++ b/src/packages/admin-ui-components/src/entity-list/columns.tsx
@@ -1,12 +1,12 @@
 import { CellContext, createColumnHelper } from '@tanstack/react-table';
+import { generateJSON, generateText } from '@tiptap/react';
+import { DateTime } from 'luxon';
 import { customFields } from 'virtual:graphweaver-user-supplied-custom-fields';
-import { generateText, generateJSON } from '@tiptap/react';
 import { Link } from 'wouter';
-import { DetailPanelInputComponentOption, Entity, EntityField, routeFor } from '../utils';
-import { cells } from '../table/cells';
 import { Checkbox } from '../checkbox';
 import { getExtensions } from '../detail-panel/fields/rich-text-field/utils';
-import { DateTime } from 'luxon';
+import { cells } from '../table/cells';
+import { DetailPanelInputComponentOption, Entity, EntityField, routeFor } from '../utils';
 
 const richTextExtensions = getExtensions({});
 
@@ -65,18 +65,22 @@ const cellForType = (
 	if (field.relationshipType) {
 		const relatedEntity = entityByType(field.type);
 
-		const linkForValue = (item: any) =>
-			relatedEntity ? (
-				<Link
-					key={item.value}
-					to={routeFor({ type: field.type, id: item.value })}
-					onClick={(e) => e.stopPropagation()}
-				>
-					{item.label}
-				</Link>
-			) : (
-				item.label
-			);
+		const linkForValue = (item: any) => {
+			if (relatedEntity) {
+				const key = relatedEntity.primaryKeyField;
+				const label = relatedEntity.summaryField ?? key;
+				return (
+					<Link
+						key={item[key]}
+						to={routeFor({ type: field.type, id: item[key] })}
+						onClick={(e) => e.stopPropagation()}
+					>
+						{item[label]}
+					</Link>
+				);
+			}
+			return item.label;
+		};
 
 		if (!value) return null;
 

--- a/src/packages/admin-ui-components/src/utils/graphql.ts
+++ b/src/packages/admin-ui-components/src/utils/graphql.ts
@@ -66,6 +66,9 @@ export const SCHEMA_QUERY = gql`
 	}
 `;
 
+const entitySelection = (relatedEntity: Entity) => 
+	[relatedEntity.primaryKeyField].concat(relatedEntity.summaryField ?? []).join('\n');
+
 export const generateGqlSelectForEntityFields = (
 	entity: Entity,
 	entityByType?: (entityType: string) => Entity
@@ -83,8 +86,7 @@ export const generateGqlSelectForEntityFields = (
 				if (!relatedEntity) throw new Error(`Related entity ${field.type} not found`);
 
 				return `${field.name} { 
-					value: ${relatedEntity.primaryKeyField}
-					label: ${relatedEntity?.summaryField ?? relatedEntity?.primaryKeyField}
+					${entitySelection(relatedEntity)}
 				}`;
 			}
 

--- a/src/packages/auth/src/decorators/hooks/acl.ts
+++ b/src/packages/auth/src/decorators/hooks/acl.ts
@@ -1,19 +1,17 @@
 import {
 	CreateOrUpdateHookParams,
 	DeleteHookParams,
+	EntityMetadata,
+	Filter,
 	GraphQLArgs,
 	ReadHookParams,
-	graphweaverMetadata,
-	EntityMetadata,
-	isEntityMetadata,
 	ResolveTree,
-	Filter,
+	graphweaverMetadata,
+	isEntityMetadata,
 	isTopLevelFilterProperty,
 } from '@exogee/graphweaver';
 import { logger } from '@exogee/logger';
 
-import { AccessType, AuthorizationContext } from '../../types';
-import { andFilters } from '../../helper-functions';
 import {
 	FieldDetails,
 	GENERIC_AUTH_ERROR_MESSAGE,
@@ -25,6 +23,8 @@ import {
 	isPopulatedFilter,
 } from '../../auth-utils';
 import { FieldLocation } from '../../errors';
+import { andFilters } from '../../helper-functions';
+import { AccessType, AuthorizationContext } from '../../types';
 
 const aggregatePattern = /_aggregate$/;
 
@@ -398,6 +398,11 @@ const generatePermissionListFromArgs = <G>() => {
 
 					// We need to loop through the relationship nodes and check the access type as it could be a mixture of read, create, update
 					for (const relationshipNode of relationshipNodes) {
+						// If the subject of the relationship is null, we can bail out from ACL checks
+						if (relationshipNode === null) {
+							continue;
+						}
+
 						// Check the access type of the relationship
 						const relationshipAccessType = filter
 							? accessType

--- a/src/packages/core/src/metadata-service/resolver.ts
+++ b/src/packages/core/src/metadata-service/resolver.ts
@@ -106,7 +106,7 @@ export const resolveAdminUiMetadata = (hooks?: Hooks) => {
 
 				// Define field attributes
 				const isReadOnly = field.readonly ?? field.adminUIOptions?.readonly ?? false;
-				const isRequired = !field.nullable;
+				const isRequired = !field.nullable || (field.apiOptions?.requiredForUpdate ?? false);
 
 				const fieldObject: AdminUiFieldMetadata = {
 					name: field.name,

--- a/src/packages/core/src/metadata-service/resolver.ts
+++ b/src/packages/core/src/metadata-service/resolver.ts
@@ -137,8 +137,12 @@ export const resolveAdminUiMetadata = (hooks?: Hooks) => {
 					fieldObject.relationshipType = RelationshipType.ONE_TO_MANY;
 
 					const relatedEntityField = Object.values(relatedObject.fields).find((field) => {
-						const fieldType = field.getType() as { name?: string };
-						return fieldType.name === (entity.target as { name?: string }).name;
+						const { isList: isOtherSideList, fieldType: fieldTypeOtherSide } =
+							getFieldTypeWithMetadata(field.getType);
+						const namesMatch =
+							(fieldTypeOtherSide as { name?: string }).name ===
+							(entity.target as { name?: string }).name;
+						return isOtherSideList && namesMatch;
 					});
 					if (Array.isArray(relatedEntityField?.getType())) {
 						fieldObject.relationshipType = RelationshipType.MANY_TO_MANY;

--- a/src/packages/core/src/types.ts
+++ b/src/packages/core/src/types.ts
@@ -3,12 +3,12 @@ import { Span, Tracer } from '@opentelemetry/api';
 import { GraphQLID, GraphQLResolveInfo, GraphQLScalarType, Source } from 'graphql';
 import { ResolveTree } from 'graphql-parse-resolve-info';
 import { ComplexityEstimator } from 'graphql-query-complexity';
-import { EntityMetadata } from './metadata';
 import {
 	CellFormatOptions,
 	DetailPanelInputComponent,
 	DetailPanelInputComponentOption,
 } from './decorators';
+import { EntityMetadata } from './metadata';
 
 export type { Instrumentation } from '@opentelemetry/instrumentation';
 export type { GraphQLResolveInfo } from 'graphql';
@@ -262,6 +262,7 @@ export interface FieldMetadata<G = unknown, D = unknown> {
 		format?: CellFormatOptions;
 	};
 	apiOptions?: {
+		requiredForUpdate?: boolean;
 		excludeFromBuiltInWriteOperations?: boolean;
 	};
 	target: { new (...args: any[]): G };

--- a/src/packages/core/src/utils/batched-writes.ts
+++ b/src/packages/core/src/utils/batched-writes.ts
@@ -223,6 +223,8 @@ export const generateOperationBatches = async <G = unknown, D = unknown>(
 						node[key as keyof typeof node] = fieldType.serialize({ value: childNode }) as
 							| G[keyof G]
 							| undefined;
+					} else if (childNode === null) {
+						// Handle a many to one relationship being unlinked. We are clearing the foreign key, so nothing to do here
 					} else if (isLinking(relatedEntityMetadata, childNode)) {
 						// If it's a linking entity or an array of linking entities, nothing to do here
 					} else if (Array.isArray(childNode)) {

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -85,7 +85,7 @@ importers:
         version: 6.4.16
       '@mikro-orm/knex':
         specifier: 6.4.16
-        version: 6.4.16(@mikro-orm/core@6.4.16)(pg@8.13.3)(sqlite3@5.1.7)
+        version: 6.4.16(@mikro-orm/core@6.4.16)(mysql2@3.14.0)(pg@8.16.0)
       '@mikro-orm/sqlite':
         specifier: 6.4.16
         version: 6.4.16(@mikro-orm/core@6.4.16)
@@ -290,7 +290,7 @@ importers:
         version: 6.4.16
       '@mikro-orm/knex':
         specifier: 6.4.16
-        version: 6.4.16(@mikro-orm/core@6.4.16)(pg@8.13.3)(sqlite3@5.1.7)
+        version: 6.4.16(@mikro-orm/core@6.4.16)(mysql2@3.14.0)(pg@8.16.0)
       '@mikro-orm/sqlite':
         specifier: 6.4.16
         version: 6.4.16(@mikro-orm/core@6.4.16)
@@ -345,7 +345,7 @@ importers:
         version: 6.4.16
       '@mikro-orm/knex':
         specifier: 6.4.16
-        version: 6.4.16(@mikro-orm/core@6.4.16)(pg@8.13.3)(sqlite3@5.1.7)
+        version: 6.4.16(@mikro-orm/core@6.4.16)(mysql2@3.14.0)(pg@8.16.0)
       '@mikro-orm/sqlite':
         specifier: 6.4.16
         version: 6.4.16(@mikro-orm/core@6.4.16)
@@ -388,7 +388,7 @@ importers:
         version: 6.4.16
       '@mikro-orm/knex':
         specifier: 6.4.16
-        version: 6.4.16(@mikro-orm/core@6.4.16)(pg@8.13.3)(sqlite3@5.1.7)
+        version: 6.4.16(@mikro-orm/core@6.4.16)(mysql2@3.14.0)(pg@8.16.0)
       '@mikro-orm/mysql':
         specifier: 6.4.16
         version: 6.4.16(@mikro-orm/core@6.4.16)
@@ -510,7 +510,7 @@ importers:
         version: 6.4.16
       '@mikro-orm/knex':
         specifier: 6.4.16
-        version: 6.4.16(@mikro-orm/core@6.4.16)(pg@8.13.3)(sqlite3@5.1.7)
+        version: 6.4.16(@mikro-orm/core@6.4.16)(mysql2@3.14.1)(pg@8.13.3)
       '@mikro-orm/postgresql':
         specifier: 6.4.16
         version: 6.4.16(@mikro-orm/core@6.4.16)
@@ -617,7 +617,7 @@ importers:
         version: 6.4.16
       '@mikro-orm/knex':
         specifier: 6.4.16
-        version: 6.4.16(@mikro-orm/core@6.4.16)(pg@8.13.3)(sqlite3@5.1.7)
+        version: 6.4.16(@mikro-orm/core@6.4.16)(mysql2@3.14.0)(pg@8.16.0)
       '@mikro-orm/sqlite':
         specifier: 6.4.16
         version: 6.4.16(@mikro-orm/core@6.4.16)
@@ -882,6 +882,9 @@ importers:
       react-error-boundary:
         specifier: 5.0.0
         version: 5.0.0(react@19.1.0)
+      react-fast-compare:
+        specifier: 3.2.2
+        version: 3.2.2
       react-hot-toast:
         specifier: 2.5.2
         version: 2.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1621,7 +1624,7 @@ importers:
     dependencies:
       '@mikro-orm/knex':
         specifier: 6.4.16
-        version: 6.4.16(@mikro-orm/core@6.4.16)(pg@8.13.3)(sqlite3@5.1.7)
+        version: 6.4.16(@mikro-orm/core@6.4.16)(mysql2@3.14.0)(pg@8.16.0)
       '@mikro-orm/sqlite':
         specifier: 6.4.16
         version: 6.4.16(@mikro-orm/core@6.4.16)
@@ -1683,7 +1686,7 @@ importers:
         version: 6.4.16
       '@mikro-orm/knex':
         specifier: 6.4.16
-        version: 6.4.16(@mikro-orm/core@6.4.16)(pg@8.13.3)(sqlite3@5.1.7)
+        version: 6.4.16(@mikro-orm/core@6.4.16)(mysql2@3.14.0)(pg@8.16.0)
       '@mikro-orm/mssql':
         specifier: 6.4.16
         version: 6.4.16(@mikro-orm/core@6.4.16)
@@ -2046,7 +2049,7 @@ packages:
     engines: {node: '>=14.16.0'}
     deprecated: Apollo Server v4 is deprecated and will transition to end-of-life on January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
     peerDependencies:
-      graphql: 16.11.0
+      graphql: ^16.6.0
 
   '@apollo/usage-reporting-protobuf@4.1.1':
     resolution: {integrity: sha512-u40dIUePHaSKVshcedO7Wp+mPiZsaU6xjv9J+VyxpoU/zL6Jle+9zWeG98tr/+SZ0nZ4OXhrbb8SNr0rAPpIDA==}
@@ -8087,10 +8090,6 @@ packages:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
 
-  foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
-
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
 
@@ -8267,10 +8266,6 @@ packages:
   glob@10.4.3:
     resolution: {integrity: sha512-Q38SGlYRpVtDBPSWEylRyctn7uDeTp4NQERTLiCT1FqA9JXPYWqAVmQU6qh4r/zMM5ehxTcbaO8EjhWnvEhmyg==}
     engines: {node: '>=18'}
-    hasBin: true
-
-  glob@10.4.5:
-    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
   glob@11.0.1:
@@ -10540,6 +10535,9 @@ packages:
   react-fast-compare@2.0.4:
     resolution: {integrity: sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==}
 
+  react-fast-compare@3.2.2:
+    resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
+
   react-hot-toast@2.5.2:
     resolution: {integrity: sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==}
     engines: {node: '>=10'}
@@ -10770,10 +10768,6 @@ packages:
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
-  rimraf@5.0.10:
-    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
   rimraf@5.0.8:
@@ -16524,7 +16518,7 @@ snapshots:
     dependencies:
       '@mikro-orm/core': 6.4.16
       fs-extra: 11.3.0
-      knex: 3.1.0(pg@8.13.3)(sqlite3@5.1.7)
+      knex: 3.1.0(sqlite3@5.1.7)(tedious@18.6.1)
       sqlstring: 2.3.3
     transitivePeerDependencies:
       - mysql
@@ -21332,11 +21326,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  foreground-child@3.3.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-
   form-data-encoder@1.7.2: {}
 
   form-data@4.0.2:
@@ -21542,15 +21531,6 @@ snapshots:
   glob@10.4.3:
     dependencies:
       foreground-child: 3.3.0
-      jackspeak: 3.4.3
-      minimatch: 9.0.5
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
-
-  glob@10.4.5:
-    dependencies:
-      foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.5
       minipass: 7.1.2
@@ -23004,7 +22984,6 @@ snapshots:
       tedious: 18.6.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   leven@3.1.0: {}
 
@@ -24400,6 +24379,8 @@ snapshots:
 
   react-fast-compare@2.0.4: {}
 
+  react-fast-compare@3.2.2: {}
+
   react-hot-toast@2.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       csstype: 3.1.3
@@ -24619,10 +24600,6 @@ snapshots:
       glob: 7.2.3
     optional: true
 
-  rimraf@5.0.10:
-    dependencies:
-      glob: 10.4.5
-
   rimraf@5.0.8:
     dependencies:
       glob: 10.4.3
@@ -24840,7 +24817,7 @@ snapshots:
     dependencies:
       axios: 1.11.0
       axios-proxy-builder: 0.1.2
-      rimraf: 5.0.10
+      rimraf: 5.0.8
       xml2js: 0.6.2
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
A set of related changes to get a complex detail panel saving, in particular around relationship controls. The changes are targeting:
- filter the payload we send to the server between form submission and hitting the network with the mutation
- when dealing with relationships, make sure the values stored in the formic form state are in the right format. Many means an array, one means an object or null
- allow unlinking a many to one relationship by passing a null

I don't think any of these changes could be considered breaking in semver terms. I would consider them bug fixes. If someone was relying on the shape of form state returned by a combobox, then upgrading to this version could break something. There's also a noticeable difference in what we submit with a mutation, we now only supply fields that have changed. I don't think these justify a major version bump. Maybe a minor is the right way to go?