### PR TITLE
Fix / Relationship Filter sometimes doesn't show filter value on deep links

### DIFF
--- a/src/packages/admin-ui-components/src/filters/relationship-filter.tsx
+++ b/src/packages/admin-ui-components/src/filters/relationship-filter.tsx
@@ -45,10 +45,23 @@ export const RelationshipFilter = ({
 	const relationshipEntity = field ? entities.find((e) => e === field.type) : undefined;
 	const relatedEntity = entityByName(relationshipEntity ?? '');
 
-	const currentFilterValue =
-		(filter?.[fieldName] as Record<string, string[]> | undefined)?.[
-			`${relatedEntity.primaryKeyField}_in`
-		] ?? [];
+	// First try with _in
+	let currentFilterValue: string[] | undefined = (
+		filter?.[fieldName] as Record<string, string[]> | undefined
+	)?.[`${relatedEntity.primaryKeyField}_in`];
+
+	// If that didn't do it, then try with just the primary key field.
+	// Arrayify if it exists.
+	if (!currentFilterValue) {
+		const maybePrimaryKey = (filter?.[fieldName] as Record<string, string> | undefined)?.[
+			relatedEntity.primaryKeyField
+		];
+
+		if (maybePrimaryKey) currentFilterValue = [maybePrimaryKey];
+	}
+
+	// Ok, must be no filter.
+	if (!currentFilterValue) currentFilterValue = [];
 
 	// Should we have any searchable fields? we should grab them from the schema as well as
 	// any that were passed in as a prop, deduplicating them.


### PR DESCRIPTION
Allow relationship filter to read both `_in` and pure primary key filters when determining current filter values.