### PR TITLE
Fix / Admin UI list page should not use cached data

### DIFF
--- a/src/packages/admin-ui-components/src/entity-list/component.tsx
+++ b/src/packages/admin-ui-components/src/entity-list/component.tsx
@@ -76,6 +76,7 @@ export const EntityList = <TData extends Record<string, unknown>>({
 		{
 			variables,
 			notifyOnNetworkStatusChange: true,
+			fetchPolicy: 'network-only',
 			...(excludeFromTracing
 				? { context: { headers: { ['x-graphweaver-suppress-tracing']: `true` } } }
 				: {}),


### PR DESCRIPTION
The list page query should always load the latest data.