### PR TITLE
Fix: Expose form state helpers to custom components

### DIFF
--- a/src/packages/admin-ui-components/src/detail-panel/component.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/component.tsx
@@ -1,6 +1,6 @@
 import { FetchResult, useMutation, useQuery } from '@apollo/client';
 import clsx from 'clsx';
-import { Form, Formik, FormikHelpers, useFormikContext } from 'formik';
+import { Form, Formik, FormikHelpers, useField, useFormikContext } from 'formik';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import isEqual from 'react-fast-compare';
 import toast from 'react-hot-toast';
@@ -211,11 +211,15 @@ const CustomFieldComponent = ({
 	field: CustomField;
 	entity: Record<string, any>;
 	panelMode: PanelMode;
-}) => (
-	<div className={styles.detailField} data-testid={`detail-panel-field-${field.name}`}>
-		{field.component({ entity, context: 'detail-form', panelMode })}
-	</div>
-);
+}) => {
+	const [_, meta, helpers] = useField(field.name);
+
+	return (
+		<div className={styles.detailField} data-testid={`detail-panel-field-${field.name}`}>
+			{field.component({ entity, context: 'detail-form', panelMode, value: meta.value, setValue: helpers.setValue })}
+		</div>
+	)
+};
 
 const PersistForm = ({ name }: { name: string }) => {
 	const { values, isSubmitting, submitForm } = useFormikContext();

--- a/src/packages/admin-ui-components/src/detail-panel/component.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/component.tsx
@@ -213,10 +213,14 @@ const CustomFieldComponent = ({
 	panelMode: PanelMode;
 }) => {
 	const [_, meta, helpers] = useField(field.name);
+	const formikProps = {
+		meta,
+		helpers,
+	}
 
 	return (
 		<div className={styles.detailField} data-testid={`detail-panel-field-${field.name}`}>
-			{field.component({ entity, context: 'detail-form', panelMode, value: meta.value, setValue: helpers.setValue })}
+			{field.component({ entity, context: 'detail-form', panelMode, formikProps, })}
 		</div>
 	)
 };

--- a/src/packages/admin-ui-components/src/utils/use-schema.ts
+++ b/src/packages/admin-ui-components/src/utils/use-schema.ts
@@ -4,6 +4,7 @@ import { JSX, useEffect, useMemo } from 'react';
 
 import { PanelMode } from '../detail-panel';
 import { SCHEMA_QUERY } from './graphql';
+import { FormikErrors } from 'formik';
 
 export interface Schema {
 	entities: Entity[];
@@ -161,6 +162,11 @@ export interface CustomFieldArgs<T = unknown> {
 	entity: T;
 	context: 'table' | 'detail-form';
 	panelMode: PanelMode;
+	value?: any;
+	setValue?: (
+		value: any,
+		shouldValidate?: boolean | undefined
+	) => Promise<void | FormikErrors<any>>;
 }
 
 export interface CustomField<T = unknown> extends EntityField {

--- a/src/packages/admin-ui-components/src/utils/use-schema.ts
+++ b/src/packages/admin-ui-components/src/utils/use-schema.ts
@@ -4,7 +4,7 @@ import { JSX, useEffect, useMemo } from 'react';
 
 import { PanelMode } from '../detail-panel';
 import { SCHEMA_QUERY } from './graphql';
-import { FormikErrors } from 'formik';
+import { FieldHelperProps, FieldMetaProps } from 'formik';
 
 export interface Schema {
 	entities: Entity[];
@@ -158,15 +158,14 @@ export interface EntityAttributes {
 	clientGeneratedPrimaryKeys?: boolean;
 }
 
-export interface CustomFieldArgs<T = unknown> {
+export interface CustomFieldArgs<T = unknown, F = unknown> {
 	entity: T;
 	context: 'table' | 'detail-form';
 	panelMode: PanelMode;
-	value?: any;
-	setValue?: (
-		value: any,
-		shouldValidate?: boolean | undefined
-	) => Promise<void | FormikErrors<any>>;
+	formikProps: {
+		meta: FieldMetaProps<F>;
+		helpers: FieldHelperProps<F>;
+	};
 }
 
 export interface CustomField<T = unknown> extends EntityField {


### PR DESCRIPTION
We're using Formik on the detail panel form. Right now, you can't properly connect to the rest of the form state with a custom component (Formik will explode on you if you try). This PR adds a bit to the `CustomFieldComponent` component by grabbing some helpers from Formik to pass directly to the component.