### PR TITLE
Fix / Allow many to many filters for relationship filters.

### DIFF
--- a/src/packages/admin-ui-components/src/filters/relationship-filter.tsx
+++ b/src/packages/admin-ui-components/src/filters/relationship-filter.tsx
@@ -42,10 +42,7 @@ export const RelationshipFilter = ({
 	const apolloClient = useApolloClient();
 	const entityType = entityByName(entity);
 	const field = entityType?.fields.find((f) => f.name === fieldName);
-	const relationshipEntity =
-		field && field.relationshipType === 'MANY_TO_ONE'
-			? entities.find((e) => e === field.type)
-			: undefined;
+	const relationshipEntity = field ? entities.find((e) => e === field.type) : undefined;
 	const relatedEntity = entityByName(relationshipEntity ?? '');
 
 	const currentFilterValue =


### PR DESCRIPTION
We don't care about the relationship type. The field is already set to multi-select anyway.