### PR TITLE
Feature / Allow direct access to Authorization Context for integrators

### DIFF
--- a/src/packages/auth/src/index.ts
+++ b/src/packages/auth/src/index.ts
@@ -1,4 +1,5 @@
 export * from './authentication';
+export * from './authorization-context';
 export * from './decorators';
 export * from './errors';
 export * from './helper-functions';

--- a/src/packages/builder/package.json
+++ b/src/packages/builder/package.json
@@ -26,7 +26,7 @@
 		"@exogee/graphweaver-mikroorm": "workspace:*",
 		"@graphql-codegen/add": "6.0.0",
 		"@graphql-codegen/cli": "6.1.0",
-		"@graphql-codegen/near-operation-file-preset": "3.1.0",
+		"@graphql-codegen/near-operation-file-preset": "4.0.0",
 		"@graphql-codegen/typescript": "5.0.2",
 		"@graphql-codegen/typescript-operations": "5.0.6",
 		"@graphql-codegen/typescript-react-apollo": "4.3.4",

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -1211,8 +1211,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0(@types/node@24.10.0)(encoding@0.1.13)(graphql@16.12.0)(typescript@5.9.3)
       '@graphql-codegen/near-operation-file-preset':
-        specifier: 3.1.0
-        version: 3.1.0(encoding@0.1.13)(graphql@16.12.0)
+        specifier: 4.0.0
+        version: 4.0.0(encoding@0.1.13)(graphql@16.12.0)
       '@graphql-codegen/typescript':
         specifier: 5.0.2
         version: 5.0.2(encoding@0.1.13)(graphql@16.12.0)
@@ -3702,11 +3702,6 @@ packages:
       graphql-ws:
         optional: true
 
-  '@graphql-codegen/add@3.2.3':
-    resolution: {integrity: sha512-sQOnWpMko4JLeykwyjFTxnhqjd/3NOG2OyMuvK76Wnnwh8DRrNf2VEs2kmSvLl7MndMlOj7Kh5U154dVcvhmKQ==}
-    peerDependencies:
-      graphql: 16.12.0
-
   '@graphql-codegen/add@6.0.0':
     resolution: {integrity: sha512-biFdaURX0KTwEJPQ1wkT6BRgNasqgQ5KbCI1a3zwtLtO7XTo7/vKITPylmiU27K5DSOWYnY/1jfSqUAEBuhZrQ==}
     engines: {node: '>=16'}
@@ -3746,8 +3741,8 @@ packages:
     peerDependencies:
       graphql: 16.12.0
 
-  '@graphql-codegen/near-operation-file-preset@3.1.0':
-    resolution: {integrity: sha512-sXIIi0BPP3IcARdzSztpE51oJTcGB67hi7ddBYfLinks/R/5aFG1Ry/J61707Kt+6Q5WhTnf5XAQUAqi6200yA==}
+  '@graphql-codegen/near-operation-file-preset@4.0.0':
+    resolution: {integrity: sha512-InHE3tN0dZKCZivrQ950y6Tnxtt/DJbvqqm5iCOmExJeIzhLoMOB0Rq2ex4KsRdSY9YtpYbYNCmO2xSU3MbRcg==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
       graphql: 16.12.0
@@ -4054,12 +4049,6 @@ packages:
 
   '@graphql-tools/utils@10.11.0':
     resolution: {integrity: sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      graphql: 16.12.0
-
-  '@graphql-tools/utils@10.9.1':
-    resolution: {integrity: sha512-B1wwkXk9UvU7LCBkPs8513WxOQ2H8Fo5p8HR1+Id9WmYE5+bd51vqN+MbrqvWczHCH2gwkREgHJN88tE0n1FCw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: 16.12.0
@@ -15074,12 +15063,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@graphql-codegen/add@3.2.3(graphql@16.12.0)':
-    dependencies:
-      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.12.0)
-      graphql: 16.12.0
-      tslib: 2.4.1
-
   '@graphql-codegen/add@6.0.0(graphql@16.12.0)':
     dependencies:
       '@graphql-codegen/plugin-helpers': 6.0.0(graphql@16.12.0)
@@ -15174,18 +15157,17 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@graphql-codegen/near-operation-file-preset@3.1.0(encoding@0.1.13)(graphql@16.12.0)':
+  '@graphql-codegen/near-operation-file-preset@4.0.0(encoding@0.1.13)(graphql@16.12.0)':
     dependencies:
-      '@graphql-codegen/add': 3.2.3(graphql@16.12.0)
-      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@16.12.0)
-      '@graphql-codegen/visitor-plugin-common': 2.13.8(encoding@0.1.13)(graphql@16.12.0)
-      '@graphql-tools/utils': 10.9.1(graphql@16.12.0)
+      '@graphql-codegen/add': 6.0.0(graphql@16.12.0)
+      '@graphql-codegen/plugin-helpers': 6.1.0(graphql@16.12.0)
+      '@graphql-codegen/visitor-plugin-common': 6.2.2(encoding@0.1.13)(graphql@16.12.0)
+      '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
       graphql: 16.12.0
       parse-filepath: 1.0.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
-      - supports-color
 
   '@graphql-codegen/plugin-helpers@3.1.2(graphql@16.12.0)':
     dependencies:
@@ -15725,15 +15707,6 @@ snapshots:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.12.0)
       '@whatwg-node/promise-helpers': 1.3.2
       cross-inspect: 1.0.1
-      graphql: 16.12.0
-      tslib: 2.8.1
-
-  '@graphql-tools/utils@10.9.1(graphql@16.12.0)':
-    dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.12.0)
-      '@whatwg-node/promise-helpers': 1.3.2
-      cross-inspect: 1.0.1
-      dset: 3.1.4
       graphql: 16.12.0
       tslib: 2.8.1
 


### PR DESCRIPTION
This is useful when you need to determine authentication information in a different way than the supported methods but want to still use the ACL system.