### PR TITLE
Fix: Link Field breaks on null values when a readonly entity field is `null`.

### DIFF
--- a/src/packages/admin-ui-components/src/detail-panel/fields/link-field.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/fields/link-field.tsx
@@ -24,6 +24,9 @@ export const LinkField = ({ name, field }: { name: string; field: EntityField })
 		}
 	};
 
+	// For when there is no entity on the other side of the relationship
+	if (!formEntity) return <span>—</span>;
+
 	return (
 		<>
 			{field.relationshipType === 'ONE_TO_ONE' || field.relationshipType === 'MANY_TO_ONE' ? (


### PR DESCRIPTION
The entire page was breaking when looking at any entity with a readonly relationship field in the detail panel, when there was nothing on the other end of that relationship.

This PR adds an early return for the case of a null value. If the field is `null`, the component instead spits out an em dash (–). I'll happily take feedback on this, I just wasn't a fan of how returning null looked (the label was stacked on top of the label for the next field in the form).

For reference, this is how it looks (to create this example & test, I unlinked a track from the album it was on in the sqlite example in this repo, and then opened it in the detail panel after building my changes):
<img width="489" height="475" alt="Screenshot 2025-09-05 at 3 22 13 pm" src="https://github.com/user-attachments/assets/fb0045a4-ba6b-483b-8fdb-b72c26f504a9" />
