### PR TITLE
Feature / Count relationship behaviour

### DIFF
--- a/src/examples/auth-zero/src/frontend/types.generated.ts
+++ b/src/examples/auth-zero/src/frontend/types.generated.ts
@@ -93,6 +93,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/auth-zero/src/types.generated.ts
+++ b/src/examples/auth-zero/src/types.generated.ts
@@ -93,6 +93,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/aws-cognito/src/frontend/types.generated.ts
+++ b/src/examples/aws-cognito/src/frontend/types.generated.ts
@@ -91,6 +91,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/aws-cognito/src/types.generated.ts
+++ b/src/examples/aws-cognito/src/types.generated.ts
@@ -91,6 +91,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/federation/src/frontend/types.generated.ts
+++ b/src/examples/federation/src/frontend/types.generated.ts
@@ -94,6 +94,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/federation/src/types.generated.ts
+++ b/src/examples/federation/src/types.generated.ts
@@ -94,6 +94,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/microsoft-entra/src/frontend/types.generated.ts
+++ b/src/examples/microsoft-entra/src/frontend/types.generated.ts
@@ -93,6 +93,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/microsoft-entra/src/types.generated.ts
+++ b/src/examples/microsoft-entra/src/types.generated.ts
@@ -93,6 +93,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/okta/src/frontend/types.generated.ts
+++ b/src/examples/okta/src/frontend/types.generated.ts
@@ -93,6 +93,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/okta/src/types.generated.ts
+++ b/src/examples/okta/src/types.generated.ts
@@ -93,6 +93,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/rest-with-auth/src/frontend/types.generated.ts
+++ b/src/examples/rest-with-auth/src/frontend/types.generated.ts
@@ -95,6 +95,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/rest-with-auth/src/types.generated.ts
+++ b/src/examples/rest-with-auth/src/types.generated.ts
@@ -95,6 +95,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/rest-with-auth/types.generated.ts
+++ b/src/examples/rest-with-auth/types.generated.ts
@@ -95,6 +95,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/rest/src/frontend/types.generated.ts
+++ b/src/examples/rest/src/frontend/types.generated.ts
@@ -91,6 +91,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/rest/src/types.generated.ts
+++ b/src/examples/rest/src/types.generated.ts
@@ -91,6 +91,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/s3-storage/src/frontend/types.generated.ts
+++ b/src/examples/s3-storage/src/frontend/types.generated.ts
@@ -91,6 +91,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/s3-storage/src/types.generated.ts
+++ b/src/examples/s3-storage/src/types.generated.ts
@@ -91,6 +91,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/sql-server/src/frontend/types.generated.ts
+++ b/src/examples/sql-server/src/frontend/types.generated.ts
@@ -93,6 +93,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/sql-server/src/types.generated.ts
+++ b/src/examples/sql-server/src/types.generated.ts
@@ -93,6 +93,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/sqlite/src/backend/schema/genre.ts
+++ b/src/examples/sqlite/src/backend/schema/genre.ts
@@ -15,6 +15,9 @@ export class Genre {
 	@Field(() => String, { nullable: true, adminUIOptions: { summaryField: true } })
 	name?: string;
 
-	@RelationshipField<Track>(() => [Track], { relatedField: 'genre' })
+	@RelationshipField<Track>(() => [Track], {
+		relatedField: 'genre',
+		adminUIOptions: { relationshipBehaviour: 'count' },
+	})
 	tracks!: Track[];
 }

--- a/src/examples/sqlite/src/frontend/types.generated.ts
+++ b/src/examples/sqlite/src/frontend/types.generated.ts
@@ -97,6 +97,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/sqlite/src/types.generated.ts
+++ b/src/examples/sqlite/src/types.generated.ts
@@ -97,6 +97,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/xero/src/frontend/types.generated.ts
+++ b/src/examples/xero/src/frontend/types.generated.ts
@@ -224,6 +224,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/examples/xero/src/types.generated.ts
+++ b/src/examples/xero/src/types.generated.ts
@@ -224,6 +224,7 @@ export type AdminUiFieldMetadata = {
   isArray?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
   relatedEntity?: Maybe<Scalars['String']['output']>;
+  relationshipBehaviour?: Maybe<Scalars['String']['output']>;
   relationshipType?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
 };

--- a/src/packages/admin-ui-components/src/detail-panel/component.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/component.tsx
@@ -32,6 +32,7 @@ import {
 	LinkField,
 	MediaField,
 	RelationshipField,
+	RelationshipCountField,
 	RichTextField,
 	TextField,
 } from './fields';
@@ -76,17 +77,25 @@ const isFieldReadonly = (
 
 /**
  * Filter out fields before submission. Don't include read only fields. Include fields that are required, or have been modified.
- * 
+ *
  * @param initialValues - The initial values of the form.
  * @param values - The current values of the form.
  * @param entity - The entity of the current form
  */
-const filterFieldsForSubmission = (initialValues: Record<string, any>, values: Record<string, any>, entity: Entity, panelMode: PanelMode) => {
+const filterFieldsForSubmission = (
+	initialValues: Record<string, any>,
+	values: Record<string, any>,
+	entity: Entity,
+	panelMode: PanelMode
+) => {
 	const result: Record<string, any> = {};
 
 	for (const [key, value] of Object.entries(values)) {
 		const field = entity.fields.find((f) => f.name === key);
-		const isRequired = panelMode === PanelMode.CREATE ? field?.attributes?.isRequiredForCreate : field?.attributes?.isRequiredForUpdate;
+		const isRequired =
+			panelMode === PanelMode.CREATE
+				? field?.attributes?.isRequiredForCreate
+				: field?.attributes?.isRequiredForUpdate;
 
 		if (!isEqual(initialValues[key], value) || isRequired) {
 			result[key] = value;
@@ -137,6 +146,11 @@ const getField = ({
 	}
 
 	if (field.relationshipType) {
+		// For relationships with 'count' behaviour, always show count field (inherently read-only)
+		if (field.relationshipBehaviour === 'count') {
+			return <RelationshipCountField name={field.name} field={field} />;
+		}
+
 		// If the field is readonly and a relationship, show a link to the entity/entities
 		if (isReadonly) {
 			return <LinkField name={field.name} field={field} />;
@@ -194,7 +208,10 @@ const DetailField = ({
 	autoFocus: boolean;
 	panelMode: PanelMode;
 }) => {
-	const isRequired = panelMode === PanelMode.CREATE ? field.attributes?.isRequiredForCreate : field.attributes?.isRequiredForUpdate;
+	const isRequired =
+		panelMode === PanelMode.CREATE
+			? field.attributes?.isRequiredForCreate
+			: field.attributes?.isRequiredForUpdate;
 	return (
 		<div className={styles.detailField} data-testid={`detail-panel-field-${field.name}`}>
 			<DetailPanelFieldLabel fieldName={field.name} required={isRequired} />
@@ -217,13 +234,13 @@ const CustomFieldComponent = ({
 	const formik = {
 		meta,
 		helpers,
-	}
+	};
 
 	return (
 		<div className={styles.detailField} data-testid={`detail-panel-field-${field.name}`}>
-			{field.component({ entity, context: 'detail-form', panelMode, formik, })}
+			{field.component({ entity, context: 'detail-form', panelMode, formik })}
 		</div>
-	)
+	);
 };
 
 const PersistForm = ({ name }: { name: string }) => {
@@ -267,7 +284,10 @@ const DetailForm = ({
 		(values: any) => {
 			const errors: Record<string, string> = {};
 			for (const field of detailFields) {
-				const isRequired = panelMode === PanelMode.CREATE ? field.attributes?.isRequiredForCreate : field.attributes?.isRequiredForUpdate;
+				const isRequired =
+					panelMode === PanelMode.CREATE
+						? field.attributes?.isRequiredForCreate
+						: field.attributes?.isRequiredForUpdate;
 				if (
 					isRequired &&
 					field.type !== 'ID' &&
@@ -312,7 +332,12 @@ const DetailForm = ({
 	const submit = useCallback(
 		async (values: any, actions: FormikHelpers<any>) => {
 			try {
-				const transformedValues = filterFieldsForSubmission(initialValues, values, entity, panelMode);
+				const transformedValues = filterFieldsForSubmission(
+					initialValues,
+					values,
+					entity,
+					panelMode
+				);
 
 				for (const transform of Object.values(dataTransforms)) {
 					transformedValues[transform.field.name] = await transform.transform(
@@ -342,45 +367,50 @@ const DetailForm = ({
 			onSubmit={submit}
 			onReset={onCancel}
 		>
-			{({ isSubmitting }) => { 
+			{({ isSubmitting }) => {
 				return (
-				<Form className={styles.detailFormContainer}>
-					<div className={styles.detailFieldList}>
-						{detailFields.map((field) => {
-							if (field.hideInDetailForm) return null;
-							else if (field.type === 'custom') {
-								return (
-									<CustomFieldComponent
-										key={field.name}
-										field={field as CustomField}
-										entity={initialValues}
-										panelMode={panelMode}
-									/>
-								);
-							} else {
-								return (
-									<DetailField
-										key={field.name}
-										entity={entity}
-										field={field}
-										autoFocus={field === firstEditableField}
-										panelMode={panelMode}
-									/>
-								);
-							}
-						})}
-						<div className={styles.detailButtonContainer}>
-							<Button type="reset" disabled={isSubmitting}>
-								Cancel
-							</Button>
-							<Button type="submit" disabled={isSubmitting || !!isReadOnly} loading={isSubmitting}>
-								Save
-							</Button>
+					<Form className={styles.detailFormContainer}>
+						<div className={styles.detailFieldList}>
+							{detailFields.map((field) => {
+								if (field.hideInDetailForm) return null;
+								else if (field.type === 'custom') {
+									return (
+										<CustomFieldComponent
+											key={field.name}
+											field={field as CustomField}
+											entity={initialValues}
+											panelMode={panelMode}
+										/>
+									);
+								} else {
+									return (
+										<DetailField
+											key={field.name}
+											entity={entity}
+											field={field}
+											autoFocus={field === firstEditableField}
+											panelMode={panelMode}
+										/>
+									);
+								}
+							})}
+							<div className={styles.detailButtonContainer}>
+								<Button type="reset" disabled={isSubmitting}>
+									Cancel
+								</Button>
+								<Button
+									type="submit"
+									disabled={isSubmitting || !!isReadOnly}
+									loading={isSubmitting}
+								>
+									Save
+								</Button>
+							</div>
 						</div>
-					</div>
-					<PersistForm name={persistName} />
-				</Form>
-			)}}
+						<PersistForm name={persistName} />
+					</Form>
+				);
+			}}
 		</Formik>
 	);
 };
@@ -459,9 +489,17 @@ export const DetailPanel = () => {
 	const initialValues = formFields.reduce(
 		(acc, field) => {
 			const result = savedSessionState ?? data?.result;
-			const value = parseValueForForm(field.type, result?.[field.name as keyof typeof result]);
+
+			// For relationship fields with count behaviour, the GraphQL field name is different
+			const queryFieldName =
+				field.relationshipType && field.relationshipBehaviour === 'count'
+					? `${field.name}_aggregate`
+					: field.name;
+
+			const value = parseValueForForm(field.type, result?.[queryFieldName as keyof typeof result]);
 			const transformedValue = transformValueForForm(field, value, entityByType);
 			acc[field.name] = transformedValue ?? field.initialValue ?? undefined;
+
 			return acc;
 		},
 		{} as Record<string, any>

--- a/src/packages/admin-ui-components/src/detail-panel/component.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/component.tsx
@@ -148,7 +148,7 @@ const getField = ({
 	if (field.relationshipType) {
 		// For relationships with 'count' behaviour, always show count field (inherently read-only)
 		if (field.relationshipBehaviour === 'count') {
-			return <RelationshipCountField name={field.name} field={field} />;
+			return <RelationshipCountField name={field.name} field={field} entity={entity} />;
 		}
 
 		// If the field is readonly and a relationship, show a link to the entity/entities

--- a/src/packages/admin-ui-components/src/detail-panel/detail-panel.stories.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/detail-panel.stories.tsx
@@ -1,7 +1,10 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { Form, Formik } from 'formik';
+import { ApolloProvider } from '@apollo/client';
+import { Router } from 'wouter';
 import { AdminUIFilterType, DetailPanelInputComponentOption, Entity, EntityField } from '../utils';
 import { DetailPanel } from './component';
+import { apolloClient } from '../apollo';
 
 // Import field components for rendering
 import {
@@ -12,6 +15,7 @@ import {
 	LinkField,
 	MediaField,
 	RelationshipField,
+	RelationshipCountField,
 	RichTextField,
 	TextField,
 } from './fields';
@@ -24,6 +28,22 @@ const mockEnum = {
 		{ name: 'INACTIVE', value: 'INACTIVE' },
 		{ name: 'PENDING', value: 'PENDING' },
 	],
+};
+
+// Mock schema context
+const mockSchema = {
+	entityByType: (entityType: string) => ({
+		name: entityType,
+		plural: `${entityType}s`,
+		primaryKeyField: 'id',
+		summaryField: 'name',
+	}),
+};
+
+// Mock schema provider component
+const MockSchemaProvider = ({ children }: { children: React.ReactNode }) => {
+	// This would normally be provided by a context, but for storybook we'll mock it
+	return <div data-testid="mock-schema-provider">{children}</div>;
 };
 
 // Mock entity for the fields
@@ -120,6 +140,12 @@ const mockFields: EntityField[] = [
 		relationshipType: 'MANY_TO_ONE',
 		attributes: { isReadOnly: true, isRequiredForCreate: false, isRequiredForUpdate: false },
 	},
+	{
+		name: 'ordersCount',
+		type: 'Order',
+		relationshipType: 'ONE_TO_MANY',
+		attributes: { isReadOnly: true, isRequiredForCreate: false, isRequiredForUpdate: false },
+	},
 ];
 
 // Mock function to render a field
@@ -166,6 +192,18 @@ const renderField = (field: EntityField, autoFocus = false) => {
 		if (field.relationshipType) {
 			// If the field is readonly and a relationship, show a link to the entity/entities
 			if (isReadonly) {
+				// For ONE_TO_MANY relationships, show count field instead of link
+				if (field.relationshipType === 'ONE_TO_MANY') {
+					return (
+						<ApolloProvider client={apolloClient}>
+							<Router>
+								<MockSchemaProvider>
+									<RelationshipCountField name={field.name} field={field} />
+								</MockSchemaProvider>
+							</Router>
+						</ApolloProvider>
+					);
+				}
 				return <LinkField name={field.name} field={field} />;
 			} else {
 				return <RelationshipField name={field.name} field={field} autoFocus={autoFocus} />;
@@ -453,6 +491,17 @@ export const LinkFieldStory: Story = {
 		docs: {
 			description: {
 				story: 'Link field for read-only relationships',
+			},
+		},
+	},
+};
+
+export const RelationshipCountFieldStory: Story = {
+	render: () => renderField(mockFields.find((f) => f.name === 'ordersCount')!),
+	parameters: {
+		docs: {
+			description: {
+				story: 'Relationship count field for read-only ONE_TO_MANY relationships',
 			},
 		},
 	},

--- a/src/packages/admin-ui-components/src/detail-panel/detail-panel.stories.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/detail-panel.stories.tsx
@@ -30,16 +30,6 @@ const mockEnum = {
 	],
 };
 
-// Mock schema context
-const mockSchema = {
-	entityByType: (entityType: string) => ({
-		name: entityType,
-		plural: `${entityType}s`,
-		primaryKeyField: 'id',
-		summaryField: 'name',
-	}),
-};
-
 // Mock schema provider component
 const MockSchemaProvider = ({ children }: { children: React.ReactNode }) => {
 	// This would normally be provided by a context, but for storybook we'll mock it
@@ -144,6 +134,7 @@ const mockFields: EntityField[] = [
 		name: 'ordersCount',
 		type: 'Order',
 		relationshipType: 'ONE_TO_MANY',
+		relationshipBehaviour: 'count',
 		attributes: { isReadOnly: true, isRequiredForCreate: false, isRequiredForUpdate: false },
 	},
 ];
@@ -192,8 +183,8 @@ const renderField = (field: EntityField, autoFocus = false) => {
 		if (field.relationshipType) {
 			// If the field is readonly and a relationship, show a link to the entity/entities
 			if (isReadonly) {
-				// For ONE_TO_MANY relationships, show count field instead of link
-				if (field.relationshipType === 'ONE_TO_MANY') {
+				// For relationships with 'count' behaviour, show count field instead of link
+				if (field.relationshipBehaviour === 'count') {
 					return (
 						<ApolloProvider client={apolloClient}>
 							<Router>

--- a/src/packages/admin-ui-components/src/detail-panel/detail-panel.stories.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/detail-panel.stories.tsx
@@ -144,6 +144,7 @@ const renderField = (field: EntityField, autoFocus = false) => {
 	const panelMode = { CREATE: 'CREATE', EDIT: 'EDIT' };
 
 	const getField = ({
+		entity,
 		field,
 		autoFocus,
 	}: {
@@ -189,7 +190,7 @@ const renderField = (field: EntityField, autoFocus = false) => {
 						<ApolloProvider client={apolloClient}>
 							<Router>
 								<MockSchemaProvider>
-									<RelationshipCountField name={field.name} field={field} />
+									<RelationshipCountField name={field.name} field={field} entity={entity} />
 								</MockSchemaProvider>
 							</Router>
 						</ApolloProvider>

--- a/src/packages/admin-ui-components/src/detail-panel/fields/index.ts
+++ b/src/packages/admin-ui-components/src/detail-panel/fields/index.ts
@@ -4,6 +4,7 @@ export * from './enum-field';
 export * from './json-field';
 export * from './link-field';
 export * from './relationship-field';
+export * from './relationship-count-field';
 export * from './media-field';
 export * from './text-field';
 export * from './rich-text-field/index';

--- a/src/packages/admin-ui-components/src/detail-panel/fields/link-field.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/fields/link-field.tsx
@@ -1,6 +1,7 @@
 import { useField, useFormikContext } from 'formik';
 import { useLocation, useSearchParams } from 'wouter';
 import { EntityField, routeFor } from '../../utils';
+import styles from '../styles.module.css';
 
 export const LinkField = ({ name, field }: { name: string; field: EntityField }) => {
 	const { dirty } = useFormikContext();
@@ -32,6 +33,7 @@ export const LinkField = ({ name, field }: { name: string; field: EntityField })
 			{field.relationshipType === 'ONE_TO_ONE' || field.relationshipType === 'MANY_TO_ONE' ? (
 				<a
 					key={formEntity.id}
+					className={styles.relationshipLink}
 					onClick={(e) =>
 						handleLinkClick(e, routeFor({ type: field.type, id: formEntity.value as string }))
 					}
@@ -44,6 +46,7 @@ export const LinkField = ({ name, field }: { name: string; field: EntityField })
 						return (
 							<a
 								key={value.value}
+								className={styles.relationshipLink}
 								onClick={(e) =>
 									handleLinkClick(e, routeFor({ type: field.type, id: value.value as string }))
 								}

--- a/src/packages/admin-ui-components/src/detail-panel/fields/relationship-count-field.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/fields/relationship-count-field.tsx
@@ -1,0 +1,59 @@
+import { useQuery } from '@apollo/client';
+import { useField, useFormikContext } from 'formik';
+
+import { EntityField, routeFor, useSchema } from '../../utils';
+import { getRelationshipCountQuery } from '../graphql';
+import { Spinner } from '../../spinner';
+import { useLocation, useSearchParams } from 'wouter';
+import { useCallback } from 'react';
+
+// This field is used when a relationship has too many items to even fetch them all,
+// so we just show a count of the items with a link to the table filtered to those matching
+// items instead.
+export const RelationshipCountField = ({ name, field }: { name: string; field: EntityField }) => {
+	const { dirty } = useFormikContext();
+	const [, setLocation] = useLocation();
+	const [{ value }] = useField({ name, multiple: false });
+	const { entityByType } = useSchema();
+	const relatedEntity = entityByType(field.type);
+	const [_, meta] = useField({ name: name, multiple: false });
+	const [__, setSearchParams] = useSearchParams();
+	const { data, loading, error } = useQuery(getRelationshipCountQuery(relatedEntity), {
+		variables: {
+			filter: {
+				[relatedEntity.primaryKeyField]: value,
+			},
+		},
+	});
+	const { initialValue: formEntity } = meta;
+
+	const handleLinkClick = useCallback(
+		(e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+			// Handle if the form has changed when clicking a link, if it has pop up a confirmation modal
+			e.preventDefault();
+
+			const route = routeFor({ type: field.type, id: formEntity.value as string });
+
+			if (dirty) {
+				// Push the route to this link onto the searchParams
+				// this will be used in the confirmation modal to navigate
+				const searchParams = new URLSearchParams(location.search);
+
+				searchParams.set('modalRedirectUrl', route);
+				setSearchParams(searchParams);
+			} else {
+				setLocation(route);
+			}
+		},
+		[dirty, setLocation, setSearchParams, formEntity.value, field.type, location.search]
+	);
+
+	if (loading) return <Spinner />;
+	if (error) return <div>Error: {error.message}</div>;
+
+	return (
+		<a key={formEntity.id} onClick={handleLinkClick}>
+			{data?.result?.count ?? 0} [entity name]s
+		</a>
+	);
+};

--- a/src/packages/admin-ui-components/src/detail-panel/fields/relationship-count-field.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/fields/relationship-count-field.tsx
@@ -26,11 +26,6 @@ export const RelationshipCountField = ({
 	const { initialValue: formEntity } = meta;
 	const [__, setSearchParams] = useSearchParams();
 
-	// Handle case where relatedEntity is not found
-	if (!relatedEntity) {
-		return <div>Error: Related entity {field.type} not found</div>;
-	}
-
 	const handleLinkClick = useCallback(
 		(e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
 			// Handle if the form has changed when clicking a link, if it has pop up a confirmation modal
@@ -61,6 +56,11 @@ export const RelationshipCountField = ({
 		},
 		[dirty, setLocation, setSearchParams, formEntity.value, field.type, location.search]
 	);
+
+	// Handle case where relatedEntity is not found
+	if (!relatedEntity) {
+		return <div>Error: Related entity {field.type} not found</div>;
+	}
 
 	return (
 		<a key={formEntity.id} className={styles.relationshipLink} onClick={handleLinkClick}>

--- a/src/packages/admin-ui-components/src/detail-panel/fields/relationship-count-field.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/fields/relationship-count-field.tsx
@@ -1,18 +1,27 @@
 import { useField, useFormikContext } from 'formik';
 
-import { EntityField, routeFor, useSchema } from '../../utils';
+import { Entity, EntityField, routeFor, useSchema } from '../../utils';
 import { useLocation, useSearchParams } from 'wouter';
 import { useCallback } from 'react';
 
 // This field is used when a relationship has too many items to even fetch them all,
 // so we just show a count of the items with a link to the table filtered to those matching
 // items instead.
-export const RelationshipCountField = ({ name, field }: { name: string; field: EntityField }) => {
+export const RelationshipCountField = ({
+	name,
+	field,
+	entity,
+}: {
+	name: string;
+	field: EntityField;
+	entity: Entity;
+}) => {
 	const { dirty } = useFormikContext();
 	const [, setLocation] = useLocation();
 	const { entityByType } = useSchema();
 	const relatedEntity = entityByType(field.type);
-	const [_, meta] = useField({ name: name, multiple: false });
+	const [_, meta] = useField({ name, multiple: false });
+	const [primaryKey] = useField({ name: entity.primaryKeyField, multiple: false });
 	const { initialValue: formEntity } = meta;
 	const [__, setSearchParams] = useSearchParams();
 
@@ -26,7 +35,17 @@ export const RelationshipCountField = ({ name, field }: { name: string; field: E
 			// Handle if the form has changed when clicking a link, if it has pop up a confirmation modal
 			e.preventDefault();
 
-			const route = routeFor({ type: field.type, id: formEntity.value as string });
+			// Figure out the property that points the other direction, e.g. back at us.
+			// If we're on Genre and we're showing a count of tracks, clicking needs to filter
+			// tracks { genre : { id: 1 } }
+			const inverseRelationship = relatedEntity.fields.find((field) => field.type === entity.name);
+
+			if (!inverseRelationship) return;
+
+			const route = routeFor({
+				type: field.type,
+				filters: { [inverseRelationship.name]: { [entity.primaryKeyField]: primaryKey.value } },
+			});
 
 			if (dirty) {
 				// Push the route to this link onto the searchParams

--- a/src/packages/admin-ui-components/src/detail-panel/fields/relationship-count-field.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/fields/relationship-count-field.tsx
@@ -3,6 +3,7 @@ import { useField, useFormikContext } from 'formik';
 import { Entity, EntityField, routeFor, useSchema } from '../../utils';
 import { useLocation, useSearchParams } from 'wouter';
 import { useCallback } from 'react';
+import styles from '../styles.module.css';
 
 // This field is used when a relationship has too many items to even fetch them all,
 // so we just show a count of the items with a link to the table filtered to those matching
@@ -62,7 +63,7 @@ export const RelationshipCountField = ({
 	);
 
 	return (
-		<a key={formEntity.id} onClick={handleLinkClick}>
+		<a key={formEntity.id} className={styles.relationshipLink} onClick={handleLinkClick}>
 			{formEntity?.count ?? 0} {relatedEntity.plural.toLowerCase()}
 		</a>
 	);

--- a/src/packages/admin-ui-components/src/detail-panel/fields/relationship-count-field.tsx
+++ b/src/packages/admin-ui-components/src/detail-panel/fields/relationship-count-field.tsx
@@ -27,9 +27,9 @@ export const RelationshipCountField = ({
 	const [__, setSearchParams] = useSearchParams();
 
 	const handleLinkClick = useCallback(
-		(e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+		(e?: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
 			// Handle if the form has changed when clicking a link, if it has pop up a confirmation modal
-			e.preventDefault();
+			e?.preventDefault();
 
 			// Figure out the property that points the other direction, e.g. back at us.
 			// If we're on Genre and we're showing a count of tracks, clicking needs to filter
@@ -57,13 +57,28 @@ export const RelationshipCountField = ({
 		[dirty, setLocation, setSearchParams, formEntity.value, field.type, location.search]
 	);
 
+	const handleKeyDown = useCallback(
+		(e: React.KeyboardEvent<HTMLAnchorElement>) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				handleLinkClick();
+			}
+		},
+		[handleLinkClick]
+	);
+
 	// Handle case where relatedEntity is not found
 	if (!relatedEntity) {
 		return <div>Error: Related entity {field.type} not found</div>;
 	}
 
 	return (
-		<a key={formEntity.id} className={styles.relationshipLink} onClick={handleLinkClick}>
+		<a
+			key={formEntity.id}
+			className={styles.relationshipLink}
+			onClick={handleLinkClick}
+			onKeyDown={handleKeyDown}
+		>
 			{formEntity?.count ?? 0} {relatedEntity.plural.toLowerCase()}
 		</a>
 	);

--- a/src/packages/admin-ui-components/src/detail-panel/graphql.ts
+++ b/src/packages/admin-ui-components/src/detail-panel/graphql.ts
@@ -66,3 +66,14 @@ export const getDeleteUrlMutation = gql`
 		getDeleteUrl(key: $key)
 	}
 `;
+
+export const getRelationshipCountQuery = (entity: Entity) => {
+	const { plural } = entity;
+	const queryName = `${plural[0].toLowerCase()}${plural.slice(1)}_aggregate`;
+
+	return gql`
+		query getRelationshipCount ($filter: ${plural}ListFilter) {
+			result: ${queryName} (filter: $filter) { count }
+		}
+	`;
+};

--- a/src/packages/admin-ui-components/src/detail-panel/styles.module.css
+++ b/src/packages/admin-ui-components/src/detail-panel/styles.module.css
@@ -113,6 +113,16 @@
 	cursor: pointer;
 }
 
+.relationshipLink {
+	cursor: pointer;
+	color: #ede8f2;
+	text-decoration: none;
+}
+
+.relationshipLink:hover {
+	text-decoration: underline;
+}
+
 /* Unsaved Changes Modal */
 .unsavedChangesModal {
 	width: 371px;

--- a/src/packages/admin-ui-components/src/entity-list/columns.tsx
+++ b/src/packages/admin-ui-components/src/entity-list/columns.tsx
@@ -65,16 +65,6 @@ const cellForType = (
 	if (field.relationshipType) {
 		// For relationships with 'count' behaviour, show count instead of links
 		if (field.relationshipBehaviour === 'count') {
-			// Debug: log the actual value structure
-			console.log('RelationshipCountField debug:', {
-				fieldName: field.name,
-				fieldType: field.type,
-				value,
-				valueType: typeof value,
-				hasCount: value && typeof value === 'object' && 'count' in value,
-			});
-
-			// When using _aggregate, the value will be an object with a count property
 			if (!value || typeof value !== 'object' || !('count' in value)) return '0';
 			const count = (value as { count: number }).count;
 			return `${count} ${field.type.toLowerCase()}s`;

--- a/src/packages/admin-ui-components/src/side-bar/styles.module.css
+++ b/src/packages/admin-ui-components/src/side-bar/styles.module.css
@@ -91,6 +91,7 @@
 	border-radius: 6px;
 	padding: 0 10px;
 	width: 100%;
+	cursor: pointer;
 }
 
 .subListItemText {

--- a/src/packages/admin-ui-components/src/table/component.tsx
+++ b/src/packages/admin-ui-components/src/table/component.tsx
@@ -49,10 +49,6 @@ export const Table = <T extends object>({
 		desc: direction === Sort.DESC,
 	}));
 
-	const handleRowClick = (row: Row<T>) => {
-		if (onRowClick) onRowClick(row);
-	};
-
 	const handleSortClick = (sortingState: ColumnSort[]) => {
 		// TODO We currently only support single column sorting
 		const [firstSortedColumn] = sortingState ?? [];
@@ -156,7 +152,7 @@ export const Table = <T extends object>({
 										!(e.target as HTMLElement).closest('label') &&
 										!(e.target as HTMLElement).closest('input')
 									) {
-										handleRowClick(row);
+										onRowClick?.(row);
 									}
 								}}
 							>

--- a/src/packages/admin-ui-components/src/table/styles.module.css
+++ b/src/packages/admin-ui-components/src/table/styles.module.css
@@ -105,3 +105,13 @@
 .table tfoot th {
 	vertical-align: middle;
 }
+
+.table a {
+	cursor: pointer;
+	color: #ede8f2;
+	text-decoration: none;
+}
+
+.table a:hover {
+	text-decoration: underline;
+}

--- a/src/packages/admin-ui-components/src/utils/graphql.ts
+++ b/src/packages/admin-ui-components/src/utils/graphql.ts
@@ -49,6 +49,7 @@ export const SCHEMA_QUERY = gql`
 						name
 						options
 					}
+					relationshipBehaviour
 				}
 				attributes {
 					isReadOnly
@@ -67,7 +68,7 @@ export const SCHEMA_QUERY = gql`
 	}
 `;
 
-const entitySelection = (relatedEntity: Entity) => 
+const entitySelection = (relatedEntity: Entity) =>
 	[relatedEntity.primaryKeyField].concat(relatedEntity.summaryField ?? []).join('\n');
 
 export const generateGqlSelectForEntityFields = (
@@ -84,6 +85,11 @@ export const generateGqlSelectForEntityFields = (
 				}
 				const relatedEntity = entityByType(field.type);
 				if (!relatedEntity) throw new Error(`Related entity ${field.type} not found`);
+
+				// For relationship fields with count behaviour, use _aggregate instead of fetching items
+				if (field.relationshipBehaviour === 'count') {
+					return `${field.name}_aggregate { count }`;
+				}
 
 				return `${field.name} { 
 					${entitySelection(relatedEntity)}

--- a/src/packages/admin-ui-components/src/utils/use-schema.ts
+++ b/src/packages/admin-ui-components/src/utils/use-schema.ts
@@ -145,6 +145,7 @@ export interface EntityField {
 	hideInFilterBar?: boolean;
 	hideInDetailForm?: boolean;
 	detailPanelInputComponent?: DetailPanelInputComponent;
+	relationshipBehaviour?: 'load' | 'count';
 }
 
 export interface EntityFieldAttributes {

--- a/src/packages/core/src/decorators/field.ts
+++ b/src/packages/core/src/decorators/field.ts
@@ -149,6 +149,13 @@ export interface FieldOptions {
 		 * By default, a simple text input is used if the field is of type text.
 		 */
 		detailPanelInputComponent?: DetailPanelInputComponentOption | DetailPanelInputComponent;
+
+		/**
+		 * For relationship fields, specifies how the relationship should be displayed in the Admin UI.
+		 * 'load' is the default - loads and renders related items with a combo box for editing.
+		 * 'count' displays a count value that links to a filtered table view.
+		 */
+		relationshipBehaviour?: 'load' | 'count';
 	};
 	apiOptions?: {
 		// This marks the field as read only in the API.

--- a/src/packages/core/src/decorators/relationship-field.ts
+++ b/src/packages/core/src/decorators/relationship-field.ts
@@ -10,6 +10,24 @@ type RelationshipFieldOptions<D> = {
 		hideInFilterBar?: boolean;
 		hideInDetailForm?: boolean;
 		readonly?: boolean;
+
+		// 'load' is the default. When this is set the table will load and render the
+		// related items. In the detail panel a combo box is presented where users can
+		// edit the linked items via the relationship.
+		//
+		// 'count' is for relationships that are too large to load and render in this way.
+		// It will display a single count value, for example "10,000 tracks". When clicked
+		// the user will be redirected to the table filtered to the related items. This will
+		// not allow them to edit the relationship on the detail panel, but often they're able
+		// to edit on the other side of the relationship, for example a genre has many tracks,
+		// but each track only has a few genres, so we can leave the default 'load' behaviour on
+		// the track side of the relationship, but switch it to 'count' on the genre side.
+		relationshipBehaviour?: 'load' | 'count';
+
+		// Use this to filter the valid options that users can select from the Admin UI.
+		// This does not validate the values sent to the API, just adds a filter to the
+		// component when it's displayed in the Admin UI only. Handy for quality of life
+		// improvements that aren't security concerns.
 		filterOptions?: Record<string, unknown>;
 	};
 

--- a/src/packages/core/src/metadata-service/field.ts
+++ b/src/packages/core/src/metadata-service/field.ts
@@ -64,4 +64,7 @@ export class AdminUiFieldMetadata {
 
 	@Field(() => DetailPanelInputComponent, { nullable: true })
 	detailPanelInputComponent?: DetailPanelInputComponent;
+
+	@Field(() => String, { nullable: true })
+	relationshipBehaviour?: string;
 }

--- a/src/packages/core/src/metadata-service/resolver.ts
+++ b/src/packages/core/src/metadata-service/resolver.ts
@@ -104,14 +104,18 @@ export const resolveAdminUiMetadata = (hooks?: Hooks) => {
 					defaultFieldForDetailPanel = field.name;
 				}
 
-				const isToMany = isList && relatedObject?.type === 'entity'
+				const isToMany = isList && relatedObject?.type === 'entity';
 
-				const canNotBeEmpty = !isToMany && field.nullable !== true
+				const canNotBeEmpty = !isToMany && field.nullable !== true;
 
 				// Define field attributes
 				const isReadOnly = field.readonly ?? field.adminUIOptions?.readonly ?? false;
-				const isRequiredForCreate = field.apiOptions?.requiredForCreate === undefined ? canNotBeEmpty : field.apiOptions?.requiredForCreate;
-				const isRequiredForUpdate = field.name === primaryKeyField || (field.apiOptions?.requiredForUpdate ?? false);
+				const isRequiredForCreate =
+					field.apiOptions?.requiredForCreate === undefined
+						? canNotBeEmpty
+						: field.apiOptions?.requiredForCreate;
+				const isRequiredForUpdate =
+					field.name === primaryKeyField || (field.apiOptions?.requiredForUpdate ?? false);
 
 				const fieldObject: AdminUiFieldMetadata = {
 					name: field.name,
@@ -132,6 +136,7 @@ export const resolveAdminUiMetadata = (hooks?: Hooks) => {
 									name: field.adminUIOptions?.detailPanelInputComponent,
 								}
 							: field.adminUIOptions?.detailPanelInputComponent,
+					relationshipBehaviour: field.adminUIOptions?.relationshipBehaviour,
 				};
 
 				// Check if we have an array of related entities

--- a/src/packages/core/src/metadata-service/resolver.ts
+++ b/src/packages/core/src/metadata-service/resolver.ts
@@ -110,10 +110,7 @@ export const resolveAdminUiMetadata = (hooks?: Hooks) => {
 
 				// Define field attributes
 				const isReadOnly = field.readonly ?? field.adminUIOptions?.readonly ?? false;
-				const isRequiredForCreate =
-					field.apiOptions?.requiredForCreate === undefined
-						? canNotBeEmpty
-						: field.apiOptions?.requiredForCreate;
+				const isRequiredForCreate = field.apiOptions?.requiredForCreate ?? canNotBeEmpty;
 				const isRequiredForUpdate =
 					field.name === primaryKeyField || (field.apiOptions?.requiredForUpdate ?? false);
 

--- a/src/packages/core/src/types.ts
+++ b/src/packages/core/src/types.ts
@@ -260,6 +260,7 @@ export interface FieldMetadata<G = unknown, D = unknown> {
 		filterOptions?: Record<string, unknown>;
 		detailPanelInputComponent?: DetailPanelInputComponentOption | DetailPanelInputComponent;
 		format?: CellFormatOptions;
+		relationshipBehaviour?: 'load' | 'count';
 	};
 	apiOptions?: {
 		requiredForCreate?: boolean;


### PR DESCRIPTION
When a relationship is particularly lopsided, it's nice to be able to show the count instead of the individual relationship items. In this case we've made tracks on genres show as a count, while on tracks genre is still an editable field. This allows us to still edit this data but provide a nice experience to users.

Clicking the count takes the admin area to the other entity, filtered by the first entity, so it's still easily possible for users to navigate these relationships as needed.