### PR TITLE
Fix ACL traversal of object-valued _not filters

### DIFF
--- a/src/examples/xero/src/backend/schema/account.ts
+++ b/src/examples/xero/src/backend/schema/account.ts
@@ -78,7 +78,9 @@ const xeroFilterFrom = (filter: Filter<Account> | Filter<Account>[]) => {
 			const keyParts = key.split('_', 2);
 			const replacedKey = keyParts[0] === 'id' ? 'AccountID' : keyParts[0];
 			let subFilter =
-				typeof value === 'object' ? xeroFilterFrom(value) : (value as string | undefined);
+				typeof value === 'object'
+					? xeroFilterFrom(value as Filter<Account> | Filter<Account>[])
+					: (value as string | undefined);
 
 			// Some Xero types need to be quoted.
 			if (isUUID(subFilter, 4)) {

--- a/src/packages/auth/src/decorators/hooks/acl.ts
+++ b/src/packages/auth/src/decorators/hooks/acl.ts
@@ -8,7 +8,6 @@ import {
 	ResolveTree,
 	graphweaverMetadata,
 	isEntityMetadata,
-	isTopLevelFilterProperty,
 } from '@exogee/graphweaver';
 import { logger } from '@exogee/logger';
 
@@ -251,10 +250,15 @@ const getFilterArgumentsOnFields = (entityMetadata: EntityMetadata, resolveTree:
 				filterKey
 			);
 
-			if (isTopLevelFilterProperty(filterKey)) {
+			if (filterKey === '_and' || filterKey === '_or') {
 				value.forEach((item) => {
 					recurseThroughArg(entityMetadata, item);
 				});
+				continue;
+			}
+
+			if (filterKey === '_not') {
+				recurseThroughArg(entityMetadata, value);
 				continue;
 			}
 

--- a/src/packages/auth/src/decorators/hooks/acl.ts
+++ b/src/packages/auth/src/decorators/hooks/acl.ts
@@ -251,14 +251,14 @@ const getFilterArgumentsOnFields = (entityMetadata: EntityMetadata, resolveTree:
 			);
 
 			if (filterKey === '_and' || filterKey === '_or') {
-				value.forEach((item) => {
+				(value as Filter<unknown>[]).forEach((item) => {
 					recurseThroughArg(entityMetadata, item);
 				});
 				continue;
 			}
 
 			if (filterKey === '_not') {
-				recurseThroughArg(entityMetadata, value);
+				recurseThroughArg(entityMetadata, value as Filter<unknown>);
 				continue;
 			}
 

--- a/src/packages/core/src/filter-types.test.ts
+++ b/src/packages/core/src/filter-types.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { Filter } from './types';
+
+type TestEntity = {
+	name: string;
+};
+
+describe('Filter', () => {
+	it('accepts one filter object for _not', () => {
+		const filter: Filter<TestEntity> = {
+			_not: {
+				name: 'Example',
+			},
+		};
+
+		expect(filter).toEqual({
+			_not: {
+				name: 'Example',
+			},
+		});
+	});
+});

--- a/src/packages/core/src/types.ts
+++ b/src/packages/core/src/types.ts
@@ -69,7 +69,7 @@ export type FilterEntity<G> = {
 export type FilterTopLevelProperties<G> = {
 	_and?: Filter<G>[];
 	_or?: Filter<G>[];
-	_not?: Filter<G>[];
+	_not?: Filter<G>;
 };
 
 // ❗ This is used by the permissions system, so if you update the above, then update this list too.

--- a/src/packages/end-to-end/src/__tests__/api/auth/acl/nested-filters.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/auth/acl/nested-filters.test.ts
@@ -162,4 +162,41 @@ describe('ACL - Nested Filters', () => {
 		assert(response.body.kind === 'single');
 		expect(response.body.singleResult.errors?.[0]?.message).toBe('Forbidden');
 	});
+
+	test('should check relationship permissions inside a _not filter', async () => {
+		assert(token);
+
+		const spyOnArtistDataProvider = jest.spyOn(artistDataProvider, 'find');
+		const spyOnAlbumDataProvider = jest.spyOn(albumDataProvider, 'find');
+		const spyOnTrackDataProvider = jest.spyOn(trackDataProvider, 'find');
+
+		const response = await graphweaver.executeOperation({
+			http: { headers: new Headers({ authorization: token }) } as any,
+			query: gql`
+				query artists($filter: ArtistsListFilter) {
+					artists(filter: $filter) {
+						id
+					}
+				}
+			`,
+			variables: {
+				filter: {
+					_not: {
+						albums: {
+							tracks: {
+								id: '1',
+							},
+						},
+					},
+				},
+			},
+		});
+
+		expect(spyOnArtistDataProvider).not.toHaveBeenCalled();
+		expect(spyOnAlbumDataProvider).not.toHaveBeenCalled();
+		expect(spyOnTrackDataProvider).not.toHaveBeenCalled();
+
+		assert(response.body.kind === 'single');
+		expect(response.body.singleResult.errors?.[0]?.message).toBe('Forbidden');
+	});
 });

--- a/src/packages/end-to-end/src/__tests__/api/auth/acl/top-level-filters.test.ts
+++ b/src/packages/end-to-end/src/__tests__/api/auth/acl/top-level-filters.test.ts
@@ -16,7 +16,14 @@ import { Field, ID, Entity, RelationshipField, BaseDataProvider } from '@exogee/
 import { ConnectionManager, MikroBackendProvider } from '@exogee/graphweaver-mikroorm';
 
 import { SqliteDriver } from '@mikro-orm/sqlite';
-import { ApplyAccessControlList, CredentialStorage, hashPassword, Password, setAddUserToContext, UserProfile } from '@exogee/graphweaver-auth';
+import {
+	ApplyAccessControlList,
+	CredentialStorage,
+	hashPassword,
+	Password,
+	setAddUserToContext,
+	UserProfile,
+} from '@exogee/graphweaver-auth';
 
 /* SQLite data entities */
 
@@ -53,9 +60,9 @@ const connection = {
 
 /* Graphweaver Entities */
 @ApplyAccessControlList({
-    Everyone: {
-        all: (context) => ({ id: context.user?.id }),
-    },
+	Everyone: {
+		all: (context) => ({ id: context.user?.id }),
+	},
 })
 @Entity('Album', {
 	provider: new MikroBackendProvider(OrmAlbum, connection),
@@ -71,12 +78,12 @@ export class Album {
 }
 
 @ApplyAccessControlList({
-    Everyone: {
-        all: (context) => {
-            if (context.user?.roles?.[0] === 'admin') return true;
-            return { id: "2" };
-        },
-    },
+	Everyone: {
+		all: (context) => {
+			if (context.user?.roles?.[0] === 'admin') return true;
+			return { id: '2' };
+		},
+	},
 })
 @Entity('Artist', {
 	provider: new MikroBackendProvider(OrmArtist, connection),
@@ -90,9 +97,9 @@ export class Artist {
 }
 
 const user = new UserProfile({
-    id: '1',
-    roles: ['admin'],
-    displayName: 'Test User',
+	id: '1',
+	roles: ['admin'],
+	displayName: 'Test User',
 });
 
 const cred: CredentialStorage = {
@@ -102,123 +109,175 @@ const cred: CredentialStorage = {
 };
 
 class PasswordBackendProvider extends BaseDataProvider<CredentialStorage> {
-    async findOne() {
-        cred.password = await hashPassword(cred.password ?? '');
-        return cred;
-    }
+	async findOne() {
+		cred.password = await hashPassword(cred.password ?? '');
+		return cred;
+	}
 }
 
 export const password = new Password({
-    provider: new PasswordBackendProvider('password'),
-    getUserProfile: async () => user,
+	provider: new PasswordBackendProvider('password'),
+	getUserProfile: async () => user,
 });
 
 setAddUserToContext(async () => user);
-
 
 const graphweaver = new Graphweaver();
 
 let token: string | undefined;
 
 describe('Compound filter tests', () => {
-    beforeAll(async () => {
-        await ConnectionManager.connect('sqlite', connection);
-        const loginResponse = await graphweaver.executeOperation<{
-            loginPassword: { authToken: string };
-        }>({
-            query: gql`
-                mutation loginPassword($username: String!, $password: String!) {
-                    loginPassword(username: $username, password: $password) {
-                        authToken
-                    }
-                }
-            `,
-            variables: {
-                username: 'test',
-                password: 'test123',
-            },
-        });
+	beforeAll(async () => {
+		await ConnectionManager.connect('sqlite', connection);
+		const loginResponse = await graphweaver.executeOperation<{
+			loginPassword: { authToken: string };
+		}>({
+			query: gql`
+				mutation loginPassword($username: String!, $password: String!) {
+					loginPassword(username: $username, password: $password) {
+						authToken
+					}
+				}
+			`,
+			variables: {
+				username: 'test',
+				password: 'test123',
+			},
+		});
 
-        assert(loginResponse.body.kind === 'single');
-        expect(loginResponse.body.singleResult.errors).toBeUndefined();
+		assert(loginResponse.body.kind === 'single');
+		expect(loginResponse.body.singleResult.errors).toBeUndefined();
 
-        token = loginResponse.body.singleResult.data?.loginPassword?.authToken;
-        expect(token).toContain('Bearer ');
-    });
-    test('Top-level _and filter', async () => {
-        const response = await graphweaver.executeOperation({
-            http: { headers: new Headers({ authorization: token ?? '' }) } as any,
-            query: gql`
-                query artists($filter: ArtistsListFilter) {
-                    artists(filter: $filter) {
-                        id
-                    }
-                }
-            `,
-            variables: {
-                "filter": {
-                  "_and": [
-                    { "id": "2"}, 
-                    { "id": "1"}
-                  ]
-                }
-              }
-        });
+		token = loginResponse.body.singleResult.data?.loginPassword?.authToken;
+		expect(token).toContain('Bearer ');
+	});
+	test('Top-level _and filter', async () => {
+		const response = await graphweaver.executeOperation({
+			http: { headers: new Headers({ authorization: token ?? '' }) } as any,
+			query: gql`
+				query artists($filter: ArtistsListFilter) {
+					artists(filter: $filter) {
+						id
+					}
+				}
+			`,
+			variables: {
+				filter: {
+					_and: [{ id: '2' }, { id: '1' }],
+				},
+			},
+		});
 
-        assert(response.body.kind === 'single');
-        expect(response.body.singleResult.errors?.[0]?.message).toBeUndefined();
-        expect(response.body.singleResult.data?.artists).toHaveLength(0);
-    });
-    test('Top-level _or filter', async () => {
-        const response = await graphweaver.executeOperation<{
-            artists: { id: string }[];
-        }>({
-            http: { headers: new Headers({ authorization: token ?? '' }) } as any,
-            query: gql`
-                query artists($filter: ArtistsListFilter) {
-                    artists(filter: $filter) {
-                        id
-                    }
-                }
-            `,
-            variables: {
-                "filter": {
-                  "_or": [
-                    { "id": "2"}, 
-                    { "id": "1"}
-                  ]
-                }
-              }
-        });
+		assert(response.body.kind === 'single');
+		expect(response.body.singleResult.errors?.[0]?.message).toBeUndefined();
+		expect(response.body.singleResult.data?.artists).toHaveLength(0);
+	});
+	test('Top-level _or filter', async () => {
+		const response = await graphweaver.executeOperation<{
+			artists: { id: string }[];
+		}>({
+			http: { headers: new Headers({ authorization: token ?? '' }) } as any,
+			query: gql`
+				query artists($filter: ArtistsListFilter) {
+					artists(filter: $filter) {
+						id
+					}
+				}
+			`,
+			variables: {
+				filter: {
+					_or: [{ id: '2' }, { id: '1' }],
+				},
+			},
+		});
 
-        assert(response.body.kind === 'single');
-        expect(response.body.singleResult.errors?.[0]?.message).toBeUndefined();
-        expect(response.body.singleResult.data?.artists).toHaveLength(2);
-    });
-    test('ACLs are still being respected', async () => {
-        const response = await graphweaver.executeOperation<{
-            artists: { id: string }[];
-        }>({
-            query: gql`
-                query artists($filter: ArtistsListFilter) {
-                    artists(filter: $filter) {
-                        id
-                    }
-                }
-            `,
-            variables: {
-                "filter": {
-                  "_or": [
-                    { "id": "2"}, 
-                    { "id": "1"}
-                  ]
-                }
-              }
-        });
+		assert(response.body.kind === 'single');
+		expect(response.body.singleResult.errors?.[0]?.message).toBeUndefined();
+		expect(response.body.singleResult.data?.artists).toHaveLength(2);
+	});
+	test('Top-level _not filter works for list and aggregate queries', async () => {
+		const response = await graphweaver.executeOperation<{
+			artists: { id: string }[];
+			artists_aggregate: { count: number };
+		}>({
+			http: { headers: new Headers({ authorization: token ?? '' }) } as any,
+			query: gql`
+				query artists($filter: ArtistsListFilter) {
+					artists(filter: $filter) {
+						id
+					}
+					artists_aggregate(filter: $filter) {
+						count
+					}
+				}
+			`,
+			variables: {
+				filter: {
+					_not: {
+						id: '2',
+					},
+				},
+			},
+		});
 
-        assert(response.body.kind === 'single');
-        expect(response.body.singleResult.errors?.[0]?.message).toBeUndefined();
-        expect(response.body.singleResult.data?.artists).toHaveLength(1);
-        expect(response.body.singleResult.data?.artists[0].id).toEqual("2");
-    });
+		assert(response.body.kind === 'single');
+		expect(response.body.singleResult.errors).toBeUndefined();
+		expect(response.body.singleResult.data?.artists).not.toContainEqual({ id: '2' });
+		expect(response.body.singleResult.data?.artists_aggregate.count).toBe(
+			response.body.singleResult.data?.artists.length
+		);
+	});
+	test('Top-level _not filter supports nested _and and _or filters', async () => {
+		const response = await graphweaver.executeOperation<{
+			artists: { id: string }[];
+		}>({
+			http: { headers: new Headers({ authorization: token ?? '' }) } as any,
+			query: gql`
+				query artists($filter: ArtistsListFilter) {
+					artists(filter: $filter) {
+						id
+					}
+				}
+			`,
+			variables: {
+				filter: {
+					_not: {
+						_and: [
+							{
+								_or: [{ id: '1' }, { id: '2' }],
+							},
+						],
+					},
+				},
+			},
+		});
+
+		assert(response.body.kind === 'single');
+		expect(response.body.singleResult.errors).toBeUndefined();
+		expect(response.body.singleResult.data?.artists).not.toContainEqual({ id: '1' });
+		expect(response.body.singleResult.data?.artists).not.toContainEqual({ id: '2' });
+	});
+	test('ACLs are still being respected', async () => {
+		const response = await graphweaver.executeOperation<{
+			artists: { id: string }[];
+		}>({
+			query: gql`
+				query artists($filter: ArtistsListFilter) {
+					artists(filter: $filter) {
+						id
+					}
+				}
+			`,
+			variables: {
+				filter: {
+					_or: [{ id: '2' }, { id: '1' }],
+				},
+			},
+		});
+
+		assert(response.body.kind === 'single');
+		expect(response.body.singleResult.errors?.[0]?.message).toBeUndefined();
+		expect(response.body.singleResult.data?.artists).toHaveLength(1);
+		expect(response.body.singleResult.data?.artists[0].id).toEqual('2');
+	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- traverse `_not` as a single filter object in ACL permission checks
- align the public `Filter` type with the generated GraphQL schema
- narrow recursive Xero filter values to preserve the full example build
- add regression coverage for list, aggregate, nested compound, relationship, permission, and type-level behavior
- leave SQL `NULL` / `NOT IN` semantics unchanged

## Testing
- targeted tests and package builds pass
- full CI build revalidation in progress
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c4db1e2-a4b3-4264-814f-cc8123ece09f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c4db1e2-a4b3-4264-814f-cc8123ece09f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

