### PR TITLE
Feature / Relationship Filters and Fields infinite scroll + search

### DIFF
--- a/src/packages/admin-ui-components/src/combo-box/combo-box.mdx
+++ b/src/packages/admin-ui-components/src/combo-box/combo-box.mdx
@@ -64,6 +64,39 @@ Allow users to type to filter options.
 
 <Canvas of={ComboBoxStories.WithFreeTyping} />
 
+### Lazy Loading with Infinite Scroll
+
+For large datasets, the ComboBox supports lazy loading with infinite scroll. This allows you to fetch data in pages as the user scrolls, improving performance and user experience.
+
+<Canvas of={ComboBoxStories.LazyLoadingWithInfiniteScroll} />
+
+#### Key Features:
+
+- **Data Fetching**: Provide a `dataFetcher` function that returns paginated data
+- **Infinite Scroll**: Automatically load more data when the user scrolls near the bottom
+- **Search Integration**: Search terms are automatically passed to the data fetcher
+- **Debounced Search**: Configurable debounce delay to prevent excessive API calls
+- **Loading States**: Visual indicators for when more data is being fetched
+
+#### Implementation:
+
+```tsx
+const dataFetcher: DataFetcher = async ({ page, searchTerm }) => {
+	const response = await fetch(`/api/items?page=${page}&pageSize=25&search=${searchTerm}`);
+	const result = await response.json();
+
+	return result.items || [];
+};
+
+<ComboBox
+	dataFetcher={dataFetcher}
+	searchDebounceMs={300}
+	allowFreeTyping={true}
+	mode={SelectMode.SINGLE}
+	placeholder="Search and scroll to load more..."
+/>;
+```
+
 ### In Form Context
 
 ComboBoxes are typically used within forms to collect user input.
@@ -74,6 +107,15 @@ ComboBoxes are typically used within forms to collect user input.
 
 <Controls of={ComboBoxStories.SingleSelect} />
 
+### Lazy Loading Props
+
+When using the lazy loading feature, you can configure these additional properties:
+
+| Prop               | Type          | Default     | Description                                    |
+| ------------------ | ------------- | ----------- | ---------------------------------------------- |
+| `dataFetcher`      | `DataFetcher` | `undefined` | Function to fetch paginated data               |
+| `searchDebounceMs` | `number`      | `300`       | Debounce delay for search input (milliseconds) |
+
 ## Usage Guidelines
 
 - Use single select when only one option should be selected at a time
@@ -83,6 +125,9 @@ ComboBoxes are typically used within forms to collect user input.
 - Use placeholder text to give users a hint about what to select
 - Include a loading state for asynchronously loaded options
 - For very short lists (2-5 items), consider using radio buttons or checkboxes instead
+- **Lazy Loading**: Use lazy loading with infinite scroll for datasets with more than 100 items to improve performance
+- **Search Integration**: When implementing lazy loading, ensure your data fetcher properly handles search terms for optimal user experience
+- **Page Size**: Choose an appropriate page size (typically 20-50 items) in your data fetcher based on your data structure and API capabilities
 
 ## Accessibility
 

--- a/src/packages/admin-ui-components/src/combo-box/combo-box.stories.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/combo-box.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { ComboBox, SelectMode, SelectOption } from './component';
+import { ComboBox, SelectMode, SelectOption, DataFetcher } from './component';
 
 // Sample options for the stories
 const fruitOptions: SelectOption[] = [
@@ -22,16 +22,36 @@ const colorOptions: SelectOption[] = [
 	{ value: 'purple', label: 'Purple' },
 ];
 
-// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+// Mock data fetcher for lazy loading demo
+const mockDataFetcher: DataFetcher = async ({ page, searchTerm }) => {
+	// Simulate API delay
+	await new Promise((resolve) => setTimeout(resolve, 500));
+
+	// Generate mock data
+	const allItems: SelectOption[] = Array.from({ length: 1000 }, (_, i) => ({
+		value: `item-${i}`,
+		label: `Item ${i + 1}${searchTerm ? ` (${searchTerm})` : ''}`,
+	}));
+
+	// Filter by search term if provided
+	const filteredItems = searchTerm
+		? allItems.filter((item) => item.label?.toLowerCase().includes(searchTerm.toLowerCase()))
+		: allItems;
+
+	const pageSize = 20;
+	const startIndex = (page - 1) * pageSize;
+	const endIndex = startIndex + pageSize;
+	const data = filteredItems.slice(startIndex, endIndex);
+
+	// Return just the data array - component will automatically fetch more if data.length > 0
+	return data;
+};
+
 const meta = {
 	title: 'Inputs/ComboBox',
 	component: ComboBox,
-	parameters: {
-		// Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
-		layout: 'centered',
-	},
-	// This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
-	// More on argTypes: https://storybook.js.org/docs/api/argtypes
+	parameters: { layout: 'centered' },
+
 	argTypes: {
 		options: {
 			description: 'The list of options available in the dropdown',
@@ -192,4 +212,22 @@ export const InForm: Story = {
 			</form>
 		),
 	],
+};
+
+export const LazyLoadingWithInfiniteScroll: Story = {
+	args: {
+		mode: SelectMode.SINGLE,
+		placeholder: 'Type to search and scroll to load more...',
+		allowFreeTyping: true,
+		dataFetcher: mockDataFetcher,
+		searchDebounceMs: 300,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'This ComboBox demonstrates lazy loading with infinite scroll. It fetches data in pages as you scroll, and supports search with debouncing. The data fetcher simulates an API call with a 500ms delay.',
+			},
+		},
+	},
 };

--- a/src/packages/admin-ui-components/src/combo-box/component.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/component.tsx
@@ -345,12 +345,16 @@ export const ComboBox = ({
 					)}
 				</div>
 
-				<span
+				<button
+					type="button"
 					onClick={() => !disabled && toggleMenu()}
 					className={clsx(styles.arrow, isOpen && styles.arrowOpen)}
+					aria-label="Toggle dropdown"
+					aria-expanded={isOpen}
+					disabled={disabled}
 				>
 					<ChevronDownIcon />
-				</span>
+				</button>
 			</div>
 
 			<ul

--- a/src/packages/admin-ui-components/src/combo-box/component.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/component.tsx
@@ -80,6 +80,7 @@ export const ComboBox = ({
 	const [searchTimeout, setSearchTimeout] = useState<NodeJS.Timeout | null>(null);
 	const [currentPage, setCurrentPage] = useState(1);
 	const [hasReachedEnd, setHasReachedEnd] = useState(false);
+	const lastSearchTermRef = useRef<string | undefined>(undefined);
 
 	// Use ref to track if we're already loading data to prevent duplicate fetches
 	const fetchedPagesRef = useRef(new Set<number>());
@@ -133,7 +134,6 @@ export const ComboBox = ({
 		},
 	});
 
-	// Define fetchData after useCombobox where isOpen is available
 	const fetchData = useCallback(
 		async (page: number, search: string) => {
 			if (!dataFetcher) return;
@@ -148,14 +148,21 @@ export const ComboBox = ({
 			try {
 				const result = await dataFetcher({ page, searchTerm: search });
 
-				if (result && result.length > 0) {
-					setDynamicOptions((prev) => [...prev, ...result]);
+				if (lastSearchTermRef.current === search) {
+					// Search term hasn't changed, merge the options in.
+					if (result && result.length > 0) {
+						setDynamicOptions((prev) => [...prev, ...result]);
+					} else {
+						setHasReachedEnd(true);
+					}
 				} else {
-					setHasReachedEnd(true);
+					// If the search term has changed, we need to reset the options
+					setDynamicOptions(result);
 				}
 			} catch (error) {
 				console.error('ComboBox fetchData error:', error);
 			} finally {
+				lastSearchTermRef.current = search;
 				setIsLoadingMore(false);
 			}
 		},

--- a/src/packages/admin-ui-components/src/combo-box/component.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/component.tsx
@@ -152,12 +152,17 @@ export const ComboBox = ({
 					// Search term hasn't changed, merge the options in.
 					if (result && result.length > 0) {
 						setDynamicOptions((prev) => [...prev, ...result]);
+						setCurrentPage(page);
 					} else {
 						setHasReachedEnd(true);
 					}
 				} else {
 					// If the search term has changed, we need to reset the options
 					setDynamicOptions(result);
+					setCurrentPage(1);
+					setHasReachedEnd(false);
+					fetchedPagesRef.current.clear();
+					fetchedPagesRef.current.add(1);
 				}
 			} catch (error) {
 				console.error('ComboBox fetchData error:', error);
@@ -305,7 +310,7 @@ export const ComboBox = ({
 									{valueArray.length > 1
 										? `${valueArray.length} Selected`
 										: (valueArray[0].label ??
-											options.find((option) => option.value === valueArray[0])?.label ??
+											options.find((option) => option.value === valueArray[0].value)?.label ??
 											'1 Selected')}
 								</span>
 								<button

--- a/src/packages/admin-ui-components/src/combo-box/component.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/component.tsx
@@ -366,6 +366,13 @@ export const ComboBox = ({
 								</li>
 							))}
 
+							{/* Show a message if there are no options */}
+							{options.length === 0 && (
+								<li className={clsx(styles.option, styles.nonSelectableOption)}>
+									No options found
+								</li>
+							)}
+
 							{/* Show loading indicator for lazy loading */}
 							{dataFetcher && isLoadingMore && (
 								<li className={styles.loadingMore}>

--- a/src/packages/admin-ui-components/src/combo-box/styles.module.css
+++ b/src/packages/admin-ui-components/src/combo-box/styles.module.css
@@ -58,6 +58,11 @@
 	outline: none;
 }
 
+/* Hide caret when input is read-only (allowFreeTyping = false) */
+.selectInput[readonly] {
+	caret-color: transparent;
+}
+
 .select:has(input:focus) .selectInput {
 	color: var(--body-copy-color);
 }
@@ -177,4 +182,28 @@
 .focused {
 	background-color: #ffffff0c;
 	opacity: 0.8;
+}
+
+.loadingMore {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 12px 8px;
+	color: #6c757d;
+	font-size: 14px;
+	cursor: default;
+	justify-content: center;
+}
+
+.loadingMore span {
+	margin-left: 4px;
+}
+
+.endOfList {
+	padding: 8px;
+	color: #6c757d;
+	font-size: 14px;
+	text-align: center;
+	cursor: default;
+	font-style: italic;
 }

--- a/src/packages/admin-ui-components/src/combo-box/styles.module.css
+++ b/src/packages/admin-ui-components/src/combo-box/styles.module.css
@@ -29,10 +29,31 @@
 
 .inputContainer {
 	display: flex;
-	flex-wrap: wrap;
+	flex-wrap: nowrap;
 	align-items: center;
 	width: calc(100% - 30px);
 	min-height: 28px;
+	overflow-x: auto;
+	overflow-y: hidden;
+	scrollbar-width: thin;
+	scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+}
+
+.inputContainer::-webkit-scrollbar {
+	height: 4px;
+}
+
+.inputContainer::-webkit-scrollbar-track {
+	background: transparent;
+}
+
+.inputContainer::-webkit-scrollbar-thumb {
+	background-color: rgba(255, 255, 255, 0.3);
+	border-radius: 2px;
+}
+
+.inputContainer::-webkit-scrollbar-thumb:hover {
+	background-color: rgba(255, 255, 255, 0.5);
 }
 
 .selectedOptions {
@@ -40,11 +61,13 @@
 	flex-wrap: nowrap;
 	padding: 0 4px;
 	z-index: 2;
+	flex-shrink: 0;
 }
 
 .inputWrapper {
 	flex: 1;
 	min-width: 50px;
+	flex-shrink: 0;
 }
 
 .selectInput {
@@ -199,7 +222,7 @@
 	margin-left: 4px;
 }
 
-.endOfList {
+.nonSelectableOption {
 	padding: 8px;
 	color: #6c757d;
 	font-size: 14px;

--- a/src/packages/admin-ui-components/src/combo-box/styles.module.css
+++ b/src/packages/admin-ui-components/src/combo-box/styles.module.css
@@ -187,6 +187,9 @@
 	transform-origin: center;
 	border-color: #fff transparent transparent transparent;
 	transition: transform 0.2s ease-in-out;
+	background: none;
+	border: none;
+	padding: 0;
 }
 
 .arrowOpen {

--- a/src/packages/admin-ui-components/src/detail-panel/graphql.ts
+++ b/src/packages/admin-ui-components/src/detail-panel/graphql.ts
@@ -7,7 +7,10 @@ export const generateUpdateEntityMutation = (
 ) => gql`
     mutation updateEntity ($input: ${entity.name}UpdateInput!){
       update${entity.name} (input: $input) {
-        ${generateGqlSelectForEntityFields(entity.fields.filter((field) => !field.hideInDetailForm), entityByType)}
+        ${generateGqlSelectForEntityFields(
+					entity.fields.filter((field) => !field.hideInDetailForm),
+					entityByType
+				)}
       }
     }
   `;
@@ -18,7 +21,10 @@ export const generateCreateEntityMutation = (
 ) => gql`
     mutation createEntity ($input: ${entity.name}InsertInput!){
       create${entity.name} (input: $input) {
-        ${generateGqlSelectForEntityFields(entity.fields.filter((field) => !field.hideInDetailForm), entityByType)}
+        ${generateGqlSelectForEntityFields(
+					entity.fields.filter((field) => !field.hideInDetailForm),
+					entityByType
+				)}
       }
     }
   `;
@@ -40,8 +46,8 @@ export const getRelationshipQuery = (entity: Entity) => {
 	const queryName = plural[0].toLowerCase() + plural.slice(1);
 
 	return gql`
-    query getRelationship ($pagination: ${plural}PaginationInput) {
-      result: ${queryName} (pagination: $pagination) {
+    query getRelationship ($filter: ${plural}ListFilter, $pagination: ${plural}PaginationInput) {
+      result: ${queryName} (filter: $filter, pagination: $pagination) {
         ${primaryKeyField}
         ${summaryField ? summaryField : ''}
       }

--- a/src/packages/admin-ui-components/src/entity-list/component.tsx
+++ b/src/packages/admin-ui-components/src/entity-list/component.tsx
@@ -84,9 +84,11 @@ export const EntityList = <TData extends Record<string, unknown>>({
 	);
 
 	if (error) {
+		console.error(error);
 		return <ErrorView message={error.message} />;
 	}
 	if (!loading && !data) {
+		console.error('Error! Unable to load entity, both loading and data are falsey.');
 		return <ErrorView message="Error! Unable to load entity." />;
 	}
 

--- a/src/packages/admin-ui-components/src/filter-bar/component.tsx
+++ b/src/packages/admin-ui-components/src/filter-bar/component.tsx
@@ -146,7 +146,7 @@ export const FilterBar = ({ iconBefore }: { iconBefore?: ReactNode }) => {
 					break;
 				case AdminUIFilterType.RELATIONSHIP:
 					component = <RelationshipFilter key={field.name} {...options} />;
-					width = '200px';
+					width = '250px';
 					break;
 				case AdminUIFilterType.ENUM:
 					component = <EnumFilter key={field.name} {...options} />;

--- a/src/packages/admin-ui-components/src/filters/dropdown-text-filter.tsx
+++ b/src/packages/admin-ui-components/src/filters/dropdown-text-filter.tsx
@@ -52,10 +52,15 @@ export const DropdownTextFilter = ({
 			}
 
 			const query = getFilterOptionsQuery(entityType, fieldName);
-
 			const orderByForQuery = { [fieldName]: 'ASC' };
-
 			const searchFilter = searchTerm ? substringFilterForFields([field], searchTerm) : undefined;
+
+			if (!query) {
+				console.warn(
+					`Query not found for field '${fieldName}' in entity '${entity}', skipping data fetch.`
+				);
+				return [];
+			}
 
 			const { data } = await apolloClient.query<{ result: any[] }>({
 				query,

--- a/src/packages/admin-ui-components/src/filters/dropdown-text-filter.tsx
+++ b/src/packages/admin-ui-components/src/filters/dropdown-text-filter.tsx
@@ -31,20 +31,26 @@ export const DropdownTextFilter = ({
 	const apolloClient = useApolloClient();
 	const entityType = entityByName(entity);
 	const field = entityType?.fields.find((f) => f.name === fieldName);
-	if (!field) return null;
-
 	const currentFilterValue = (filter?.[`${fieldName}_in`] as string[]) ?? [];
 
-	const handleOnChange = (options?: SelectOption[]) => {
-		const hasSelectedOptions = (options ?? [])?.length > 0;
-		onChange?.(
-			fieldName,
-			hasSelectedOptions ? { [`${fieldName}_in`]: options?.map((option) => option.value) } : {}
-		);
-	};
+	const handleOnChange = useCallback(
+		(options?: SelectOption[]) => {
+			const hasSelectedOptions = (options ?? [])?.length > 0;
+			onChange?.(
+				fieldName,
+				hasSelectedOptions ? { [`${fieldName}_in`]: options?.map((option) => option.value) } : {}
+			);
+		},
+		[fieldName, onChange]
+	);
 
 	const dataFetcher = useCallback(
 		async ({ page, searchTerm }: DataFetchOptions) => {
+			if (!field) {
+				console.warn(`Field '${fieldName}' not found in entity '${entity}', skipping data fetch.`);
+				return [];
+			}
+
 			const query = getFilterOptionsQuery(entityType, fieldName);
 
 			const orderByForQuery = { [fieldName]: 'ASC' };
@@ -70,6 +76,8 @@ export const DropdownTextFilter = ({
 		},
 		[apolloClient, entityType, fieldName, field]
 	);
+
+	if (!field) return null;
 
 	return (
 		<ComboBox

--- a/src/packages/admin-ui-components/src/filters/dropdown-text-filter.tsx
+++ b/src/packages/admin-ui-components/src/filters/dropdown-text-filter.tsx
@@ -1,5 +1,4 @@
-import { useApolloClient, useFragment } from '@apollo/client';
-
+import { useApolloClient } from '@apollo/client';
 import {
 	ComboBox,
 	DataFetchOptions,
@@ -8,9 +7,9 @@ import {
 	SelectOption,
 	useSchema,
 	substringFilterForFields,
+	toSelectOption,
 } from '..';
-import { fragmentForDisplayValueOfEntity, getFilterOptionsQuery } from './graphql';
-import { toSelectOption } from './utils';
+import { getFilterOptionsQuery } from './graphql';
 import { useCallback } from 'react';
 
 export interface DropdownTextFilterProps {
@@ -35,16 +34,6 @@ export const DropdownTextFilter = ({
 	if (!field) return null;
 
 	const currentFilterValue = (filter?.[`${fieldName}_in`] as string[]) ?? [];
-
-	// This reads the data for the field directly from the Apollo cache without going back to
-	// the server. We only need the first item for display purposes since we only show one label.
-	const { data: displayData } = useFragment({
-		...fragmentForDisplayValueOfEntity(entityType),
-		from: {
-			__typename: entityType.name,
-			[entityType.primaryKeyField]: currentFilterValue[0],
-		},
-	});
 
 	const handleOnChange = (options?: SelectOption[]) => {
 		const hasSelectedOptions = (options ?? [])?.length > 0;
@@ -76,25 +65,16 @@ export const DropdownTextFilter = ({
 
 			return data.result.map((item: any) => ({
 				label: item[fieldName] || 'notfound',
-				value: item[entityType.primaryKeyField],
+				value: item[fieldName],
 			}));
 		},
 		[apolloClient, entityType, fieldName, field]
 	);
 
-	// Build the current value with proper labels from the cache
-	const currentValue =
-		currentFilterValue.length === 1
-			? {
-					label: displayData?.[fieldName] ?? currentFilterValue[0],
-					value: currentFilterValue[0],
-				}
-			: currentFilterValue.map(toSelectOption);
-
 	return (
 		<ComboBox
 			key={fieldName}
-			value={currentValue}
+			value={currentFilterValue.map(toSelectOption)}
 			placeholder={fieldName}
 			onChange={handleOnChange}
 			allowFreeTyping={!!field.filter?.options?.substringMatch}

--- a/src/packages/admin-ui-components/src/filters/graphql.ts
+++ b/src/packages/admin-ui-components/src/filters/graphql.ts
@@ -1,7 +1,9 @@
 import { gql } from '@apollo/client';
 import { Entity } from '../utils';
 
-export const getRelationshipQuery = (entity: Entity) => {
+export const getRelationshipQuery = (entity?: Entity) => {
+	if (!entity) return;
+
 	const queryName = entity.plural[0].toLowerCase() + entity.plural.slice(1);
 
 	return gql`
@@ -14,7 +16,9 @@ export const getRelationshipQuery = (entity: Entity) => {
 	`;
 };
 
-export const getFilterOptionsQuery = (entity: Entity, fieldName: string) => {
+export const getFilterOptionsQuery = (entity: Entity | undefined, fieldName: string) => {
+	if (!entity) return;
+
 	const queryName = entity.plural[0].toLowerCase() + entity.plural.slice(1);
 
 	return gql`
@@ -27,12 +31,25 @@ export const getFilterOptionsQuery = (entity: Entity, fieldName: string) => {
 	`;
 };
 
-export const fragmentForDisplayValueOfEntity = (entity: Entity) => ({
-	fragmentName: `${entity.name}DisplayValue`,
-	fragment: gql`
-		fragment ${entity.name}DisplayValue on ${entity.name} {
-			${entity.primaryKeyField}
-			${entity.summaryField}
-		}
-	`,
-});
+export const fragmentForDisplayValueOfEntity = (entity?: Entity) => {
+	if (!entity) {
+		return {
+			fragmentName: 'EmptyFragment',
+			fragment: gql`
+				fragment EmptyFragment on Empty {
+					id
+				}
+			`,
+		};
+	}
+
+	return {
+		fragmentName: `${entity.name}DisplayValue`,
+		fragment: gql`
+			fragment ${entity.name}DisplayValue on ${entity.name} {
+				${entity.primaryKeyField}
+				${entity.summaryField ?? ''}
+			}
+		`,
+	};
+};

--- a/src/packages/admin-ui-components/src/filters/graphql.ts
+++ b/src/packages/admin-ui-components/src/filters/graphql.ts
@@ -8,21 +8,20 @@ export const getRelationshipQuery = (entity: Entity) => {
 		query getRelationship ($filter: ${entity.plural}ListFilter, $pagination: ${entity.plural}PaginationInput) {
 			result: ${queryName} (filter: $filter, pagination: $pagination) {
 				${entity.primaryKeyField}
-				${entity.summaryField ? entity.summaryField : ''}
+				${entity.summaryField ?? ''}
 			}
 		}
 	`;
 };
 
-export const queryForFilterOptions = (entity: Entity, fieldName: string) => {
-	const pluralName = entity.plural;
-	const queryName = pluralName[0].toLowerCase() + pluralName.slice(1);
+export const getFilterOptionsQuery = (entity: Entity, fieldName: string) => {
+	const queryName = entity.plural[0].toLowerCase() + entity.plural.slice(1);
 
 	return gql`
-		query ${pluralName}FilterOptions {
-			result: ${queryName} {
+		query getFilterOptions ($filter: ${entity.plural}ListFilter, $pagination: ${entity.plural}PaginationInput) {
+			result: ${queryName} (filter: $filter, pagination: $pagination) {
 				${entity.primaryKeyField}
-				${fieldName}
+				${fieldName !== entity.primaryKeyField ? fieldName : ''}
 			}
 		}
 	`;

--- a/src/packages/admin-ui-components/src/filters/relationship-filter.tsx
+++ b/src/packages/admin-ui-components/src/filters/relationship-filter.tsx
@@ -43,15 +43,11 @@ export const RelationshipFilter = ({
 	const apolloClient = useApolloClient();
 	const entityType = entityByName(entity);
 	const field = entityType?.fields.find((f) => f.name === fieldName);
-	if (!field?.type) return null;
-
 	const relationshipEntity =
 		field && field.relationshipType === 'MANY_TO_ONE'
 			? entities.find((e) => e === field.type)
 			: undefined;
-
-	if (!relationshipEntity) return null;
-	const relatedEntity = entityByName(relationshipEntity);
+	const relatedEntity = entityByName(relationshipEntity ?? '');
 
 	const currentFilterValue =
 		(filter?.[fieldName] as Record<string, string[]> | undefined)?.[
@@ -90,19 +86,22 @@ export const RelationshipFilter = ({
 		},
 	});
 
-	const handleOnChange = (options?: SelectOption[]) => {
-		const hasSelectedOptions = (options ?? [])?.length > 0;
-		onChange?.(
-			fieldName,
-			hasSelectedOptions
-				? {
-						[fieldName]: {
-							[`${relatedEntity.primaryKeyField}_in`]: options?.map((option) => option.value),
-						},
-					}
-				: {}
-		);
-	};
+	const handleOnChange = useCallback(
+		(options?: SelectOption[]) => {
+			const hasSelectedOptions = (options ?? [])?.length > 0;
+			onChange?.(
+				fieldName,
+				hasSelectedOptions
+					? {
+							[fieldName]: {
+								[`${relatedEntity.primaryKeyField}_in`]: options?.map((option) => option.value),
+							},
+						}
+					: {}
+			);
+		},
+		[fieldName, onChange, relatedEntity.primaryKeyField]
+	);
 
 	const dataFetcher = useCallback(
 		async ({ page, searchTerm }: DataFetchOptions) => {

--- a/src/packages/admin-ui-components/src/filters/relationship-filter.tsx
+++ b/src/packages/admin-ui-components/src/filters/relationship-filter.tsx
@@ -1,10 +1,10 @@
-import { useFragment, useLazyQuery } from '@apollo/client';
+import { useApolloClient, useFragment } from '@apollo/client';
 
-import { ComboBox, SelectMode, SelectOption } from '../combo-box';
+import { ComboBox, DataFetchOptions, SelectMode, SelectOption } from '../combo-box';
 import { Filter, useSchema } from '../utils';
 import { fragmentForDisplayValueOfEntity, getRelationshipQuery } from './graphql';
 import { toSelectOption } from './utils';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 export type RelationshipFilterType = { [fieldIn: string]: string[] };
 
@@ -28,6 +28,8 @@ export interface RelationshipFilterProps {
 	dropdownItemsFilter?: Filter;
 }
 
+const PAGE_SIZE = 100;
+
 export const RelationshipFilter = ({
 	fieldName,
 	entity,
@@ -38,6 +40,7 @@ export const RelationshipFilter = ({
 	dropdownItemsFilter,
 }: RelationshipFilterProps) => {
 	const { entityByName, entities } = useSchema();
+	const apolloClient = useApolloClient();
 	const entityType = entityByName(entity);
 	const [inputValue, setInputValue] = useState('');
 	const field = entityType?.fields.find((f) => f.name === fieldName);
@@ -103,35 +106,41 @@ export const RelationshipFilter = ({
 		dropdownFilter = dropdownItemsFilter;
 	}
 
-	const [fetchRelationshipOptionsList, { data, loading, error }] = useLazyQuery<{
-		result: any[];
-	}>(getRelationshipQuery(relatedEntity), {
-		variables: {
-			filter: Object.keys(dropdownFilter).length > 0 ? dropdownFilter : undefined,
+	const dataFetcher = useCallback(
+		async ({ page }: DataFetchOptions) => {
+			const query = getRelationshipQuery(relatedEntity);
 
-			...(relatedEntity.summaryField
-				? {
-						pagination: {
-							orderBy: orderBy ?? { [relatedEntity.summaryField]: 'ASC' },
-						},
-					}
-				: {}),
+			// If there's a user specified orderBy, use that. Otherwise, use the summary field if it exists,
+			// otherwise fall back to the primary key field. We need some kind of sort so that the pagination
+			// is deterministic.
+			const orderByForQuery =
+				orderBy ??
+				(relatedEntity.summaryField
+					? { [relatedEntity.summaryField]: 'ASC' }
+					: { [relatedEntity.primaryKeyField]: 'ASC' });
+
+			const { data } = await apolloClient.query<{ result: any[] }>({
+				query,
+				variables: {
+					filter: Object.keys(dropdownFilter).length > 0 ? dropdownFilter : undefined,
+					pagination: {
+						orderBy: orderByForQuery,
+						limit: PAGE_SIZE,
+						offset: Math.max(0, (page - 1) * PAGE_SIZE),
+					},
+				},
+			});
+
+			return data.result.map((item: any) => {
+				const label = relatedEntity.summaryField ?? relatedEntity.primaryKeyField;
+				return {
+					label: label ? item[label] : 'notfound',
+					value: item[relatedEntity.primaryKeyField],
+				};
+			});
 		},
-	});
-
-	const handleOnOpen = () => {
-		if (!data && !loading && !error) {
-			fetchRelationshipOptionsList();
-		}
-	};
-
-	const relationshipOptions = (data?.result ?? []).map<SelectOption>((item) => {
-		const label = relatedEntity.summaryField ?? relatedEntity.primaryKeyField;
-		return {
-			label: label ? (item as any)[label] : 'notfound',
-			value: item[relatedEntity.primaryKeyField],
-		};
-	});
+		[apolloClient, relatedEntity, dropdownFilter, orderBy]
+	);
 
 	const currentValue =
 		currentFilterValue.length === 1
@@ -146,16 +155,14 @@ export const RelationshipFilter = ({
 	return (
 		<ComboBox
 			key={fieldName}
-			options={relationshipOptions}
 			value={currentValue}
 			placeholder={fieldName}
 			onChange={handleOnChange}
 			onInputChange={setInputValue}
 			allowFreeTyping={!!searchableFields?.length}
-			onOpen={handleOnOpen}
-			loading={loading}
 			mode={SelectMode.MULTI}
 			data-testid={`${fieldName}-filter`}
+			dataFetcher={dataFetcher}
 		/>
 	);
 };

--- a/src/packages/admin-ui-components/src/filters/relationship-filter.tsx
+++ b/src/packages/admin-ui-components/src/filters/relationship-filter.tsx
@@ -61,7 +61,7 @@ export const RelationshipFilter = ({
 	// If there's a summary field on the entity, and that summary field is marked as searchable, then
 	// it should be added to the searchable fields.
 	if (
-		relatedEntity.summaryField &&
+		relatedEntity?.summaryField &&
 		relatedEntity.fields.find((f) => f.name === relatedEntity.summaryField)?.filter?.options
 			?.substringMatch
 	) {

--- a/src/packages/admin-ui-components/src/utils/index.ts
+++ b/src/packages/admin-ui-components/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './data-loading';
 export * from './graphql';
 export * from './route-for';
+export * from './search-filter';
 export * from './timestamp';
 export * from './trace-to-tree';
 export * from './use-schema';

--- a/src/packages/admin-ui-components/src/utils/search-filter.ts
+++ b/src/packages/admin-ui-components/src/utils/search-filter.ts
@@ -1,0 +1,31 @@
+import { EntityField, Filter } from './index';
+
+export const substringOperatorForField = (fieldMetadata: EntityField) =>
+	fieldMetadata.filter?.options?.caseInsensitive ? 'ilike' : 'like';
+
+export const substringFilterForFields = (
+	fieldMetadata: EntityField[],
+	inputValue: string,
+	additionalFilter?: Filter
+): Filter | undefined => {
+	let searchTermFilter: Filter | undefined;
+	if (inputValue && fieldMetadata.length === 1) {
+		searchTermFilter = {
+			[`${fieldMetadata[0].name}_${substringOperatorForField(fieldMetadata[0])}`]: `%${inputValue}%`,
+		};
+	} else if (inputValue) {
+		searchTermFilter = {
+			// We are intentionally not passing in the additional filter here because
+			// we want to search all fields for the search term and not add the additional filter
+			// to each field.
+			_or: fieldMetadata.map((fieldMetadata) =>
+				substringFilterForFields([fieldMetadata], inputValue)
+			),
+		};
+	}
+
+	if (searchTermFilter && !additionalFilter) return searchTermFilter;
+	else if (!searchTermFilter && additionalFilter) return additionalFilter;
+	else if (!searchTermFilter && !additionalFilter) return;
+	else return { _and: [searchTermFilter, additionalFilter] };
+};

--- a/src/packages/apollo-client/src/index.ts
+++ b/src/packages/apollo-client/src/index.ts
@@ -34,8 +34,6 @@ const generateTypePolicyFields = (entities: Entity[]) => {
 				};
 			} | null
 		) => {
-			console.log('Apollo cache keyArgs called with args:', args);
-
 			// Remove Order Stabilization Keys
 			const filters = (args?.filter ?? {}) as unknown as FilterWithStabilization;
 			if (filters[stabilizationKeys]) {

--- a/src/packages/apollo-client/src/index.ts
+++ b/src/packages/apollo-client/src/index.ts
@@ -27,7 +27,11 @@ const generateTypePolicyFields = (entities: Entity[]) => {
 		keyArgs: (
 			args: {
 				filter?: Record<string, unknown>;
-				pagination?: { orderBy: Record<string, unknown> };
+				pagination?: {
+					orderBy: Record<string, unknown>;
+					offset?: number;
+					limit?: number;
+				};
 			} | null
 		) => {
 			// Remove Order Stabilization Keys
@@ -40,10 +44,11 @@ const generateTypePolicyFields = (entities: Entity[]) => {
 			}
 
 			const filter = JSON.stringify(filters);
-			const orderBy = args?.pagination?.orderBy ? JSON.stringify(args.pagination.orderBy) : '';
+			const pagination = args?.pagination ? JSON.stringify(args.pagination) : '';
 
-			// https://www.apollographql.com/docs/react/pagination/key-args/#keyargs-function-advanced
-			return btoa(`${filter}:${orderBy}`);
+			// Include the full pagination object (including offset and limit) in the cache key
+			// This ensures queries with different offset values create separate cache entries
+			return btoa(`${filter}:${pagination}`);
 		},
 		merge(existing = [], incoming: { __ref: string }[]) {
 			const mergeMap = new Map<string, { __ref: string }>();

--- a/src/packages/apollo-client/src/index.ts
+++ b/src/packages/apollo-client/src/index.ts
@@ -50,22 +50,9 @@ const generateTypePolicyFields = (entities: Entity[]) => {
 
 			// Include the full pagination object (including offset and limit) in the cache key
 			// This ensures queries with different offset values create separate cache entries
-			const cacheKey = btoa(`${filter}:${pagination}`);
-
-			console.log('Apollo cache key generated:', {
-				filter,
-				pagination,
-				cacheKey,
-				originalArgs: args,
-			});
-
-			return cacheKey;
+			return btoa(`${filter}:${pagination}`);
 		},
 		merge(existing = [], incoming: { __ref: string }[]) {
-			console.log('Apollo cache merge called:', {
-				existing: existing.length,
-				incoming: incoming.length,
-			});
 			const mergeMap = new Map<string, { __ref: string }>();
 			for (const entity of [...existing, ...incoming]) {
 				mergeMap.set(entity.__ref, entity);

--- a/src/packages/apollo-client/src/index.ts
+++ b/src/packages/apollo-client/src/index.ts
@@ -34,6 +34,8 @@ const generateTypePolicyFields = (entities: Entity[]) => {
 				};
 			} | null
 		) => {
+			console.log('Apollo cache keyArgs called with args:', args);
+
 			// Remove Order Stabilization Keys
 			const filters = (args?.filter ?? {}) as unknown as FilterWithStabilization;
 			if (filters[stabilizationKeys]) {
@@ -48,9 +50,22 @@ const generateTypePolicyFields = (entities: Entity[]) => {
 
 			// Include the full pagination object (including offset and limit) in the cache key
 			// This ensures queries with different offset values create separate cache entries
-			return btoa(`${filter}:${pagination}`);
+			const cacheKey = btoa(`${filter}:${pagination}`);
+
+			console.log('Apollo cache key generated:', {
+				filter,
+				pagination,
+				cacheKey,
+				originalArgs: args,
+			});
+
+			return cacheKey;
 		},
 		merge(existing = [], incoming: { __ref: string }[]) {
+			console.log('Apollo cache merge called:', {
+				existing: existing.length,
+				incoming: incoming.length,
+			});
 			const mergeMap = new Map<string, { __ref: string }>();
 			for (const entity of [...existing, ...incoming]) {
 				mergeMap.set(entity.__ref, entity);

--- a/src/packages/cli/src/init/constants.ts
+++ b/src/packages/cli/src/init/constants.ts
@@ -1,12 +1,12 @@
 import { version, devDependencies } from '../../package.json';
-import { peerDependencies as mikroPackagePeerDependencies } from '../../../mikroorm/package.json';
+import { devDependencies as mikroPackageDevDependencies } from '../../../mikroorm/package.json';
 import { dependencies as graphweaverServerDependencies } from '../../../server/package.json';
 
 export const AS_INTEGRATIONS_AWS_LAMBDA_TARGET_VERSION =
 	graphweaverServerDependencies['@as-integrations/aws-lambda'];
 export const GRAPHQL_TARGET_VERSION = graphweaverServerDependencies.graphql;
 export const GRAPHWEAVER_TARGET_VERSION = version;
-export const MIKRO_ORM_TARGET_VERSION = mikroPackagePeerDependencies['@mikro-orm/core'];
+export const MIKRO_ORM_TARGET_VERSION = mikroPackageDevDependencies['@mikro-orm/core'];
 export const NODE_TYPES_TARGET_VERSION = devDependencies['@types/node'];
 export const TYPESCRIPT_TARGET_VERSION = devDependencies.typescript;
 

--- a/src/packages/end-to-end/src/__tests__/ui/sqlite/components/combobox.test.ts
+++ b/src/packages/end-to-end/src/__tests__/ui/sqlite/components/combobox.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@playwright/test';
 import { config } from '../../../../config';
-import { bodyHasText } from '../../../../utils';
 
 test('Check Select field displays correct number of selected items based on initial values', async ({
 	page,

--- a/src/packages/end-to-end/src/__tests__/ui/sqlite/components/combobox.test.ts
+++ b/src/packages/end-to-end/src/__tests__/ui/sqlite/components/combobox.test.ts
@@ -19,8 +19,10 @@ test('Check Select field shows correct number of selected items after adding add
 	await page.goto(config.adminUiUrl);
 	await page.getByRole('link', { name: 'Album' }).click();
 	await page.getByRole('cell', { name: '3', exact: true }).click();
-	await page.waitForResponse(bodyHasText('Eine Kleine Nachtmusik'));
-	await page.locator('input#detail-panel-field-tracks-input').click({ delay: 1000 });
+	await page
+		.locator('div')
+		.filter({ hasText: /^tracks3 Selected×$/ })
+		.click({ delay: 1000 });
 	await page.getByRole('listbox').getByText('"40"').click();
 	await expect(page.locator('form')).toContainText('4 Selected');
 });
@@ -31,9 +33,11 @@ test('Check adding additional item to OneToMany field and saving functions as ex
 	await page.goto(config.adminUiUrl);
 	await page.getByRole('link', { name: 'Album' }).click();
 	await page.getByRole('cell', { name: 'For Those About To Rock We' }).click();
-	await page.waitForResponse(bodyHasText('Eine Kleine Nachtmusik'));
-	await page.locator('input#detail-panel-field-tracks-input').click({ delay: 1000 });
-	await page.locator('li').getByText('"40"').click();
+	await page
+		.locator('div')
+		.filter({ hasText: /^tracks10 Selected×$/ })
+		.click({ delay: 1000 });
+	await page.getByText('"40"').click();
 	await expect(page.locator('form')).toContainText('11 Selected');
 	await page.getByRole('button', { name: 'Save' }).click();
 	await expect(

--- a/src/packages/end-to-end/src/__tests__/ui/sqlite/components/export-csv.test.ts
+++ b/src/packages/end-to-end/src/__tests__/ui/sqlite/components/export-csv.test.ts
@@ -36,18 +36,22 @@ test('Export CSV with nested entities', async ({ page }) => {
 
 	const csvRaw = await saveDownload(await exportEvent, { filename: 'albums-export.csv' });
 	const csv = parse(csvRaw, { columns: true });
-	expect(csv).toEqual(expect.arrayContaining([
-		expect.objectContaining({
-			"albumId": "1",
-			"artist": "AC/DC",
-			"title": "For Those About To Rock We Salute You",
-			"tracks": "For Those About To Rock (We Salute You), Put The Finger On You, Let's Get It Up, Inject The Venom, Snowballed, Evil Walks, C.O.D., Breaking The Rules, Night Of The Long Knives, Spellbound, \"40\""
-		  }),
-		  expect.objectContaining({
-			"albumId": "4",
-			"artist": "AC/DC",
-			"title": "Let There Be Rock",
-			"tracks": "Go Down, Dog Eat Dog, Let There Be Rock, Bad Boy Boogie, Problem Child, Overdose, Hell Ain't A Bad Place To Be, Whole Lotta Rosie"
-		  })
-	]));
+	expect(csv).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				albumId: '1',
+				artist: 'AC/DC',
+				title: 'For Those About To Rock We Salute You',
+				tracks:
+					"For Those About To Rock (We Salute You), Put The Finger On You, Let's Get It Up, Inject The Venom, Snowballed, Evil Walks, C.O.D., Breaking The Rules, Night Of The Long Knives, Spellbound",
+			}),
+			expect.objectContaining({
+				albumId: '4',
+				artist: 'AC/DC',
+				title: 'Let There Be Rock',
+				tracks:
+					"Go Down, Dog Eat Dog, Let There Be Rock, Bad Boy Boogie, Problem Child, Overdose, Hell Ain't A Bad Place To Be, Whole Lotta Rosie",
+			}),
+		])
+	);
 });

--- a/src/packages/end-to-end/src/__tests__/ui/sqlite/components/export-csv.test.ts
+++ b/src/packages/end-to-end/src/__tests__/ui/sqlite/components/export-csv.test.ts
@@ -42,15 +42,13 @@ test('Export CSV with nested entities', async ({ page }) => {
 				albumId: '1',
 				artist: 'AC/DC',
 				title: 'For Those About To Rock We Salute You',
-				tracks:
-					"For Those About To Rock (We Salute You), Put The Finger On You, Let's Get It Up, Inject The Venom, Snowballed, Evil Walks, C.O.D., Breaking The Rules, Night Of The Long Knives, Spellbound",
+				tracks: `For Those About To Rock (We Salute You), Put The Finger On You, Let's Get It Up, Inject The Venom, Snowballed, Evil Walks, C.O.D., Breaking The Rules, Night Of The Long Knives, Spellbound, "40"`,
 			}),
 			expect.objectContaining({
 				albumId: '4',
 				artist: 'AC/DC',
 				title: 'Let There Be Rock',
-				tracks:
-					"Go Down, Dog Eat Dog, Let There Be Rock, Bad Boy Boogie, Problem Child, Overdose, Hell Ain't A Bad Place To Be, Whole Lotta Rosie",
+				tracks: `Go Down, Dog Eat Dog, Let There Be Rock, Bad Boy Boogie, Problem Child, Overdose, Hell Ain't A Bad Place To Be, Whole Lotta Rosie, "40"`,
 			}),
 		])
 	);

--- a/src/packages/end-to-end/src/__tests__/ui/sqlite/components/export-csv.test.ts
+++ b/src/packages/end-to-end/src/__tests__/ui/sqlite/components/export-csv.test.ts
@@ -48,7 +48,7 @@ test('Export CSV with nested entities', async ({ page }) => {
 				albumId: '4',
 				artist: 'AC/DC',
 				title: 'Let There Be Rock',
-				tracks: `Go Down, Dog Eat Dog, Let There Be Rock, Bad Boy Boogie, Problem Child, Overdose, Hell Ain't A Bad Place To Be, Whole Lotta Rosie, "40"`,
+				tracks: `Go Down, Dog Eat Dog, Let There Be Rock, Bad Boy Boogie, Problem Child, Overdose, Hell Ain't A Bad Place To Be, Whole Lotta Rosie`,
 			}),
 		])
 	);


### PR DESCRIPTION
This PR adds:

* Infinite scroll with pagination to relationship fields and filters.
* If you configure your relationship fields to be substring searchable, then the relationship fields and filters will allow users to type a search query. This is sent to the backend with a `like` or `ilike` `%${query}%` depending on whether you've set it to case insensitive or not. To make this performant it's recommended to use trigram indexes on these fields, or to only enable on small datasets.

This should resolve issues loading large amounts of related data in the dropdowns for relationships and gives developers more options to customise the admin UI for large datasets.

In addition, while working on this I resolved the following:
- End to End tests were using the latest version of MikroORM because the version is just `"6"` in the peer dependencies. The latest version of Mikro is breaking things for us, and users shouldn't get the absolute latest version of Mikro out of the box unless we've tested it. Our generated project now uses the exact version we used in CI to test, so we know they'll get a working experience out of the box at least. If they then upgrade to a more recent version and that breaks things, that's cool, we will work on fixing it, but at least that's not their out of the box experience.
- Fixed two breaking end-to-end tests around the combobox.