### PR TITLE
Fix / Ensure full flush before close on printing schema

### DIFF
--- a/src/packages/cli/src/tasks.ts
+++ b/src/packages/cli/src/tasks.ts
@@ -3,12 +3,17 @@ import { exec } from 'child_process';
 const asyncExec = async (command: string) =>
 	new Promise<void>((resolve, reject) => {
 		const execCommand = exec(command, (error) => {
-			if (error) {
-				return reject(error);
-			}
-			resolve();
+			if (error) return reject(error);
 		});
+
+		// Pipe stdout and stderr to parent process
 		execCommand.stdout?.pipe(process.stdout);
+		execCommand.stderr?.pipe(process.stderr);
+
+		execCommand.on('close', (code) => {
+			if (code === 0) return resolve();
+			else return reject(`Process exited with code ${code}`);
+		});
 	});
 
 export const generateTypes = async () => {


### PR DESCRIPTION
Currently we're getting truncated output on print-schema for large schemas.

This ensures all data from stdout is flushed before we resolve the promise.