### PR TITLE
Fix / Show selected items in combo box

### DIFF
--- a/.github/workflows/postgres-end-to-end-tests.yml
+++ b/.github/workflows/postgres-end-to-end-tests.yml
@@ -81,7 +81,7 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
-          path: playwright-report/
+          path: src/packages/end-to-end/playwright-report/
           retention-days: 1
 
     env:

--- a/.github/workflows/postgres-end-to-end-tests.yml
+++ b/.github/workflows/postgres-end-to-end-tests.yml
@@ -77,6 +77,13 @@ jobs:
           pnpm test-ui-postgres &&
           killall node
 
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 1
+
     env:
       CI: true
       DATABASE_HOST: localhost

--- a/.github/workflows/postgres-end-to-end-tests.yml
+++ b/.github/workflows/postgres-end-to-end-tests.yml
@@ -77,13 +77,6 @@ jobs:
           pnpm test-ui-postgres &&
           killall node
 
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: playwright-report
-          path: src/packages/end-to-end/playwright-report/
-          retention-days: 1
-
     env:
       CI: true
       DATABASE_HOST: localhost

--- a/src/packages/admin-ui-components/src/combo-box/combo-box.mdx
+++ b/src/packages/admin-ui-components/src/combo-box/combo-box.mdx
@@ -44,6 +44,12 @@ ComboBoxes can have pre-selected values for both single and multi-select modes.
 
 <Canvas of={ComboBoxStories.WithMultipleSelectedValues} />
 
+#### Selected Items in Dropdown
+
+When using multi-select mode, selected items appear at the top of the dropdown as purple lozenges. Users can click on individual lozenges to deselect them, and the items will return to the main options list in their original order.
+
+<Canvas of={ComboBoxStories.SelectedItemsInDropdown} />
+
 ### States and Variations
 
 #### Loading State
@@ -125,6 +131,9 @@ When using the lazy loading feature, you can configure these additional properti
 - Use placeholder text to give users a hint about what to select
 - Include a loading state for asynchronously loaded options
 - For very short lists (2-5 items), consider using radio buttons or checkboxes instead
+- **Multi-select UX**: In multi-select mode, selected items appear at the top of the dropdown for easy access and deselection
+- **Individual Deselection**: Users can click on individual selected item lozenges to remove them without affecting other selections
+- **Order Preservation**: When items are deselected, they return to their original position in the options list
 - **Lazy Loading**: Use lazy loading with infinite scroll for datasets with more than 100 items to improve performance
 - **Search Integration**: When implementing lazy loading, ensure your data fetcher properly handles search terms for optimal user experience
 - **Page Size**: Choose an appropriate page size (typically 20-50 items) in your data fetcher based on your data structure and API capabilities

--- a/src/packages/admin-ui-components/src/combo-box/combo-box.stories.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/combo-box.stories.tsx
@@ -135,6 +135,31 @@ export const WithMultipleSelectedValues: Story = {
 		value: [fruitOptions[0], fruitOptions[3]], // Apple and Durian
 		placeholder: 'Select fruits',
 	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"This ComboBox shows multiple selected items. When you open the dropdown, you'll see the selected items at the top with purple lozenges that can be clicked to deselect individual items.",
+			},
+		},
+	},
+};
+
+export const SelectedItemsInDropdown: Story = {
+	args: {
+		options: fruitOptions,
+		mode: SelectMode.MULTI,
+		value: [fruitOptions[0], fruitOptions[2], fruitOptions[4]], // Apple, Cherry, Elderberry
+		placeholder: 'Select fruits',
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'This ComboBox demonstrates the selected items feature. Selected items appear at the top of the dropdown as purple lozenges. Click on any lozenge to deselect that item, and it will return to the main options list in its original order.',
+			},
+		},
+	},
 };
 
 export const Loading: Story = {

--- a/src/packages/admin-ui-components/src/combo-box/component.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/component.tsx
@@ -268,7 +268,12 @@ export const ComboBox = ({
 				<div className={styles.inputContainer}>
 					{valueArray.length > 0 && (
 						<div className={styles.selectedOptions}>
-							<div className={styles.optionPill} tabIndex={0} onKeyDown={handleOnPillKeyDown}>
+							<div 
+								className={styles.optionPill} 
+								tabIndex={0} 
+								onKeyDown={handleOnPillKeyDown}
+								
+							>
 								<span className={styles.optionPillLabel}>
 									{valueArray.length > 1
 										? `${valueArray.length} Selected`
@@ -310,6 +315,12 @@ export const ComboBox = ({
 				<button
 					type="button"
 					onClick={() => !disabled && toggleMenu()}
+					onKeyDown={(e) => {
+						if (e.key === 'ArrowDown' && !isOpen) {
+							e.preventDefault()
+							!disabled && toggleMenu()
+						}
+					}}
 					className={clsx(styles.arrow, isOpen && styles.arrowOpen)}
 					aria-label="Toggle dropdown"
 					aria-expanded={isOpen}
@@ -333,6 +344,7 @@ export const ComboBox = ({
 							{valueArray.map((selectedItem) => (
 								<div
 									key={selectedItem.value}
+									role="option"
 									className={clsx(styles.option, styles.selectedOption)}
 									onClick={() => handleItemDeselect(selectedItem)}
 									data-testid={`selected-option-${selectedItem.label}`}

--- a/src/packages/admin-ui-components/src/combo-box/component.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/component.tsx
@@ -330,14 +330,14 @@ export const ComboBox = ({
 					) : (
 						<>
 							{/* Show selected items at the top */}
-							{valueArray.map((selectedItem) => (
+							{valueArray.map((selectedItem, index) => (
 								<li
 									key={selectedItem.value}
 									className={clsx(styles.option, styles.selectedOption)}
 									onClick={() => handleItemDeselect(selectedItem)}
 									data-testid={`selected-option-${selectedItem.label}`}
-									aria-label={`Remove ${selectedItem.label || 'selected item'}`}
-									aria-selected={true}
+									aria-label={selectedItem.label}
+									{...getItemProps({ item: selectedItem as SelectOption, index })}
 								>
 									<span>{selectedItem.label ?? 'Unknown'}</span>
 									<span>
@@ -362,7 +362,6 @@ export const ComboBox = ({
 										key={String(item.value)}
 										{...getItemProps({ item, index })}
 										data-testid={`combo-option-${item.label}`}
-										aria-selected={false}
 									>
 										<span>{item.label}</span>
 									</li>

--- a/src/packages/admin-ui-components/src/combo-box/component.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/component.tsx
@@ -336,19 +336,13 @@ export const ComboBox = ({
 									className={clsx(styles.option, styles.selectedOption)}
 									onClick={() => handleItemDeselect(selectedItem)}
 									data-testid={`selected-option-${selectedItem.label}`}
+									aria-label={`Remove ${selectedItem.label || 'selected item'}`}
+									aria-selected={true}
 								>
 									<span>{selectedItem.label ?? 'Unknown'}</span>
-									<button
-										type="button"
-										className={styles.removeSelectedItem}
-										onClick={(e) => {
-											e.stopPropagation();
-											handleItemDeselect(selectedItem);
-										}}
-										aria-label={`Remove ${selectedItem.label || 'selected item'}`}
-									>
+									<span>
 										&times;
-									</button>
+									</span>
 								</li>
 							))}
 
@@ -368,6 +362,7 @@ export const ComboBox = ({
 										key={String(item.value)}
 										{...getItemProps({ item, index })}
 										data-testid={`combo-option-${item.label}`}
+										aria-selected={false}
 									>
 										<span>{item.label}</span>
 									</li>

--- a/src/packages/admin-ui-components/src/combo-box/component.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/component.tsx
@@ -360,7 +360,7 @@ export const ComboBox = ({
 											[styles.highlighted]: highlightedIndex === index,
 										})}
 										key={String(item.value)}
-										{...getItemProps({ item, index })}
+										{...getItemProps({ item, index: index + valueArray.length })}
 										data-testid={`combo-option-${item.label}`}
 									>
 										<span>{item.label}</span>

--- a/src/packages/admin-ui-components/src/combo-box/component.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/component.tsx
@@ -80,6 +80,8 @@ export const ComboBox = ({
 	const [currentPage, setCurrentPage] = useState(1);
 	const [hasReachedEnd, setHasReachedEnd] = useState(false);
 	const lastSearchTermRef = useRef<string | undefined>(undefined);
+	// We need this to scroll the menu to the top when the dropdown is opened.
+	const dropdownRef = useRef<HTMLUListElement>(null);
 
 	// Use ref to track if we're already loading data to prevent duplicate fetches
 	const fetchedPagesRef = useRef(new Set<number>());
@@ -175,6 +177,13 @@ export const ComboBox = ({
 		},
 		[dataFetcher, isOpen]
 	);
+
+	// Scroll the menu to the top when it's opened.
+	useEffect(() => {
+		if (isOpen && dropdownRef.current) {
+			dropdownRef.current.scrollTop = 0;
+		}
+	}, [isOpen]);
 
 	// Handle search with debouncing - moved here after useCombobox where isOpen is available
 	useEffect(() => {
@@ -310,7 +319,11 @@ export const ComboBox = ({
 				</button>
 			</div>
 
-			<ul className={styles.optionsDropdown} {...getMenuProps()} onScroll={handleScroll}>
+			<ul
+				className={styles.optionsDropdown}
+				{...getMenuProps({ ref: dropdownRef })}
+				onScroll={handleScroll}
+			>
 				{isOpen &&
 					(loading ? (
 						<Spinner />

--- a/src/packages/admin-ui-components/src/combo-box/component.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/component.tsx
@@ -344,6 +344,7 @@ export const ComboBox = ({
 									onClick={() => handleItemDeselect(selectedItem)}
 									data-testid={`selected-option-${selectedItem.label}`}
 									aria-label={`Remove ${selectedItem.label ?? 'Unknown'}`}
+									aria-selected={true}
 								>
 									<span>{selectedItem.label ?? 'Unknown'}</span>
 									<span>

--- a/src/packages/admin-ui-components/src/combo-box/component.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/component.tsx
@@ -268,12 +268,7 @@ export const ComboBox = ({
 				<div className={styles.inputContainer}>
 					{valueArray.length > 0 && (
 						<div className={styles.selectedOptions}>
-							<div 
-								className={styles.optionPill} 
-								tabIndex={0} 
-								onKeyDown={handleOnPillKeyDown}
-								
-							>
+							<div className={styles.optionPill} tabIndex={0} onKeyDown={handleOnPillKeyDown}>
 								<span className={styles.optionPillLabel}>
 									{valueArray.length > 1
 										? `${valueArray.length} Selected`
@@ -316,9 +311,9 @@ export const ComboBox = ({
 					type="button"
 					onClick={() => !disabled && toggleMenu()}
 					onKeyDown={(e) => {
-						if (e.key === 'ArrowDown' && !isOpen) {
-							e.preventDefault()
-							!disabled && toggleMenu()
+						if (e.key === 'ArrowDown' && !isOpen && !disabled) {
+							e.preventDefault();
+							toggleMenu();
 						}
 					}}
 					className={clsx(styles.arrow, isOpen && styles.arrowOpen)}

--- a/src/packages/admin-ui-components/src/combo-box/component.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/component.tsx
@@ -311,9 +311,9 @@ export const ComboBox = ({
 					type="button"
 					onClick={() => !disabled && toggleMenu()}
 					onKeyDown={(e) => {
-						if (e.key === 'ArrowDown' && !isOpen && !disabled) {
+						if ((e.key === 'ArrowDown' || e.key === 'Space') && !disabled) {
 							e.preventDefault();
-							toggleMenu();
+							openMenu();
 						}
 					}}
 					className={clsx(styles.arrow, isOpen && styles.arrowOpen)}

--- a/src/packages/admin-ui-components/src/combo-box/component.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/component.tsx
@@ -330,20 +330,19 @@ export const ComboBox = ({
 					) : (
 						<>
 							{/* Show selected items at the top */}
-							{valueArray.map((selectedItem, index) => (
-								<li
+							{valueArray.map((selectedItem) => (
+								<div
 									key={selectedItem.value}
 									className={clsx(styles.option, styles.selectedOption)}
 									onClick={() => handleItemDeselect(selectedItem)}
 									data-testid={`selected-option-${selectedItem.label}`}
-									aria-label={selectedItem.label}
-									{...getItemProps({ item: selectedItem, index })}
+									aria-label={`Remove ${selectedItem.label ?? 'Unknown'}`}
 								>
 									<span>{selectedItem.label ?? 'Unknown'}</span>
 									<span>
 										&times;
 									</span>
-								</li>
+								</div>
 							))}
 
 							{/* Show separator if there are selected items and regular options */}
@@ -360,7 +359,7 @@ export const ComboBox = ({
 											[styles.highlighted]: highlightedIndex === index,
 										})}
 										key={String(item.value)}
-										{...getItemProps({ item, index: index + valueArray.length })}
+										{...getItemProps({ item, index })}
 										data-testid={`combo-option-${item.label}`}
 									>
 										<span>{item.label}</span>

--- a/src/packages/admin-ui-components/src/combo-box/component.tsx
+++ b/src/packages/admin-ui-components/src/combo-box/component.tsx
@@ -337,7 +337,7 @@ export const ComboBox = ({
 									onClick={() => handleItemDeselect(selectedItem)}
 									data-testid={`selected-option-${selectedItem.label}`}
 									aria-label={selectedItem.label}
-									{...getItemProps({ item: selectedItem as SelectOption, index })}
+									{...getItemProps({ item: selectedItem, index })}
 								>
 									<span>{selectedItem.label ?? 'Unknown'}</span>
 									<span>

--- a/src/packages/admin-ui-components/src/combo-box/styles.module.css
+++ b/src/packages/admin-ui-components/src/combo-box/styles.module.css
@@ -22,7 +22,6 @@
 	border-width: 1px;
 	border-radius: 6px;
 	cursor: pointer;
-	max-height: 35px;
 	min-height: 35px;
 	width: 100%;
 }
@@ -152,6 +151,13 @@
 	display: none;
 	min-width: 250px;
 	width: 250px;
+	list-style: none;
+	padding: 0;
+}
+
+.optionsDropdown li {
+	list-style: none;
+	margin: 0;
 }
 
 .optionsDropdown .selectedOptions {
@@ -165,14 +171,10 @@
 
 .option {
 	cursor: pointer;
-	padding: 8px;
+	padding: 8px 12px;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-}
-
-.selected {
-	background-color: #0000003a;
 }
 
 .highlighted {
@@ -226,10 +228,51 @@
 }
 
 .nonSelectableOption {
-	padding: 8px;
 	color: #6c757d;
 	font-size: 14px;
 	text-align: center;
 	cursor: default;
 	font-style: italic;
+}
+
+.selectedOption {
+	background-color: var(--primary-color);
+	color: #fff;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 1px;
+	padding-right: 8px;
+	white-space: nowrap;
+	overflow: hidden;
+	transition: background-color 0.2s ease;
+}
+
+.selectedOption:hover {
+	background-color: var(--color-red);
+}
+
+.removeSelectedItem {
+	color: #fff;
+	cursor: pointer;
+	font-size: 16px;
+	margin-left: 8px;
+	pointer-events: all;
+	background-color: transparent;
+	border: none;
+	padding: 0;
+	outline: none;
+	font-family: inherit;
+	transition: opacity 0.2s ease;
+}
+
+.removeSelectedItem:hover {
+	opacity: 0.8;
+}
+
+.separator {
+	height: 1px;
+	background-color: var(--select-border-color);
+	margin: 8px 0;
+	cursor: default;
 }

--- a/src/packages/admin-ui-components/src/detail-panel/fields/enum-field.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/fields/enum-field.tsx
@@ -21,7 +21,7 @@ export const EnumField = ({
 		if (multiple) {
 			helpers.setValue(selected.map(({ value }) => value));
 		} else {
-			helpers.setValue(selected?.[0].value);
+			helpers.setValue(selected[0]?.value);
 		}
 	};
 

--- a/src/packages/end-to-end/src/__tests__/ui/postgres/enum-editor.test.ts
+++ b/src/packages/end-to-end/src/__tests__/ui/postgres/enum-editor.test.ts
@@ -9,7 +9,8 @@ test('Detail Panel - should allow editing of an entity with an enum dropdown', a
 
 	// This invoice starts in 'UNPAID' status, so let's change that.
 	await page.getByTestId('detail-panel-field-paymentStatus').click();
-	await page.getByRole('option', { name: 'PAID', exact: true }).click();
+	await expect(page.getByTestId('selected-option-UNPAID')).toBeVisible();
+	await page.getByTestId('combo-option-PAID').click();
 
 	// We should have 'PAID' selected now.
 	await expect(page.getByTestId('detail-panel-field-paymentStatus')).toContainText(

--- a/src/packages/end-to-end/src/__tests__/ui/postgres/enum-editor.test.ts
+++ b/src/packages/end-to-end/src/__tests__/ui/postgres/enum-editor.test.ts
@@ -10,7 +10,7 @@ test('Detail Panel - should allow editing of an entity with an enum dropdown', a
 	// This invoice starts in 'UNPAID' status, so let's change that.
 	await page.getByTestId('detail-panel-field-paymentStatus').click();
 	await expect(page.getByTestId('selected-option-UNPAID')).toBeVisible();
-	await page.getByTestId('combo-option-PAID').click();
+	await page.getByRole('option', { name: 'PAID', exact: true }).click();
 
 	// We should have 'PAID' selected now.
 	await expect(page.getByTestId('detail-panel-field-paymentStatus')).toContainText(

--- a/src/packages/end-to-end/src/__tests__/ui/postgres/enum-editor.test.ts
+++ b/src/packages/end-to-end/src/__tests__/ui/postgres/enum-editor.test.ts
@@ -9,7 +9,6 @@ test('Detail Panel - should allow editing of an entity with an enum dropdown', a
 
 	// This invoice starts in 'UNPAID' status, so let's change that.
 	await page.getByTestId('detail-panel-field-paymentStatus').click();
-	await expect(page.getByTestId('selected-option-UNPAID')).toBeVisible();
 	await page.getByRole('option', { name: 'PAID', exact: true }).click();
 
 	// We should have 'PAID' selected now.

--- a/src/packages/end-to-end/src/__tests__/ui/postgres/enum-editor.test.ts
+++ b/src/packages/end-to-end/src/__tests__/ui/postgres/enum-editor.test.ts
@@ -7,12 +7,16 @@ test('Detail Panel - should allow editing of an entity with an enum dropdown', a
 	await page.getByTestId('Invoice-entity-link').click();
 	await page.getByRole('cell', { name: '1', exact: true }).click();
 
-	// This invoice starts in 'UNPAID' status, so let's change that.
+	// This invoice starts in 'PAID' status, so let's change that.
+	await expect(page.getByTestId('detail-panel-field-paymentStatus')).toContainText(
+		'paymentStatusPAID×'
+	);
+
 	await page.getByTestId('detail-panel-field-paymentStatus').click();
-	await page.getByRole('option', { name: 'PAID', exact: true }).click();
+	await page.getByRole('option', { name: 'UNPAID', exact: true }).click();
 
 	// We should have 'PAID' selected now.
 	await expect(page.getByTestId('detail-panel-field-paymentStatus')).toContainText(
-		'paymentStatusPAID×'
+		'paymentStatusUNPAID×'
 	);
 });


### PR DESCRIPTION
Our UX around selected items is not great at the moment. If one item is selected, it's easy to tell which it is, but once multiple are selected then it is really hard as a user to see what you've chosen.

This PR provides a better UX for this by showing the selected items at the top of the dropdown, always scrolling to the top of the dropdown when it opens, and allowing users to individually deselect options instead of the all or nothing clear we have currently:

**With 3 selected items**
<img width="297" height="266" alt="Screenshot 2025-09-01 at 12 08 44 pm" src="https://github.com/user-attachments/assets/aa195f9e-8e3b-489e-8c82-d98d3b40935b" />

**When hovering a selected item**
<img width="297" height="258" alt="Screenshot 2025-09-01 at 12 08 59 pm" src="https://github.com/user-attachments/assets/56b668a5-dc9b-4ce1-958f-df0c6d7c6729" />

This applies to the `ComboBox`, `RelationshipFilter`, and `RelationshipField` components.