### PR TITLE
Fix after-create ACL for non-id primary keys

### DIFF
--- a/src/packages/auth/src/auth-utils.test.ts
+++ b/src/packages/auth/src/auth-utils.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { ForbiddenError } from 'apollo-server-errors';
+import { requiredPermissionsForAction } from './auth-utils';
+import { AccessType } from './types';
+
+describe('requiredPermissionsForAction', () => {
+	it('treats a single default id primary key as Read', () => {
+		expect(requiredPermissionsForAction({ id: '123' })).toBe(AccessType.Read);
+	});
+
+	it('treats an id primary key plus other fields as Update', () => {
+		expect(requiredPermissionsForAction({ id: '123', name: 'Alice' })).toBe(AccessType.Update);
+	});
+
+	it('treats a payload without an id primary key as Create', () => {
+		expect(requiredPermissionsForAction({ name: 'Alice' })).toBe(AccessType.Create);
+	});
+
+	it('treats a single non-id primary key as Read', () => {
+		expect(requiredPermissionsForAction({ appId: '82000' }, 'appId')).toBe(AccessType.Read);
+	});
+
+	it('treats a non-id primary key plus other fields as Update', () => {
+		expect(requiredPermissionsForAction({ appId: '82000', name: 'Deal' }, 'appId')).toBe(
+			AccessType.Update
+		);
+	});
+
+	it('treats a payload without the entity primary key as Create even if id is present', () => {
+		// Entities whose PK is not `id` must not be misclassified via a stray `id` field.
+		expect(requiredPermissionsForAction({ id: 'not-the-pk', name: 'Deal' }, 'appId')).toBe(
+			AccessType.Create
+		);
+	});
+
+	it('does not treat { appId } as Create when using the default id primary key field', () => {
+		// Regression: after-create ACL previously hardcoded `id`, so linking via `{ appId }`
+		// required Create on the related entity instead of Read.
+		expect(requiredPermissionsForAction({ appId: '82000' })).toBe(AccessType.Create);
+		expect(requiredPermissionsForAction({ appId: '82000' }, 'appId')).toBe(AccessType.Read);
+	});
+
+	it('throws Forbidden for an empty intent', () => {
+		expect(() => requiredPermissionsForAction({})).toThrow(ForbiddenError);
+	});
+});

--- a/src/packages/auth/src/auth-utils.ts
+++ b/src/packages/auth/src/auth-utils.ts
@@ -99,15 +99,25 @@ export const getAccessFilter = async (
 	return evaluateAccessControlValue(readEntry);
 };
 
-export const requiredPermissionsForAction = (intent: any): AccessType => {
+/**
+ * Infer the access type implied by a nested relationship input node.
+ * Uses the related entity's primary key field (defaults to `id`) so entities with
+ * non-`id` PKs (e.g. `{ appId }`) are classified the same way as `{ id }` links.
+ * Aligns with `getRelationshipAccessTypeForArg` in the before-create ACL hook.
+ */
+export const requiredPermissionsForAction = (
+	intent: any,
+	primaryKeyField: string = 'id'
+): AccessType => {
 	const keys = Object.keys(intent);
 	const length = keys.length;
+	const primaryKeyValue = intent?.[primaryKeyField];
 
-	if (length === 1 && intent.id !== undefined) {
+	if (length === 1 && primaryKeyValue !== undefined) {
 		return AccessType.Read;
-	} else if (length > 1 && intent.id !== undefined) {
+	} else if (length > 1 && primaryKeyValue !== undefined) {
 		return AccessType.Update;
-	} else if (Object.keys(intent).length > 0 && intent.id === undefined) {
+	} else if (length > 0 && primaryKeyValue === undefined) {
 		return AccessType.Create;
 	}
 
@@ -307,15 +317,16 @@ export async function checkAuthorization<G = unknown>(
 				continue;
 			}
 
-			const accessType = requiredPermissionsForAction(value);
+			const relatedPrimaryKeyField = relatedEntityMetadata.primaryKeyField ?? 'id';
 			const values = Array.isArray(value) ? value : [value];
 			for (const item of values) {
-				const relatedId = item[relatedEntityMetadata.primaryKeyField ?? 'id'];
+				const relatedId = item[relatedPrimaryKeyField];
 
-				// We only check the nested inputs with ID's, this is because if there was no ID
+				// We only check the nested inputs with primary keys, this is because if there was no PK
 				// supplied in the input args then the entity has been created in the data source.
-				// The creation hook will triggered for that entity and the permissions checked
+				// The creation hook will be triggered for that entity and the permissions checked
 				if (relatedId) {
+					const accessType = requiredPermissionsForAction(item, relatedPrimaryKeyField);
 					relatedEntityAuthChecks.push(
 						checkAuthorization(
 							relatedEntityMetadata.name,

--- a/src/packages/auth/src/auth-utils.ts
+++ b/src/packages/auth/src/auth-utils.ts
@@ -317,7 +317,8 @@ export async function checkAuthorization<G = unknown>(
 				continue;
 			}
 
-			const relatedPrimaryKeyField = relatedEntityMetadata.primaryKeyField ?? 'id';
+			const relatedPrimaryKeyField =
+				graphweaverMetadata.primaryKeyFieldForEntity(relatedEntityMetadata);
 			const values = Array.isArray(value) ? value : [value];
 			for (const item of values) {
 				const relatedId = item[relatedPrimaryKeyField];

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,7 +3,7 @@
 		"target": "es2021",
 		"module": "es2020",
 		"moduleResolution": "bundler",
-		"lib": ["ES6", "es2021"],
+		"lib": ["ES6", "es2021", "ES2022.Error"],
 		"allowJs": true,
 		"jsx": "react",
 		"declaration": true,


### PR DESCRIPTION
## Summary
- `requiredPermissionsForAction` now uses the related entity's primary key field (default `id`) instead of hardcoding `id`, matching `getRelationshipAccessTypeForArg` in the before-create ACL hook.
- `checkAuthorization` passes that primary key when classifying nested relationship inputs, so linking via `{ appId: '…' }` correctly requires Read rather than Create.
- Adds unit coverage for default `id` PKs and non-`id` PKs to prevent regression.

## Why
After-create ACL checks used `requiredPermissionsForAction`, which only treated `{ id }` as a Read link. Entities whose GraphQL primary key is e.g. `appId` were treated as Create, so ReadOnly (or any role without Create on the related entity) got `Forbidden` when creating a parent that linked an existing child by PK.

## Test plan
- [x] `pnpm test -- src/auth-utils.test.ts` in `@exogee/graphweaver-auth`
- [ ] Confirm nested create that links an existing entity by a non-`id` PK succeeds for a role with Read-only on that entity
- [ ] Confirm create-without-PK still requires Create, and PK + other fields still requires Update


Made with [Cursor](https://cursor.com)